### PR TITLE
Add default block templates

### DIFF
--- a/theme/templates/blocks/basic.button.php
+++ b/theme/templates/blocks/basic.button.php
@@ -1,0 +1,11 @@
+<templateSetting caption="Button Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Text</dt>
+        <dd><input type="text" name="custom_text" value="Click Me"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Link</dt>
+        <dd><input type="text" name="custom_link" value="#"></dd>
+    </dl>
+</templateSetting>
+<a href="{custom_link}" class="btn btn-primary" data-tpl-tooltip="Button" data-editable>{custom_text}</a>

--- a/theme/templates/blocks/basic.card.php
+++ b/theme/templates/blocks/basic.card.php
@@ -1,0 +1,21 @@
+<templateSetting caption="Card Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image URL</dt>
+        <dd><input type="text" name="custom_img" value="https://via.placeholder.com/600x400"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Heading</dt>
+        <dd><input type="text" name="custom_heading" value="Card Title"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Text</dt>
+        <dd><textarea name="custom_text">Lorem ipsum dolor sit amet.</textarea></dd>
+    </dl>
+</templateSetting>
+<div class="card-block" data-tpl-tooltip="Card">
+    <img src="{custom_img}" alt="">
+    <div class="card-content">
+        <h3 class="card-title" data-editable>{custom_heading}</h3>
+        <p class="card-text" data-editable>{custom_text}</p>
+    </div>
+</div>

--- a/theme/templates/blocks/basic.divider.php
+++ b/theme/templates/blocks/basic.divider.php
@@ -1,0 +1,13 @@
+<templateSetting caption="Divider Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Style</dt>
+        <dd>
+            <select name="custom_style">
+                <option value="solid" selected="selected">Solid</option>
+                <option value="dashed">Dashed</option>
+                <option value="dotted">Dotted</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<hr class="divider-{custom_style}" data-tpl-tooltip="Divider"/>

--- a/theme/templates/blocks/basic.heading.php
+++ b/theme/templates/blocks/basic.heading.php
@@ -1,0 +1,25 @@
+<templateSetting caption="Heading Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Text</dt>
+        <dd><input type="text" name="custom_text" value="Heading"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Level</dt>
+        <dd>
+            <select name="custom_level">
+                <option value="h1">H1</option>
+                <option value="h2" selected="selected">H2</option>
+                <option value="h3">H3</option>
+                <option value="h4">H4</option>
+                <option value="h5">H5</option>
+                <option value="h6">H6</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<toggle rel="custom_level" value="h1"><h1 data-tpl-tooltip="Heading" data-editable>{custom_text}</h1></toggle>
+<toggle rel="custom_level" value="h2"><h2 data-tpl-tooltip="Heading" data-editable>{custom_text}</h2></toggle>
+<toggle rel="custom_level" value="h3"><h3 data-tpl-tooltip="Heading" data-editable>{custom_text}</h3></toggle>
+<toggle rel="custom_level" value="h4"><h4 data-tpl-tooltip="Heading" data-editable>{custom_text}</h4></toggle>
+<toggle rel="custom_level" value="h5"><h5 data-tpl-tooltip="Heading" data-editable>{custom_text}</h5></toggle>
+<toggle rel="custom_level" value="h6"><h6 data-tpl-tooltip="Heading" data-editable>{custom_text}</h6></toggle>

--- a/theme/templates/blocks/basic.image-gallery.php
+++ b/theme/templates/blocks/basic.image-gallery.php
@@ -1,0 +1,19 @@
+<templateSetting caption="Gallery Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image 1 URL</dt>
+        <dd><input type="text" name="custom_img1" value="https://via.placeholder.com/300"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image 2 URL</dt>
+        <dd><input type="text" name="custom_img2" value="https://via.placeholder.com/300"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image 3 URL</dt>
+        <dd><input type="text" name="custom_img3" value="https://via.placeholder.com/300"></dd>
+    </dl>
+</templateSetting>
+<div class="image-gallery" data-tpl-tooltip="Image Gallery">
+    <img src="{custom_img1}" alt="">
+    <img src="{custom_img2}" alt="">
+    <img src="{custom_img3}" alt="">
+</div>

--- a/theme/templates/blocks/basic.image.php
+++ b/theme/templates/blocks/basic.image.php
@@ -1,0 +1,11 @@
+<templateSetting caption="Image Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Source</dt>
+        <dd><input type="text" name="custom_src" value="https://via.placeholder.com/600x400"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Alt Text</dt>
+        <dd><input type="text" name="custom_alt" value=""></dd>
+    </dl>
+</templateSetting>
+<img src="{custom_src}" alt="{custom_alt}" data-tpl-tooltip="Image"/>

--- a/theme/templates/blocks/basic.list.php
+++ b/theme/templates/blocks/basic.list.php
@@ -1,0 +1,37 @@
+<templateSetting caption="List Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Type</dt>
+        <dd>
+            <select name="custom_type">
+                <option value="ul" selected="selected">Unordered</option>
+                <option value="ol">Ordered</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Item 1</dt>
+        <dd><input type="text" name="custom_item1" value="First"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Item 2</dt>
+        <dd><input type="text" name="custom_item2" value="Second"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Item 3</dt>
+        <dd><input type="text" name="custom_item3" value="Third"></dd>
+    </dl>
+</templateSetting>
+<toggle rel="custom_type" value="ul">
+    <ul class="list-block" data-tpl-tooltip="List">
+        <li data-editable>{custom_item1}</li>
+        <li data-editable>{custom_item2}</li>
+        <li data-editable>{custom_item3}</li>
+    </ul>
+</toggle>
+<toggle rel="custom_type" value="ol">
+    <ol class="list-block" data-tpl-tooltip="List">
+        <li data-editable>{custom_item1}</li>
+        <li data-editable>{custom_item2}</li>
+        <li data-editable>{custom_item3}</li>
+    </ol>
+</toggle>

--- a/theme/templates/blocks/basic.paragraph.php
+++ b/theme/templates/blocks/basic.paragraph.php
@@ -1,0 +1,7 @@
+<templateSetting caption="Paragraph Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Text</dt>
+        <dd><textarea name="custom_text">Sample paragraph text.</textarea></dd>
+    </dl>
+</templateSetting>
+<p class="paragraph" data-tpl-tooltip="Paragraph" data-editable>{custom_text}</p>

--- a/theme/templates/blocks/basic.quote.php
+++ b/theme/templates/blocks/basic.quote.php
@@ -1,0 +1,14 @@
+<templateSetting caption="Quote Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Quote</dt>
+        <dd><textarea name="custom_text">Inspirational quote goes here.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Author</dt>
+        <dd><input type="text" name="custom_author" value="Author Name"></dd>
+    </dl>
+</templateSetting>
+<blockquote class="quote-block" data-tpl-tooltip="Quote">
+    <p data-editable>{custom_text}</p>
+    <cite data-editable>{custom_author}</cite>
+</blockquote>

--- a/theme/templates/blocks/basic.spacer.php
+++ b/theme/templates/blocks/basic.spacer.php
@@ -1,0 +1,7 @@
+<templateSetting caption="Spacer Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Height (px)</dt>
+        <dd><input type="number" name="custom_height" value="40"></dd>
+    </dl>
+</templateSetting>
+<div class="spacer" style="height:{custom_height}px" data-tpl-tooltip="Spacer"></div>

--- a/theme/templates/blocks/basic.video.php
+++ b/theme/templates/blocks/basic.video.php
@@ -1,0 +1,9 @@
+<templateSetting caption="Video Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Embed URL</dt>
+        <dd><input type="text" name="custom_src" value="https://www.youtube.com/embed/dQw4w9WgXcQ"></dd>
+    </dl>
+</templateSetting>
+<div class="video-block" data-tpl-tooltip="Video">
+    <iframe src="{custom_src}" frameborder="0" allowfullscreen></iframe>
+</div>

--- a/theme/templates/blocks/layout.section.php
+++ b/theme/templates/blocks/layout.section.php
@@ -1,0 +1,21 @@
+<templateSetting caption="Section Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Width</dt>
+        <dd>
+            <select name="custom_type">
+                <option value="container" selected="selected">Standard</option>
+                <option value="container-fluid">Full Width</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<toggle rel="custom_type" value="container">
+    <section class="container" data-tpl-tooltip="Section">
+        <div class="drop-area"></div>
+    </section>
+</toggle>
+<toggle rel="custom_type" value="container-fluid">
+    <section class="container-fluid" data-tpl-tooltip="Section">
+        <div class="drop-area"></div>
+    </section>
+</toggle>


### PR DESCRIPTION
## Summary
- add working templates for button, card, divider, heading, image, gallery, list, paragraph, quote, spacer, video and section blocks

## Testing
- `php -l theme/templates/blocks/basic.button.php`
- `for f in theme/templates/blocks/*.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_6871226389348331804258a491f160be