### PR TITLE
Add move block controls to live builder

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -44,6 +44,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!block) return;
     if (e.target.closest('.block-controls .edit')) {
       openSettings(block);
+    } else if (e.target.closest('.block-controls .move-up')) {
+      const prev = block.previousElementSibling;
+      if (prev) block.parentNode.insertBefore(block, prev);
+    } else if (e.target.closest('.block-controls .move-down')) {
+      const next = block.nextElementSibling;
+      if (next) block.parentNode.insertBefore(next, block);
     } else if (e.target.closest('.block-controls .delete')) {
       confirmDelete('Delete this block?').then((ok) => {
         if (ok) block.remove();

--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -71,6 +71,8 @@ export function addBlockControls(block) {
     controls.className = 'block-controls';
     controls.innerHTML =
       '<span class="control edit" title="Edit"><i class="fa-solid fa-pen"></i></span>' +
+      '<span class="control move-up" title="Move Up"><i class="fa-solid fa-arrow-up"></i></span>' +
+      '<span class="control move-down" title="Move Down"><i class="fa-solid fa-arrow-down"></i></span>' +
       '<span class="control drag" title="Drag"><i class="fa-solid fa-arrows-up-down-left-right"></i></span>' +
       '<span class="control delete" title="Delete"><i class="fa-solid fa-trash"></i></span>';
     block.style.position = 'relative';


### PR DESCRIPTION
## Summary
- add move-up/move-down icons to block controls
- support moving blocks via these icons

## Testing
- `node --check liveed/builder.js`
- `node --check liveed/modules/dragDrop.js`


------
https://chatgpt.com/codex/tasks/task_e_687125bb226c8331bbfbb6f7f90bfb95