### PR TITLE
Fix builder canvas to hide templateSetting

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -145,3 +145,8 @@
 .wysiwyg-toolbar button:hover {
   background: #edf2f7;
 }
+
+/* Hide block settings templates inside the canvas */
+.canvas templateSetting {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- ensure templateSetting blocks are hidden in the page builder canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68712f0656188331a616e786ceba82da