### PR TITLE
Close palette accordions by default

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -24,7 +24,6 @@ function renderPalette(palette, files = []) {
     .forEach((g) => {
       const details = document.createElement('details');
       details.className = 'palette-group';
-      details.open = true;
 
       const summary = document.createElement('summary');
       summary.textContent = g.charAt(0).toUpperCase() + g.slice(1);


### PR DESCRIPTION
## Summary
- remove the open attribute when creating palette groups so that palettes start collapsed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871352c67508331b1731aee81fe4d8c