### PR TITLE
fix templateSetting in editor

### DIFF
--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -82,6 +82,8 @@ export function addBlockControls(block) {
   if (!block.dataset.original) {
     block.dataset.original = block.innerHTML;
   }
+  const ts = block.querySelector('templateSetting');
+  if (ts) ts.remove();
   const areas = block.querySelectorAll('.drop-area');
   areas.forEach(setupDropArea);
   if (areas.length === 0) {

--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -5,6 +5,17 @@ let settingsPanel;
 let settingsContent;
 let savePageFn;
 
+function getTemplateSettingElement(block) {
+  return (
+    block.querySelector('templateSetting') ||
+    (() => {
+      const wrap = document.createElement('div');
+      wrap.innerHTML = block.dataset.original || block.innerHTML;
+      return wrap.querySelector('templateSetting');
+    })()
+  );
+}
+
 export function initSettings(options = {}) {
   canvas = options.canvas;
   settingsPanel = options.settingsPanel;
@@ -90,7 +101,7 @@ export function confirmDelete(message) {
 }
 
 function getSettingsForm(template, block) {
-  const templateSetting = block.querySelector('templateSetting');
+  const templateSetting = getTemplateSettingElement(block);
   let form = '';
   if (templateSetting) {
     form += templateSetting.innerHTML;
@@ -103,7 +114,7 @@ function getSettingsForm(template, block) {
 }
 
 function initTemplateSettingValues(block) {
-  const templateSetting = block.querySelector('templateSetting');
+  const templateSetting = getTemplateSettingElement(block);
   if (!templateSetting || !settingsPanel) return;
   const inputs = settingsPanel.querySelectorAll('input[name], textarea[name], select[name]');
   inputs.forEach((input) => {
@@ -120,12 +131,7 @@ function renderBlock(block) {
   const settings = getSettings(block);
   const original = block.dataset.original || block.innerHTML;
   let html = original;
-  const templateSetting =
-    block.querySelector('templateSetting') || (function () {
-      const wrapper = document.createElement('div');
-      wrapper.innerHTML = original;
-      return wrapper.querySelector('templateSetting');
-    })();
+  const templateSetting = getTemplateSettingElement(block);
   if (!templateSetting) return;
   const inputs = templateSetting.querySelectorAll('input[name], textarea[name], select[name]');
   inputs.forEach((input) => {
@@ -134,6 +140,7 @@ function renderBlock(block) {
     settings[name] = value;
     html = html.split('{' + name + '}').join(value);
   });
+  html = html.replace(/<templateSetting[^>]*>[\s\S]*?<\/templateSetting>/i, '');
   block.innerHTML = html;
   inputs.forEach((input) => {
     const name = input.name;


### PR DESCRIPTION
## Summary
- ensure `templateSetting` elements are removed from the canvas area
- load settings from the original template when opening the settings panel

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6871355866688331aecbd6504360a2e1