### PR TITLE
Add Font Awesome link to page template

### DIFF
--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -55,6 +55,7 @@ function renderFooterMenu($items){
 		<link rel="preload" as="style" crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>
 
 		<!-- Vendor Stylesheets -->
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 		<link nocache="nocache" rel="stylesheet" crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"/>
 
                 <!-- Preload Stylesheet -->


### PR DESCRIPTION
## Summary
- add Font Awesome CSS link for version 6.0.0-beta3 to the `theme/templates/pages/page.php` template

## Testing
- `php -l theme/templates/pages/page.php`

------
https://chatgpt.com/codex/tasks/task_e_687134edcae48331b70ce4dc54e5f0e8