### PR TITLE
Enable auto-save in live editor

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -51,7 +51,7 @@ function renderPalette(palette, files = []) {
     });
 }
 
-function savePage() {
+function savePage(showAlert = true) {
   const canvas = document.getElementById('canvas');
   const html = canvas.innerHTML;
   const fd = new FormData();
@@ -60,9 +60,11 @@ function savePage() {
   fetch(window.builderBase + '/liveed/save-content.php', {
     method: 'POST',
     body: fd,
-  }).then((r) => r.text()).then(() => {
-    alert('Saved');
-  });
+  })
+    .then((r) => r.text())
+    .then(() => {
+      if (showAlert) alert('Saved');
+    });
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -88,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     applyStoredSettings,
   });
 
-  initUndoRedo({ canvas });
+  initUndoRedo({ canvas, onChange: () => savePage(false) });
   initWysiwyg(canvas, true);
 
   canvas.querySelectorAll('.block-wrapper').forEach(addBlockControls);

--- a/liveed/modules/undoRedo.js
+++ b/liveed/modules/undoRedo.js
@@ -1,6 +1,7 @@
 export function initUndoRedo(options = {}) {
   const canvas = options.canvas;
   const restore = options.restore;
+  const onChange = options.onChange;
   if (!canvas) return;
   let history = [];
   let index = -1;
@@ -14,6 +15,7 @@ export function initUndoRedo(options = {}) {
     history = history.slice(0, index + 1);
     history.push(html);
     index = history.length - 1;
+    if (typeof onChange === 'function') onChange(html);
   };
 
   const scheduleRecord = () => {
@@ -30,6 +32,7 @@ export function initUndoRedo(options = {}) {
     canvas.innerHTML = html;
     if (restore) restore();
     recording = true;
+    if (typeof onChange === 'function') onChange(html);
   };
 
   const undo = () => {


### PR DESCRIPTION
## Summary
- update `undoRedo` module to emit `onChange` callback
- tweak `savePage` to allow silent save and call from undo manager

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68713ebb4bfc8331bb884d81b6a2ff72