### PR TITLE
Fix builder controls not showing

### DIFF
--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -80,6 +80,7 @@ function canvasDragStart(e) {
 
 export function addBlockControls(block) {
   ensureBlockState(block);
+  if (applyStoredSettings) applyStoredSettings(block);
   if (!loggedIn) {
     const existing = block.querySelector('.block-controls');
     if (existing) existing.remove();
@@ -109,7 +110,6 @@ export function addBlockControls(block) {
   if (areas.length === 0) {
     setupDropArea(block);
   }
-  if (applyStoredSettings) applyStoredSettings(block);
 }
 
 export function setupDropArea(area) {
@@ -168,8 +168,8 @@ function handleDrop(e) {
           wrapper.dataset.template = file;
           wrapper.dataset.original = html;
           wrapper.innerHTML = html;
-          addBlockControls(wrapper);
           if (applyStoredSettings) applyStoredSettings(wrapper);
+          addBlockControls(wrapper);
           if (after == null) area.appendChild(wrapper);
           else area.insertBefore(wrapper, after);
           if (openSettings) openSettings(wrapper);

--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -1,4 +1,5 @@
 import { ensureBlockState, getSetting, setSetting, getSettings } from './state.js';
+import { addBlockControls } from './dragDrop.js';
 
 let canvas;
 let settingsPanel;
@@ -172,4 +173,5 @@ function applySettings(template, block) {
     setSetting(block, name, value);
   });
   renderBlock(block);
+  addBlockControls(block);
 }


### PR DESCRIPTION
## Summary
- render stored settings before adding controls
- add controls again after applying settings

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68713ef877188331943a8322068db292