### PR TITLE
Add search to block palette in live editor

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -48,6 +48,13 @@
   border-bottom: 1px solid #e2e8f0;
   padding-bottom: 8px;
 }
+.palette-search {
+  padding: 6px 8px;
+  margin-bottom: 12px;
+  border: 1px solid #cbd5e0;
+  border-radius: 4px;
+  width: 100%;
+}
 .palette-items {
   flex: 1;
   overflow-y: auto;

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -3,6 +3,8 @@ import { initSettings, openSettings, applyStoredSettings, confirmDelete } from '
 import { initUndoRedo } from './modules/undoRedo.js';
 import { initWysiwyg } from './modules/wysiwyg.js';
 
+let allBlockFiles = [];
+
 function renderPalette(palette, files = []) {
   const container = palette.querySelector('.palette-items');
   if (!container) return;
@@ -75,11 +77,22 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initSettings({ canvas, settingsPanel, savePage });
 
+  const searchInput = palette.querySelector('.palette-search');
+
   fetch(window.builderBase + '/liveed/list-blocks.php')
     .then((r) => r.json())
     .then((data) => {
-      renderPalette(palette, data.blocks || []);
+      allBlockFiles = data.blocks || [];
+      renderPalette(palette, allBlockFiles);
     });
+
+  if (searchInput) {
+    searchInput.addEventListener('input', () => {
+      const term = searchInput.value.toLowerCase();
+      const filtered = allBlockFiles.filter((f) => f.toLowerCase().includes(term));
+      renderPalette(palette, filtered);
+    });
+  }
 
   initDragDrop({
     palette,

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -40,7 +40,7 @@ $headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/liveed/builder.css\
 $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
 $builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span><button id="saveBtn" class="btn btn-primary">Save</button></header>';
-$builderStart = '<div class="builder"><aside class="block-palette"><h2>Blocks</h2><div class="palette-items"></div></aside><main class="canvas-container">';
+$builderStart = '<div class="builder"><aside class="block-palette"><h2>Blocks</h2><input type="text" class="palette-search" placeholder="Search blocks"><div class="palette-items"></div></aside><main class="canvas-container">';
 $builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><span class="title">Settings</span><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div></div>' .
     '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';</script>' .
     '<script type="module" src="' . $scriptBase . '/liveed/builder.js"></script>';


### PR DESCRIPTION
## Summary
- add template search input to block palette
- style search bar
- filter blocks in palette by search term

## Testing
- `php -l liveed/builder.php`
- `node --check liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_6871479e089c8331a29b3d44bc468926