### PR TITLE
Enable block placement within header layout

### DIFF
--- a/theme/templates/blocks/layout.header-area.php
+++ b/theme/templates/blocks/layout.header-area.php
@@ -10,5 +10,6 @@
         </nav>
         <a href="/contact" class="cta-btn">Contact Us</a>
         <button class="nav-toggle" aria-label="Toggle Menu"><i class="fa-solid fa-bars"></i></button>
+        <div class="drop-area"></div>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- add missing `.drop-area` inside the header layout block

## Testing
- `php -v | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_687147dc2c7483319110b44abcb52f76