### PR TITLE
Update drag areas for layout templates

### DIFF
--- a/theme/templates/blocks/layout.columns.php
+++ b/theme/templates/blocks/layout.columns.php
@@ -11,7 +11,7 @@
     </dl>
 </templateSetting>
 
-<div class="row" data-tpl-tooltip="Columns">
+<div class="row drop-area" data-tpl-tooltip="Columns">
     <toggle rel="custom_cols" value="2">
         <div class="col"><div class="drop-area"></div></div>
         <div class="col"><div class="drop-area"></div></div>

--- a/theme/templates/blocks/layout.section.php
+++ b/theme/templates/blocks/layout.section.php
@@ -10,12 +10,8 @@
     </dl>
 </templateSetting>
 <toggle rel="custom_type" value="container">
-    <section class="container" data-tpl-tooltip="Section">
-        <div class="drop-area"></div>
-    </section>
+    <section class="container drop-area" data-tpl-tooltip="Section"></section>
 </toggle>
 <toggle rel="custom_type" value="container-fluid">
-    <section class="container-fluid" data-tpl-tooltip="Section">
-        <div class="drop-area"></div>
-    </section>
+    <section class="container-fluid drop-area" data-tpl-tooltip="Section"></section>
 </toggle>


### PR DESCRIPTION
## Summary
- make layout columns block a drop area
- mark section containers as drop areas

## Testing
- `php -l theme/templates/blocks/layout.columns.php`
- `php -l theme/templates/blocks/layout.section.php`


------
https://chatgpt.com/codex/tasks/task_e_687148b30b1c8331bd4104faf6132a62