### PR TITLE
Add tooltip attribute to blocks

### DIFF
--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -167,6 +167,14 @@ function handleDrop(e) {
           wrapper.className = 'block-wrapper';
           wrapper.dataset.template = file;
           wrapper.dataset.original = html;
+          const base = file.replace(/\.php$/, '');
+          const parts = base.split('.');
+          const group = parts.shift();
+          const raw = parts.join(' ') || group;
+          const label = raw
+            .replace(/[-_]/g, ' ')
+            .replace(/\b\w/g, (c) => c.toUpperCase());
+          wrapper.setAttribute('data-tpl-tooltip', label);
           wrapper.innerHTML = html;
           if (applyStoredSettings) applyStoredSettings(wrapper);
           addBlockControls(wrapper);


### PR DESCRIPTION
## Summary
- include a `data-tpl-tooltip` attribute when blocks are dropped onto the canvas

## Testing
- `node --check liveed/modules/dragDrop.js`

------
https://chatgpt.com/codex/tasks/task_e_687155e7b0cc83318a4f894969872817