### PR TITLE
Enable drop areas with class only

### DIFF
--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -44,6 +44,9 @@ export function initDragDrop(options = {}) {
     canvas.addEventListener('dragend', handleDragEnd, true);
   }
   setupDropArea(canvas);
+  if (canvas) {
+    canvas.querySelectorAll('.drop-area').forEach(setupDropArea);
+  }
 }
 
 function paletteDragStart(e) {

--- a/spark-cms.css
+++ b/spark-cms.css
@@ -114,3 +114,35 @@ body {
     margin-bottom: 0;
 }
 
+/* Drop area styling used during drag and drop */
+.drop-area {
+    position: relative;
+    height: auto;
+    background: #efefef;
+    padding: 40px 0;
+}
+
+.drop-area.drag-over {
+    background: #ebf4ff;
+}
+
+.drop-area.drag-over::before {
+    content: '';
+    position: absolute;
+    top: -3px;
+    left: -3px;
+    right: -3px;
+    bottom: -3px;
+    border: 3px dashed #3182ce;
+    border-radius: 8px;
+    background: rgba(49, 130, 206, 0.1);
+    pointer-events: none;
+    animation: dropZonePulse 0.8s infinite;
+    box-shadow: 0 0 8px rgba(66, 153, 225, 0.6);
+}
+
+@keyframes dropZonePulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(66, 153, 225, 0.5); }
+    50% { box-shadow: 0 0 0 10px rgba(66, 153, 225, 0); }
+}
+


### PR DESCRIPTION
## Summary
- register all `.drop-area` elements as valid drop targets
- add drop-area drag highlight styles for front-end

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68718659edd0833189e645dd09b63449