### PR TITLE
Remove obsolete Save button

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -15,20 +15,6 @@
   font-size: 18px;
   font-weight: 600;
 }
-.builder-header .builder-btn {
-  padding: 8px 16px;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-.builder-btn {
-  background: #3182ce;
-  color: #fff;
-}
-.builder-btn:hover {
-  background: #2b6cb0;
-}
 .save-status {
   margin-left: 10px;
   font-size: 14px;

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -116,7 +116,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('canvas');
   const palette = document.querySelector('.block-palette');
   const settingsPanel = document.getElementById('settingsPanel');
-  const saveBtn = document.getElementById('saveBtn');
 
   initSettings({ canvas, settingsPanel, savePage });
 
@@ -177,7 +176,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  if (saveBtn) saveBtn.addEventListener('click', savePage);
 
   document.addEventListener('mouseover', (e) => {
     const handle = e.target.closest('.control.drag');

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -40,7 +40,7 @@ $headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/liveed/builder.css\
     "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css\"/>";
 $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
-$builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span><button id="saveBtn" class="builder-btn">Save</button><span id="saveStatus" class="save-status"></span></header>';
+$builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span><span id="saveStatus" class="save-status"></span></header>';
 $builderStart = '<div class="builder"><aside class="block-palette">' . $builderHeader . '<h2>Blocks</h2><input type="text" class="palette-search" placeholder="Search blocks"><div class="palette-items"></div></aside><main class="canvas-container">';
 $builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><span class="title">Settings</span><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div></div>' .
     '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';</script>' .


### PR DESCRIPTION
## Summary
- drop manual save button from builder UI
- clean up related styles and JavaScript

## Testing
- `php -l liveed/builder.php`
- `node --check liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_6871868a1ffc833180e86d2a7783e4b6