### PR TITLE
Add separate column layout blocks

### DIFF
--- a/theme/templates/blocks/layout.column_1.php
+++ b/theme/templates/blocks/layout.column_1.php
@@ -1,0 +1,6 @@
+<!-- File: layout.column_1.php -->
+<!-- Template: layout.column_1 -->
+<div class="row drop-area" data-tpl-tooltip="1 Column">
+    <div class="col"><div class="drop-area"></div></div>
+</div>
+

--- a/theme/templates/blocks/layout.column_2.php
+++ b/theme/templates/blocks/layout.column_2.php
@@ -1,0 +1,7 @@
+<!-- File: layout.column_2.php -->
+<!-- Template: layout.column_2 -->
+<div class="row drop-area" data-tpl-tooltip="2 Columns">
+    <div class="col"><div class="drop-area"></div></div>
+    <div class="col"><div class="drop-area"></div></div>
+</div>
+

--- a/theme/templates/blocks/layout.column_3.php
+++ b/theme/templates/blocks/layout.column_3.php
@@ -1,0 +1,8 @@
+<!-- File: layout.column_3.php -->
+<!-- Template: layout.column_3 -->
+<div class="row drop-area" data-tpl-tooltip="3 Columns">
+    <div class="col"><div class="drop-area"></div></div>
+    <div class="col"><div class="drop-area"></div></div>
+    <div class="col"><div class="drop-area"></div></div>
+</div>
+

--- a/theme/templates/blocks/layout.column_4.php
+++ b/theme/templates/blocks/layout.column_4.php
@@ -1,0 +1,9 @@
+<!-- File: layout.column_4.php -->
+<!-- Template: layout.column_4 -->
+<div class="row drop-area" data-tpl-tooltip="4 Columns">
+    <div class="col"><div class="drop-area"></div></div>
+    <div class="col"><div class="drop-area"></div></div>
+    <div class="col"><div class="drop-area"></div></div>
+    <div class="col"><div class="drop-area"></div></div>
+</div>
+

--- a/theme/templates/blocks/layout.columns.php
+++ b/theme/templates/blocks/layout.columns.php
@@ -5,7 +5,8 @@
         <dt>Columns:</dt>
         <dd>
             <select name="custom_cols">
-                <option value="2" selected="selected">2</option>
+                <option value="1" selected="selected">1</option>
+                <option value="2">2</option>
                 <option value="3">3</option>
                 <option value="4">4</option>
             </select>
@@ -14,6 +15,9 @@
 </templateSetting>
 
 <div class="row drop-area" data-tpl-tooltip="Columns">
+    <toggle rel="custom_cols" value="1">
+        <div class="col"><div class="drop-area"></div></div>
+    </toggle>
     <toggle rel="custom_cols" value="2">
         <div class="col"><div class="drop-area"></div></div>
         <div class="col"><div class="drop-area"></div></div>


### PR DESCRIPTION
## Summary
- expand `layout.columns` to support 1–4 columns
- add standalone column templates for 1, 2, 3 and 4 column layouts

## Testing
- `php -l theme/templates/blocks/layout.columns.php`
- `php -l theme/templates/blocks/layout.column_1.php`
- `php -l theme/templates/blocks/layout.column_2.php`
- `php -l theme/templates/blocks/layout.column_3.php`
- `php -l theme/templates/blocks/layout.column_4.php`


------
https://chatgpt.com/codex/tasks/task_e_6871878866688331a80616810e9e42f8