### PR TITLE
Fix autosave trigger in builder

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -140,6 +140,7 @@ document.addEventListener('DOMContentLoaded', () => {
   updateCanvasPlaceholder();
 
   document.addEventListener('canvasUpdated', updateCanvasPlaceholder);
+  document.addEventListener('canvasUpdated', savePage);
 
   canvas.addEventListener('click', (e) => {
     const block = e.target.closest('.block-wrapper');
@@ -151,6 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (ok) {
           block.remove();
           updateCanvasPlaceholder();
+          savePage();
         }
       });
     }


### PR DESCRIPTION
## Summary
- ensure auto-saving triggers after canvas changes
- save page immediately when a block is deleted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68719081f99c8331b4bc2fd5170b27ff