### PR TITLE
Add crop preset dropdown for media cropping

### DIFF
--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -291,6 +291,8 @@ $(function(){
         flipX = 1;
         flipY = 1;
         $('#scaleSlider').val(1);
+        $('#crop-preset').val('NaN');
+        cropper.setAspectRatio(NaN);
         cropper.zoomTo(1);
     }
 
@@ -363,6 +365,11 @@ $(function(){
     $('#scaleSlider').on('input', function(){
         const val = parseFloat(this.value);
         if(cropper) cropper.zoomTo(val);
+    });
+    $('#crop-preset').change(function(){
+        if(!cropper) return;
+        const ratio = parseFloat(this.value);
+        cropper.setAspectRatio(isNaN(ratio) ? NaN : ratio);
     });
 
     $('#sort-by').change(function(){ sortBy = this.value; renderImages(); });

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -178,6 +178,18 @@
                                         <label class="form-label" for="scaleSlider">Scale</label>
                                         <input type="range" class="form-input" id="scaleSlider" min="0.5" max="3" step="0.1" value="1">
                                     </div>
+                                    <div class="control-group">
+                                        <label for="crop-preset">Crop Presets:</label>
+                                        <select id="crop-preset">
+                                            <option value="NaN">Freeform</option>
+                                            <option value="1">1:1 (Square)</option>
+                                            <option value="1.7777">16:9 (Wide)</option>
+                                            <option value="1.3333">4:3 (Standard)</option>
+                                            <option value="0.6667">2:3 (3x5)</option>
+                                            <option value="0.75">3:4 (4x6)</option>
+                                            <option value="0.7143">5:7</option>
+                                        </select>
+                                    </div>
                                     <div class="form-group">
                                         <label class="form-label" for="saveFormat">Format</label>
                                         <select class="form-select" id="saveFormat">


### PR DESCRIPTION
## Summary
- add dropdown of crop presets in media editor
- allow choosing aspect ratios when cropping images

## Testing
- `php -l CMS/modules/media/view.php`

------
https://chatgpt.com/codex/tasks/task_e_6871993bcd1c83319a9301f806c41626