### PR TITLE
Add estimated size to media editor

### DIFF
--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -166,6 +166,17 @@ $(function(){
         return parseFloat((bytes/Math.pow(k,i)).toFixed(2))+' '+sizes[i];
     }
 
+    function updateSizeEstimate(){
+        if(!cropper){ $('#sizeEstimate').text(''); return; }
+        const canvas = cropper.getCroppedCanvas();
+        const format = $('#saveFormat').val() || 'jpeg';
+        const mime = 'image/' + (format === 'jpg' ? 'jpeg' : format);
+        const quality = format === 'jpeg' ? 0.9 : 1;
+        canvas.toBlob(function(blob){
+            $('#sizeEstimate').text('Estimated: '+formatFileSize(blob.size));
+        }, mime, quality);
+    }
+
     function uploadFiles(files){
         if(!currentFolder || !files.length) return;
         const fd = new FormData();
@@ -294,6 +305,7 @@ $(function(){
         $('#crop-preset').val('NaN');
         cropper.setAspectRatio(NaN);
         cropper.zoomTo(1);
+        updateSizeEstimate();
     }
 
     function saveEditedImage(){
@@ -364,13 +376,18 @@ $(function(){
     });
     $('#scaleSlider').on('input', function(){
         const val = parseFloat(this.value);
-        if(cropper) cropper.zoomTo(val);
+        if(cropper){
+            cropper.zoomTo(val);
+            updateSizeEstimate();
+        }
     });
     $('#crop-preset').change(function(){
         if(!cropper) return;
         const ratio = parseFloat(this.value);
         cropper.setAspectRatio(isNaN(ratio) ? NaN : ratio);
+        updateSizeEstimate();
     });
+    $('#saveFormat').change(updateSizeEstimate);
 
     $('#sort-by').change(function(){ sortBy = this.value; renderImages(); });
     $('#sort-order').change(function(){ sortOrder = this.value; renderImages(); });

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -177,6 +177,7 @@
                                     <div class="form-group">
                                         <label class="form-label" for="scaleSlider">Scale</label>
                                         <input type="range" class="form-input" id="scaleSlider" min="0.5" max="3" step="0.1" value="1">
+                                        <div id="sizeEstimate" class="size-estimate"></div>
                                     </div>
                                     <div class="control-group">
                                         <label for="crop-preset">Crop Presets:</label>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1036,6 +1036,7 @@
 .crop-sidebar label{display:block;margin-bottom:5px;font-weight:500;color:#4a5568;font-size:14px}
 .crop-sidebar .btn{width:100%}
 .crop-sidebar input[type=range]{width:100%}
+.size-estimate{font-size:12px;color:#6b7280;margin-top:4px}
 #imageEditModal .crop-container{flex:1;text-align:center}
 #imageEditModal .modal-content{
     min-width:600px;


### PR DESCRIPTION
## Summary
- show estimated output size below the scale slider
- update size estimate when scaling or changing format

## Testing
- `php -l CMS/modules/media/view.php`

------
https://chatgpt.com/codex/tasks/task_e_68719af18b6c83318468d4a16a98398c