### PR TITLE
Fix drop area contents not preserved

### DIFF
--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -154,7 +154,16 @@ function renderBlock(block) {
     html = html.split('{' + name + '}').join(value);
   });
   html = html.replace(/<templateSetting[^>]*>[\s\S]*?<\/templateSetting>/i, '');
-  block.innerHTML = html;
+  const existingAreas = Array.from(block.querySelectorAll('.drop-area')).map((a) => Array.from(a.childNodes));
+  const temp = document.createElement('div');
+  temp.innerHTML = html;
+  const newAreas = temp.querySelectorAll('.drop-area');
+  newAreas.forEach((area, i) => {
+    const contents = existingAreas[i];
+    if (contents) contents.forEach((n) => area.appendChild(n));
+  });
+  block.innerHTML = temp.innerHTML;
+  block.querySelectorAll('.drop-area').forEach((a) => (a.dataset.dropArea = 'true'));
   inputs.forEach((input) => {
     const name = input.name;
     const value = settings[name];


### PR DESCRIPTION
## Summary
- ensure blocks with settings retain nested drop-area content when re-rendered

## Testing
- `node --check liveed/builder.js`
- `node --check liveed/modules/settings.js`


------
https://chatgpt.com/codex/tasks/task_e_6871fda876c88331a19232cc8af560f7