### PR TITLE
Add responsive preview to live editor

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -53,6 +53,26 @@
 .history-toolbar button:hover {
   background: #cbd5e0;
 }
+.preview-toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.preview-toolbar button {
+  background: #e2e8f0;
+  border: none;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  color: #2d3748;
+}
+
+.preview-toolbar button.active {
+  background: #3182ce;
+  color: #fff;
+}
 .block-palette h2 {
   margin: 0 0 12px;
   font-size: 16px;
@@ -654,6 +674,20 @@
   outline: none;
   border-color: #3182ce;
   box-shadow: 0 0 0 2px rgba(49, 130, 206, 0.2);
+}
+
+.canvas-container.preview-desktop .canvas {
+  width: 100%;
+}
+
+.canvas-container.preview-tablet .canvas {
+  width: 768px;
+  margin: auto;
+}
+
+.canvas-container.preview-phone .canvas {
+  width: 375px;
+  margin: auto;
 }
 
 @media (max-width: 480px) {

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -102,6 +102,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('canvas');
   const palette = document.querySelector('.block-palette');
   const settingsPanel = document.getElementById('settingsPanel');
+  const previewContainer = document.querySelector('.canvas-container');
+  const previewButtons = document.querySelectorAll('.preview-toolbar button');
+
+  function updatePreview(size) {
+    if (!previewContainer) return;
+    previewContainer.classList.remove('preview-desktop', 'preview-tablet', 'preview-phone');
+    previewContainer.classList.add('preview-' + size);
+    previewButtons.forEach((btn) => {
+      btn.classList.toggle('active', btn.dataset.size === size);
+    });
+  }
+
+  previewButtons.forEach((btn) => {
+    btn.addEventListener('click', () => updatePreview(btn.dataset.size));
+  });
+
+  updatePreview('desktop');
 
   initSettings({ canvas, settingsPanel, savePage: scheduleSave });
 

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -45,9 +45,15 @@ $historyToolbar = '<div class="history-toolbar">'
     . '<button type="button" class="undo-btn" title="Undo"><i class="fa-solid fa-rotate-left"></i></button>'
     . '<button type="button" class="redo-btn" title="Redo"><i class="fa-solid fa-rotate-right"></i></button>'
     . '</div>';
+$previewToolbar = '<div class="preview-toolbar">'
+    . '<button type="button" data-size="desktop" class="active" title="Desktop"><i class="fa-solid fa-desktop"></i></button>'
+    . '<button type="button" data-size="tablet" title="Tablet"><i class="fa-solid fa-tablet-screen-button"></i></button>'
+    . '<button type="button" data-size="phone" title="Phone"><i class="fa-solid fa-mobile-screen-button"></i></button>'
+    . '</div>';
 $builderStart = '<div class="builder"><aside class="block-palette">'
     . $builderHeader
     . $historyToolbar
+    . $previewToolbar
     . '<h2>Blocks</h2><input type="text" class="palette-search" placeholder="Search blocks"><div class="palette-items"></div></aside><main class="canvas-container">';
 $builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><span class="title">Settings</span><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div></div>' .
     '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';</script>' .


### PR DESCRIPTION
## Summary
- add a preview toolbar in builder UI
- wire preview buttons via JS to switch device sizes
- style preview buttons and preview widths

## Testing
- `node --check liveed/builder.js`
- `php -l liveed/builder.php`


------
https://chatgpt.com/codex/tasks/task_e_687200de93b88331aac8af656a899922