### PR TITLE
Add preview toggle to builder

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -11,6 +11,23 @@
   align-items: center;
   height: 60px;
 }
+.builder-header .header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.builder-header .view-btn {
+  background: #e2e8f0;
+  border: none;
+  padding: 6px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  color: #2d3748;
+}
+.builder-header .view-btn:hover {
+  background: #cbd5e0;
+}
 .builder-header .title {
   font-size: 18px;
   font-weight: 600;
@@ -664,4 +681,20 @@
     min-height: 400px;
     padding: 20px;
   }
+}
+
+/* View mode styles */
+.builder.view-mode .block-palette,
+.builder.view-mode .history-toolbar,
+.builder.view-mode #settingsPanel,
+.builder.view-mode .block-controls,
+.builder.view-mode .wysiwyg-toolbar {
+  display: none !important;
+}
+.builder.view-mode .canvas {
+  border: none;
+  box-shadow: none;
+}
+.builder.view-mode .canvas-container {
+  padding: 0;
 }

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -102,6 +102,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const canvas = document.getElementById('canvas');
   const palette = document.querySelector('.block-palette');
   const settingsPanel = document.getElementById('settingsPanel');
+  const viewToggle = document.getElementById('viewToggle');
 
   initSettings({ canvas, settingsPanel, savePage: scheduleSave });
 
@@ -137,6 +138,27 @@ document.addEventListener('DOMContentLoaded', () => {
   if (undoBtn) undoBtn.addEventListener('click', () => history.undo());
   if (redoBtn) redoBtn.addEventListener('click', () => history.redo());
   initWysiwyg(canvas, true);
+
+  if (viewToggle) {
+    viewToggle.addEventListener('click', () => {
+      const builder = document.querySelector('.builder');
+      const isView = builder.classList.toggle('view-mode');
+      if (isView) {
+        viewToggle.innerHTML = '<i class="fa-solid fa-eye-slash"></i>';
+        viewToggle.title = 'Exit view mode';
+        settingsPanel.classList.remove('open');
+        canvas.querySelectorAll('[data-editable]').forEach((el) => {
+          el.removeAttribute('contenteditable');
+        });
+      } else {
+        viewToggle.innerHTML = '<i class="fa-solid fa-eye"></i>';
+        viewToggle.title = 'View mode';
+        canvas.querySelectorAll('[data-editable]').forEach((el) => {
+          el.setAttribute('contenteditable', 'true');
+        });
+      }
+    });
+  }
 
   canvas.addEventListener('input', scheduleSave);
   canvas.addEventListener('change', scheduleSave);

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -40,7 +40,7 @@ $headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/liveed/builder.css\
     "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css\"/>";
 $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
-$builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span><span id="saveStatus" class="save-status"></span></header>';
+$builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span><div class="header-actions"><button type="button" id="viewToggle" class="view-btn" title="View mode"><i class="fa-solid fa-eye"></i></button><span id="saveStatus" class="save-status"></span></div></header>';
 $historyToolbar = '<div class="history-toolbar">'
     . '<button type="button" class="undo-btn" title="Undo"><i class="fa-solid fa-rotate-left"></i></button>'
     . '<button type="button" class="redo-btn" title="Redo"><i class="fa-solid fa-rotate-right"></i></button>'


### PR DESCRIPTION
## Summary
- add Preview mode toggle button to the builder header
- style preview button and hide editor UI when preview mode is active
- implement logic to switch between edit and view modes

## Testing
- `php -l liveed/builder.php`
- `node -c liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_687200f90e8083318bba3914b3719240