### PR TITLE
Add favorite blocks support to LiveEd builder

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -355,12 +355,22 @@
   font-family: 'Font Awesome 6 Free';
   font-weight: 900;
   color: #a0aec0;
-  margin-left: auto;
+  margin-left: 8px;
 }
 
 .block-item.dragging {
   opacity: 0.5;
   transform: rotate(3deg) scale(0.95);
+}
+
+.fav-toggle {
+  margin-left: auto;
+  cursor: pointer;
+  color: #a0aec0;
+}
+
+.fav-toggle.active {
+  color: #ffd700;
 }
 
 .canvas.drag-over {


### PR DESCRIPTION
## Summary
- implement favorites for block palette using localStorage
- add toggle to mark block items as favorite
- render a Favorites group in the palette
- style favorite star icon

## Testing
- `node --check liveed/builder.js`
- `php -l liveed/builder.php`

------
https://chatgpt.com/codex/tasks/task_e_68720109c80c8331b552ba69f45bdab1