### PR TITLE
Add block duplication control to builder

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -1,6 +1,7 @@
 // File: builder.js
 import { initDragDrop, addBlockControls } from './modules/dragDrop.js';
 import { initSettings, openSettings, applyStoredSettings, confirmDelete } from './modules/settings.js';
+import { ensureBlockState, getSettings, setSetting } from './modules/state.js';
 import { initUndoRedo } from './modules/undoRedo.js';
 import { initWysiwyg } from './modules/wysiwyg.js';
 
@@ -160,6 +161,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!block) return;
     if (e.target.closest('.block-controls .edit')) {
       openSettings(block);
+    } else if (e.target.closest('.block-controls .duplicate')) {
+      const clone = block.cloneNode(true);
+      clone.classList.remove('selected');
+      delete clone.dataset.blockId;
+      block.after(clone);
+      ensureBlockState(clone);
+      const settings = getSettings(block);
+      for (const key in settings) {
+        setSetting(clone, key, settings[key]);
+      }
+      addBlockControls(clone);
+      applyStoredSettings(clone);
+      document.dispatchEvent(new Event('canvasUpdated'));
     } else if (e.target.closest('.block-controls .delete')) {
       confirmDelete('Delete this block?').then((ok) => {
         if (ok) {

--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -104,6 +104,7 @@ export function addBlockControls(block) {
     controls.innerHTML =
       '<span class="control edit" title="Edit"><i class="fa-solid fa-pen"></i></span>' +
       '<span class="control drag" title="Drag"><i class="fa-solid fa-arrows-up-down-left-right"></i></span>' +
+      '<span class="control duplicate" title="Duplicate"><i class="fa-solid fa-clone"></i></span>' +
       '<span class="control delete" title="Delete"><i class="fa-solid fa-trash"></i></span>';
     block.style.position = 'relative';
     block.appendChild(controls);


### PR DESCRIPTION
## Summary
- allow duplicating blocks in the Liveed builder
- wire up block state copying when duplicating

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687200ca894083319c47e0436ba13c4a