### PR TITLE
Add TemplateSetting validation

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -647,6 +647,14 @@
   box-sizing: border-box;
 }
 
+.settings-panel .invalid {
+  border-color: #e53e3e;
+}
+
+.settings-panel .invalid:focus {
+  box-shadow: 0 0 0 2px rgba(229, 62, 62, 0.2);
+}
+
 .settings-content input[type="text"]:focus,
 .settings-content input[type="number"]:focus,
 .settings-content textarea:focus,

--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -38,11 +38,13 @@ export function initSettings(options = {}) {
       if (e.target.id === 'apply-settings') {
         const block = settingsPanel.block;
         const template = settingsPanel.template;
-        if (block) applySettings(template, block);
-        settingsPanel.classList.remove('open');
-        settingsPanel.block = null;
-        canvas.querySelectorAll('.block-wrapper').forEach((b) => b.classList.remove('selected'));
-        savePageFn();
+        if (block && validateSettings()) {
+          applySettings(template, block);
+          settingsPanel.classList.remove('open');
+          settingsPanel.block = null;
+          canvas.querySelectorAll('.block-wrapper').forEach((b) => b.classList.remove('selected'));
+          savePageFn();
+        }
       } else if (e.target.id === 'cancel-settings' || e.target.classList.contains('close-btn')) {
         settingsPanel.classList.remove('open');
         settingsPanel.block = null;
@@ -137,6 +139,21 @@ function initTemplateSettingValues(block) {
       input.value = val;
     }
   });
+}
+
+function validateSettings() {
+  if (!settingsPanel) return true;
+  let valid = true;
+  const inputs = settingsPanel.querySelectorAll('input[name], textarea[name], select[name]');
+  inputs.forEach((input) => {
+    input.classList.remove('invalid');
+    if (!input.checkValidity()) {
+      input.classList.add('invalid');
+      input.reportValidity();
+      valid = false;
+    }
+  });
+  return valid;
 }
 
 function renderBlock(block) {


### PR DESCRIPTION
## Summary
- validate settings form before applying changes
- highlight invalid inputs in the builder

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687201b772bc8331b88335ceadfc72a8