### PR TITLE
Add broken link warning in Liveed builder

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -26,6 +26,9 @@
 .save-status.error {
   color: #e53e3e;
 }
+.save-status.warn {
+  color: #dd6b20;
+}
 .block-palette {
   width: 260px;
   background: #f8fafc;


### PR DESCRIPTION
## Summary
- add warning state for save status
- check links and images before saving page
- display warning when broken links are detected

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687201fb2dc883319cbb7a9560064be5