### PR TITLE
Add accessibility checks to builder

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -760,3 +760,23 @@
   text-align: center;
   margin-bottom: 10px;
 }
+
+.block-wrapper.a11y-warning {
+  outline: 2px solid #e53e3e;
+  position: relative;
+}
+.block-wrapper.a11y-warning::after {
+  content: '\26A0';
+  position: absolute;
+  top: -10px;
+  left: -10px;
+  background: #e53e3e;
+  color: #fff;
+  border-radius: 50%;
+  padding: 2px 5px;
+  font-size: 12px;
+}
+
+.block-item.needs-a11y {
+  box-shadow: 0 0 0 2px #e53e3e;
+}

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -5,6 +5,7 @@ import { ensureBlockState, getSettings, setSetting } from './modules/state.js';
 import { initUndoRedo } from './modules/undoRedo.js';
 import { initWysiwyg } from './modules/wysiwyg.js';
 import { initMediaPicker, openMediaPicker } from './modules/mediaPicker.js';
+import { initAccessibility, checkAccessibility } from './modules/accessibility.js';
 
 let allBlockFiles = [];
 let favorites = [];
@@ -181,6 +182,8 @@ document.addEventListener('DOMContentLoaded', () => {
     applyStoredSettings,
   });
 
+  initAccessibility({ canvas, palette });
+
   const history = initUndoRedo({ canvas, onChange: scheduleSave });
   const undoBtn = palette.querySelector('.undo-btn');
   const redoBtn = palette.querySelector('.redo-btn');
@@ -196,8 +199,14 @@ document.addEventListener('DOMContentLoaded', () => {
   initMediaPicker({ basePath: window.builderBase });
   window.openMediaPicker = openMediaPicker;
 
-  canvas.addEventListener('input', scheduleSave);
-  canvas.addEventListener('change', scheduleSave);
+  canvas.addEventListener('input', () => {
+    scheduleSave();
+    checkAccessibility();
+  });
+  canvas.addEventListener('change', () => {
+    scheduleSave();
+    checkAccessibility();
+  });
 
   canvas.querySelectorAll('.block-wrapper').forEach(addBlockControls);
 
@@ -210,8 +219,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   updateCanvasPlaceholder();
 
+  checkAccessibility();
+
   document.addEventListener('canvasUpdated', updateCanvasPlaceholder);
   document.addEventListener('canvasUpdated', scheduleSave);
+  document.addEventListener('canvasUpdated', checkAccessibility);
 
   canvas.addEventListener('click', (e) => {
     const block = e.target.closest('.block-wrapper');

--- a/liveed/modules/accessibility.js
+++ b/liveed/modules/accessibility.js
@@ -1,0 +1,45 @@
+// File: accessibility.js
+let canvas, palette;
+
+export function initAccessibility(opts = {}) {
+  canvas = opts.canvas;
+  palette = opts.palette;
+  checkAccessibility();
+}
+
+export function checkAccessibility() {
+  if (!canvas) return;
+  const blocks = canvas.querySelectorAll('.block-wrapper');
+  blocks.forEach((block) => {
+    block.classList.remove('a11y-warning');
+    block.removeAttribute('data-a11y');
+    const issues = [];
+    block.querySelectorAll('img').forEach((img) => {
+      const alt = img.getAttribute('alt');
+      if (!alt || !alt.trim()) {
+        issues.push('Image missing alt text');
+      }
+    });
+    if (issues.length) {
+      block.classList.add('a11y-warning');
+      block.setAttribute('data-a11y', issues.join('; '));
+    }
+  });
+  highlightPalette();
+}
+
+function highlightPalette() {
+  if (!palette) return;
+  const items = palette.querySelectorAll('.block-item');
+  items.forEach((it) => it.classList.remove('needs-a11y'));
+  const issueTemplates = new Set(
+    Array.from(canvas.querySelectorAll('.block-wrapper.a11y-warning')).map(
+      (b) => b.dataset.template
+    )
+  );
+  items.forEach((it) => {
+    if (issueTemplates.has(it.dataset.file)) {
+      it.classList.add('needs-a11y');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add accessibility module to scan for issues
- highlight blocks and palette items when alt text is missing
- integrate accessibility checks into builder
- style warning highlights

## Testing
- `php -l liveed/builder.php`
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_687204b4c1ec8331b03dc799767b9c87