### PR TITLE
Add accessibility warnings for missing alt text

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -31,6 +31,11 @@
 .save-status.error {
   color: #e53e3e;
 }
+.a11y-status {
+  margin-left: 10px;
+  font-size: 14px;
+  color: #e53e3e;
+}
 .block-palette {
   width: 260px;
   background: #f8fafc;
@@ -420,6 +425,24 @@
   opacity: 0.5;
   transform: rotate(2deg) scale(0.98);
   z-index: 1000;
+}
+.block-wrapper.accessibility-warning {
+  border-color: #e53e3e;
+}
+.block-wrapper.accessibility-warning::after {
+  content: '⚠';
+  position: absolute;
+  top: -10px;
+  left: -10px;
+  background: #e53e3e;
+  color: #fff;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
 }
 
 .block-controls {

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -5,6 +5,7 @@ import { ensureBlockState, getSettings, setSetting } from './modules/state.js';
 import { initUndoRedo } from './modules/undoRedo.js';
 import { initWysiwyg } from './modules/wysiwyg.js';
 import { initMediaPicker, openMediaPicker } from './modules/mediaPicker.js';
+import { initAccessibility } from './modules/accessibility.js';
 
 let allBlockFiles = [];
 let favorites = [];
@@ -194,6 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   initWysiwyg(canvas, true);
   initMediaPicker({ basePath: window.builderBase });
+  initAccessibility({ canvas });
   window.openMediaPicker = openMediaPicker;
 
   canvas.addEventListener('input', scheduleSave);

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -45,7 +45,8 @@ $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
 $builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span>'
     . '<div class="header-actions"><button type="button" class="manual-save-btn btn btn-primary">Save</button>'
-    . '<span id="saveStatus" class="save-status"></span></div></header>';
+    . '<span id="saveStatus" class="save-status"></span>'
+    . '<span id="a11yStatus" class="a11y-status"></span></div></header>';
 $historyToolbar = '<div class="history-toolbar">'
     . '<button type="button" class="undo-btn" title="Undo"><i class="fa-solid fa-rotate-left"></i></button>'
     . '<button type="button" class="redo-btn" title="Redo"><i class="fa-solid fa-rotate-right"></i></button>'

--- a/liveed/modules/accessibility.js
+++ b/liveed/modules/accessibility.js
@@ -1,0 +1,36 @@
+// File: accessibility.js
+let canvas;
+
+export function initAccessibility(options = {}) {
+  canvas = options.canvas;
+  if (!canvas) return;
+  checkAccessibility();
+  document.addEventListener('canvasUpdated', checkAccessibility);
+}
+
+export function checkAccessibility() {
+  if (!canvas) return;
+  let issueCount = 0;
+  canvas.querySelectorAll('.block-wrapper').forEach((block) => {
+    block.classList.remove('accessibility-warning');
+    block.removeAttribute('data-a11y-msg');
+    let hasIssue = false;
+    block.querySelectorAll('img').forEach((img) => {
+      const alt = img.getAttribute('alt');
+      if (!alt || !alt.trim()) {
+        hasIssue = true;
+      }
+    });
+    if (hasIssue) {
+      block.classList.add('accessibility-warning');
+      block.dataset.a11yMsg = 'Image missing alt text';
+      issueCount += 1;
+    }
+  });
+  const statusEl = document.getElementById('a11yStatus');
+  if (statusEl) {
+    statusEl.textContent = issueCount
+      ? issueCount + ' accessibility issue' + (issueCount > 1 ? 's' : '')
+      : '';
+  }
+}


### PR DESCRIPTION
## Summary
- show accessibility issue count in the builder header
- highlight blocks that miss image alt text
- run checks whenever the canvas changes

## Testing
- `php -l liveed/builder.php`
- `node --check liveed/modules/accessibility.js`
- `node --check liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_687204f8cc608331baf01c7817caa996