### PR TITLE
Add builder view mode

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -668,6 +668,20 @@
   margin: auto;
 }
 
+/* View mode hides editing chrome */
+.builder.view-mode .block-palette,
+.builder.view-mode .builder-header,
+.builder.view-mode .history-toolbar,
+.builder.view-mode .preview-toolbar,
+.builder.view-mode #settingsPanel,
+.builder.view-mode .block-controls {
+  display: none !important;
+}
+.builder.view-mode .canvas {
+  border: none;
+  box-shadow: none;
+}
+
 @media (max-width: 480px) {
   .canvas-container {
     padding: 15px;

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -151,6 +151,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   updatePreview('desktop');
 
+  const builderEl = document.querySelector('.builder');
+  const viewToggleBtn = document.querySelector('.view-toggle-btn');
+  if (viewToggleBtn && builderEl) {
+    viewToggleBtn.addEventListener('click', () => {
+      const viewMode = builderEl.classList.toggle('view-mode');
+      viewToggleBtn.classList.toggle('active', viewMode);
+      if (!viewMode) return;
+      const panel = document.getElementById('settingsPanel');
+      if (panel) panel.classList.remove('open');
+    });
+  }
+
   favorites = JSON.parse(localStorage.getItem('favoriteBlocks') || '[]');
 
   initSettings({ canvas, settingsPanel, savePage: scheduleSave });

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -44,7 +44,9 @@ $headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/liveed/builder.css\
 $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
 $builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span>'
-    . '<div class="header-actions"><button type="button" class="manual-save-btn btn btn-primary">Save</button>'
+    . '<div class="header-actions">'
+    . '<button type="button" class="view-toggle-btn btn btn-secondary" title="Toggle preview"><i class="fa-solid fa-eye"></i></button>'
+    . '<button type="button" class="manual-save-btn btn btn-primary">Save</button>'
     . '<span id="saveStatus" class="save-status"></span></div></header>';
 $historyToolbar = '<div class="history-toolbar">'
     . '<button type="button" class="undo-btn" title="Undo"><i class="fa-solid fa-rotate-left"></i></button>'


### PR DESCRIPTION
## Summary
- add a preview toggle button in the builder header
- implement logic to switch builder into view mode
- style the view mode so editing panels and block controls are hidden

## Testing
- `php -l liveed/builder.php`

------
https://chatgpt.com/codex/tasks/task_e_687204570c58833194515279fc9a46b0