### PR TITLE
Add draggable and collapsible block palette

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -20,6 +20,24 @@
   align-items: center;
   gap: 8px;
 }
+.drag-handle {
+  cursor: move;
+  color: #4a5568;
+  font-size: 18px;
+}
+.drag-handle:hover {
+  color: #2d3748;
+}
+.collapse-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 18px;
+  color: #4a5568;
+}
+.collapse-btn:hover {
+  color: #2d3748;
+}
 .save-status {
   margin-left: 10px;
   font-size: 14px;
@@ -40,6 +58,31 @@
   box-shadow: 2px 0 8px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
+}
+.block-palette.floating {
+  position: absolute;
+  z-index: 1000;
+  top: 20px;
+  left: 20px;
+  height: auto;
+ }
+.block-palette.collapsed {
+  width: 40px;
+  padding: 8px;
+ }
+.block-palette.collapsed .history-toolbar,
+.block-palette.collapsed .preview-toolbar,
+.block-palette.collapsed h2,
+.block-palette.collapsed .palette-search,
+.block-palette.collapsed .palette-items,
+.block-palette.collapsed .manual-save-btn,
+.block-palette.collapsed #saveStatus {
+  display: none;
+}
+.block-palette.collapsed .title {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 14px;
 }
 .history-toolbar {
   display: flex;

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -135,6 +135,70 @@ document.addEventListener('DOMContentLoaded', () => {
   const settingsPanel = document.getElementById('settingsPanel');
   const previewContainer = document.querySelector('.canvas-container');
   const previewButtons = document.querySelectorAll('.preview-toolbar button');
+  const dragHandle = palette.querySelector('.drag-handle');
+  const collapseBtn = palette.querySelector('.collapse-btn');
+
+  function savePaletteState() {
+    const state = {
+      floating: palette.classList.contains('floating'),
+      collapsed: palette.classList.contains('collapsed'),
+      left: palette.style.left,
+      top: palette.style.top,
+    };
+    localStorage.setItem('paletteState', JSON.stringify(state));
+  }
+
+  function applyPaletteState() {
+    const state = JSON.parse(localStorage.getItem('paletteState') || '{}');
+    if (state.floating) {
+      palette.classList.add('floating');
+      if (state.left) palette.style.left = state.left;
+      if (state.top) palette.style.top = state.top;
+    }
+    if (state.collapsed) {
+      palette.classList.add('collapsed');
+      if (collapseBtn)
+        collapseBtn.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
+    }
+  }
+
+  applyPaletteState();
+
+  if (dragHandle) {
+    dragHandle.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      const rect = palette.getBoundingClientRect();
+      palette.classList.add('floating');
+      palette.style.width = rect.width + 'px';
+      palette.style.left = rect.left + 'px';
+      palette.style.top = rect.top + 'px';
+      const startX = e.clientX;
+      const startY = e.clientY;
+      function onMove(ev) {
+        palette.style.left = rect.left + ev.clientX - startX + 'px';
+        palette.style.top = rect.top + ev.clientY - startY + 'px';
+      }
+      function onUp() {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        savePaletteState();
+      }
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
+
+  if (collapseBtn) {
+    collapseBtn.addEventListener('click', () => {
+      palette.classList.toggle('collapsed');
+      if (palette.classList.contains('collapsed')) {
+        collapseBtn.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
+      } else {
+        collapseBtn.innerHTML = '<i class="fa-solid fa-chevron-left"></i>';
+      }
+      savePaletteState();
+    });
+  }
 
   function updatePreview(size) {
     if (!previewContainer) return;

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -44,7 +44,10 @@ $headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/liveed/builder.css\
 $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
 $builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span>'
-    . '<div class="header-actions"><button type="button" class="manual-save-btn btn btn-primary">Save</button>'
+    . '<div class="header-actions">'
+    . '<span class="drag-handle" title="Drag palette"><i class="fa-solid fa-up-down-left-right"></i></span>'
+    . '<button type="button" class="collapse-btn" title="Collapse palette"><i class="fa-solid fa-chevron-left"></i></button>'
+    . '<button type="button" class="manual-save-btn btn btn-primary">Save</button>'
     . '<span id="saveStatus" class="save-status"></span></div></header>';
 $historyToolbar = '<div class="history-toolbar">'
     . '<button type="button" class="undo-btn" title="Undo"><i class="fa-solid fa-rotate-left"></i></button>'


### PR DESCRIPTION
## Summary
- add drag handle and collapse button to palette header
- style palette floating and collapsed modes
- persist palette state in localStorage
- implement drag and collapse behavior in JS

## Testing
- `php -l liveed/builder.php`
- `node -c liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_68720510ee948331b80b3537c29c3817