### PR TITLE
Add draggable and collapsible block palette

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -11,6 +11,9 @@
   align-items: center;
   height: 60px;
 }
+.block-palette .builder-header {
+  cursor: move;
+}
 .builder-header .title {
   font-size: 18px;
   font-weight: 600;
@@ -45,6 +48,42 @@
   box-shadow: 2px 0 8px rgba(0, 0, 0, 0.05);
   display: flex;
   flex-direction: column;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  z-index: 1000;
+}
+
+.palette-toggle-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.builder .canvas-container {
+  margin-left: 260px;
+}
+
+.block-palette.collapsed {
+  width: 40px;
+  padding: 8px;
+}
+
+.builder.palette-collapsed .canvas-container {
+  margin-left: 40px;
+}
+
+.block-palette.collapsed .history-toolbar,
+.block-palette.collapsed .preview-toolbar,
+.block-palette.collapsed h2,
+.block-palette.collapsed .palette-items,
+.block-palette.collapsed .palette-search,
+.block-palette.collapsed .builder-header .title,
+.block-palette.collapsed .manual-save-btn,
+.block-palette.collapsed #saveStatus,
+.block-palette.collapsed #a11yStatus {
+  display: none;
 }
 .history-toolbar {
   display: flex;

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -189,6 +189,69 @@ document.addEventListener('DOMContentLoaded', () => {
   const previewContainer = document.querySelector('.canvas-container');
   const previewButtons = document.querySelectorAll('.preview-toolbar button');
   const gridToggle = document.getElementById('gridToggle');
+  const builderEl = document.querySelector('.builder');
+  const toggleBtn = palette.querySelector('.palette-toggle-btn');
+  const paletteHeader = palette.querySelector('.builder-header');
+
+  // Restore palette position
+  const storedPos = localStorage.getItem('palettePosition');
+  if (storedPos) {
+    try {
+      const pos = JSON.parse(storedPos);
+      if (pos.left) palette.style.left = pos.left;
+      if (pos.top) palette.style.top = pos.top;
+    } catch (e) {}
+  }
+
+  // Collapse state
+  const storedCollapsed = localStorage.getItem('paletteCollapsed') === '1';
+  if (storedCollapsed) {
+    palette.classList.add('collapsed');
+    if (builderEl) builderEl.classList.add('palette-collapsed');
+    if (toggleBtn) toggleBtn.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
+  }
+
+  if (toggleBtn) {
+    toggleBtn.addEventListener('click', () => {
+      const collapsed = palette.classList.toggle('collapsed');
+      if (builderEl) builderEl.classList.toggle('palette-collapsed', collapsed);
+      toggleBtn.innerHTML = collapsed
+        ? '<i class="fa-solid fa-chevron-right"></i>'
+        : '<i class="fa-solid fa-chevron-left"></i>';
+      localStorage.setItem('paletteCollapsed', collapsed ? '1' : '0');
+    });
+  }
+
+  // Dragging
+  if (paletteHeader) {
+    let dragging = false;
+    let offsetX = 0;
+    let offsetY = 0;
+    const onMove = (e) => {
+      if (!dragging) return;
+      palette.style.left = e.clientX - offsetX + 'px';
+      palette.style.top = e.clientY - offsetY + 'px';
+    };
+    const onUp = () => {
+      if (!dragging) return;
+      dragging = false;
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      localStorage.setItem(
+        'palettePosition',
+        JSON.stringify({ left: palette.style.left, top: palette.style.top })
+      );
+    };
+    paletteHeader.addEventListener('mousedown', (e) => {
+      if (e.target.closest('.palette-toggle-btn')) return;
+      dragging = true;
+      const rect = palette.getBoundingClientRect();
+      offsetX = e.clientX - rect.left;
+      offsetY = e.clientY - rect.top;
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
 
   function setGridActive(on) {
     gridActive = on;

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -44,7 +44,8 @@ $headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/liveed/builder.css\
 $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
 $builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span>'
-    . '<div class="header-actions"><button type="button" class="manual-save-btn btn btn-primary">Save</button>'
+    . '<div class="header-actions"><button type="button" class="palette-toggle-btn" title="Collapse Palette"><i class="fa-solid fa-chevron-left"></i></button>'
+    . '<button type="button" class="manual-save-btn btn btn-primary">Save</button>'
     . '<span id="saveStatus" class="save-status"></span>'
     . '<span id="a11yStatus" class="a11y-status"></span></div></header>';
 $historyToolbar = '<div class="history-toolbar">'


### PR DESCRIPTION
## Summary
- allow LiveEd palette to be collapsed and moved around
- style palette for floating behaviour

## Testing
- `php -l liveed/builder.php`
- `node --check liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_6872067492c48331925be47e805293a6