### PR TITLE
Add view mode to page builder

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -840,3 +840,29 @@
   background: #3182ce;
   color: #fff;
 }
+
+/* View mode */
+.view-toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1100;
+  background: #3182ce;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.builder.view-mode .block-palette,
+.builder.view-mode .history-toolbar,
+.builder.view-mode .preview-toolbar,
+.builder.view-mode #settingsPanel,
+.builder.view-mode .block-wrapper > .block-controls {
+  display: none !important;
+}
+
+.builder.view-mode .canvas-container {
+  margin-left: 0;
+}

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -190,6 +190,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const previewButtons = document.querySelectorAll('.preview-toolbar button');
   const gridToggle = document.getElementById('gridToggle');
   const builderEl = document.querySelector('.builder');
+  const viewToggle = document.getElementById('viewModeToggle');
   const toggleBtn = palette.querySelector('.palette-toggle-btn');
   const paletteHeader = palette.querySelector('.builder-header');
 
@@ -265,6 +266,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (gridToggle) {
     gridToggle.addEventListener('click', () => setGridActive(!gridActive));
+  }
+
+  if (viewToggle) {
+    viewToggle.addEventListener('click', () => {
+      const viewing = builderEl.classList.toggle('view-mode');
+      viewToggle.innerHTML = viewing
+        ? '<i class="fa-solid fa-eye-slash"></i>'
+        : '<i class="fa-solid fa-eye"></i>';
+      if (viewing) {
+        if (settingsPanel) settingsPanel.classList.remove('open');
+        setGridActive(false);
+      }
+    });
   }
 
   function updatePreview(size) {
@@ -350,6 +364,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('canvasUpdated', scheduleSave);
 
   canvas.addEventListener('click', (e) => {
+    if (builderEl.classList.contains('view-mode')) return;
     const block = e.target.closest('.block-wrapper');
     if (!block) return;
     if (e.target.closest('.block-controls .edit')) {

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -58,7 +58,7 @@ $previewToolbar = '<div class="preview-toolbar">'
     . '<button type="button" data-size="phone" title="Phone"><i class="fa-solid fa-mobile-screen-button"></i></button>'
     . '<button type="button" id="gridToggle" title="Toggle Grid"><i class="fa-solid fa-border-all"></i></button>'
     . '</div>';
-$builderStart = '<div class="builder"><aside class="block-palette">'
+$builderStart = '<div class="builder"><button type="button" id="viewModeToggle" class="view-toggle" title="View mode"><i class="fa-solid fa-eye"></i></button><aside class="block-palette">'
     . $builderHeader
     . $historyToolbar
     . $previewToolbar


### PR DESCRIPTION
## Summary
- allow toggling a `view mode` in the live editor
- hide the editing UI when view mode is enabled

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6872079302108331889fe6e4a24d3daa