### PR TITLE
Improve block palette layout

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -390,9 +390,29 @@
   padding: 8px 12px;
   background: #f7fafc;
   font-weight: 600;
+  position: relative;
+  user-select: none;
+}
+.palette-group summary::-webkit-details-marker {
+  display: none;
+}
+.palette-group summary::after {
+  content: '▾';
+  position: absolute;
+  right: 8px;
+  transition: transform 0.2s;
+}
+.palette-group[open] summary::after {
+  transform: rotate(180deg);
 }
 .palette-group .group-items {
   padding: 8px 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+}
+.palette-group .block-item {
+  margin-bottom: 0;
 }
 
 /* --- Enhanced styles inspired by demo --- */
@@ -430,7 +450,9 @@
 }
 
 .fav-toggle {
-  margin-left: auto;
+  position: absolute;
+  top: 4px;
+  right: 6px;
   cursor: pointer;
   color: #a0aec0;
 }
@@ -585,6 +607,7 @@
 /* Optional: Add a search icon */
 .palette-search-container {
   position: relative;
+  margin-bottom: 12px;
 }
 
 .palette-search-container::before {

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -51,6 +51,7 @@ function renderPalette(palette, files = []) {
     .forEach((g) => {
       const details = document.createElement('details');
       details.className = 'palette-group';
+      details.open = true;
 
       const summary = document.createElement('summary');
       summary.textContent = g.charAt(0).toUpperCase() + g.slice(1);

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -62,7 +62,7 @@ $builderStart = '<div class="builder"><button type="button" id="viewModeToggle" 
     . $builderHeader
     . $historyToolbar
     . $previewToolbar
-    . '<h2>Blocks</h2><input type="text" class="palette-search" placeholder="Search blocks"><div class="palette-items"></div></aside><main class="canvas-container">';
+    . '<h2>Blocks</h2><div class="palette-search-container"><input type="text" class="palette-search" placeholder="Search blocks"></div><div class="palette-items"></div></aside><main class="canvas-container">';
 
 $mediaPickerHtml = '<div id="mediaPickerModal" class="modal">'
     . '<div class="modal-content media-picker">'


### PR DESCRIPTION
## Summary
- open palette groups by default and adjust markup
- style palette groups and search field for better usability
- move favorites star to top-right of block items

## Testing
- `php -l liveed/builder.php`

------
https://chatgpt.com/codex/tasks/task_e_68720ba6a3848331b706827a4c725c5e