### PR TITLE
Use media picker for image and video blocks

### DIFF
--- a/theme/templates/blocks/basic.card.php
+++ b/theme/templates/blocks/basic.card.php
@@ -3,7 +3,10 @@
 <templateSetting caption="Card Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Image URL</dt>
-        <dd><input type="text" name="custom_img" value="https://via.placeholder.com/600x400"></dd>
+        <dd>
+            <input type="text" name="custom_img" id="custom_img" value="https://via.placeholder.com/600x400">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_img')">Browse</button>
+        </dd>
     </dl>
     <dl class="sparkDialog _tpl-box">
         <dt>Heading</dt>

--- a/theme/templates/blocks/basic.image-gallery.php
+++ b/theme/templates/blocks/basic.image-gallery.php
@@ -3,15 +3,24 @@
 <templateSetting caption="Gallery Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Image 1 URL</dt>
-        <dd><input type="text" name="custom_img1" value="https://via.placeholder.com/300"></dd>
+        <dd>
+            <input type="text" name="custom_img1" id="custom_img1" value="https://via.placeholder.com/300">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_img1')">Browse</button>
+        </dd>
     </dl>
     <dl class="sparkDialog _tpl-box">
         <dt>Image 2 URL</dt>
-        <dd><input type="text" name="custom_img2" value="https://via.placeholder.com/300"></dd>
+        <dd>
+            <input type="text" name="custom_img2" id="custom_img2" value="https://via.placeholder.com/300">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_img2')">Browse</button>
+        </dd>
     </dl>
     <dl class="sparkDialog _tpl-box">
         <dt>Image 3 URL</dt>
-        <dd><input type="text" name="custom_img3" value="https://via.placeholder.com/300"></dd>
+        <dd>
+            <input type="text" name="custom_img3" id="custom_img3" value="https://via.placeholder.com/300">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_img3')">Browse</button>
+        </dd>
     </dl>
 </templateSetting>
 <div class="image-gallery" data-tpl-tooltip="Image Gallery">

--- a/theme/templates/blocks/basic.image.php
+++ b/theme/templates/blocks/basic.image.php
@@ -3,7 +3,10 @@
 <templateSetting caption="Image Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Source</dt>
-        <dd><input type="text" name="custom_src" value="https://via.placeholder.com/600x400"></dd>
+        <dd>
+            <input type="text" name="custom_src" id="custom_src" value="https://via.placeholder.com/600x400">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_src')">Browse</button>
+        </dd>
     </dl>
     <dl class="sparkDialog _tpl-box">
         <dt>Alt Text</dt>

--- a/theme/templates/blocks/basic.video.php
+++ b/theme/templates/blocks/basic.video.php
@@ -3,7 +3,10 @@
 <templateSetting caption="Video Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Embed URL</dt>
-        <dd><input type="text" name="custom_src" value="https://www.youtube.com/embed/dQw4w9WgXcQ"></dd>
+        <dd>
+            <input type="text" name="custom_src" id="custom_src_video" value="https://www.youtube.com/embed/dQw4w9WgXcQ">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_src_video')">Browse</button>
+        </dd>
     </dl>
 </templateSetting>
 <div class="video-block" data-tpl-tooltip="Video">


### PR DESCRIPTION
## Summary
- allow selecting files from the media picker for image/video related blocks

## Testing
- `php -l theme/templates/blocks/basic.image.php`
- `php -l theme/templates/blocks/basic.card.php`
- `php -l theme/templates/blocks/basic.image-gallery.php`
- `php -l theme/templates/blocks/basic.video.php`


------
https://chatgpt.com/codex/tasks/task_e_68721073bc2c8331b4262312e5a44238