### PR TITLE
Remove placeholder image URLs

### DIFF
--- a/theme/templates/blocks/basic.card.php
+++ b/theme/templates/blocks/basic.card.php
@@ -4,7 +4,7 @@
     <dl class="sparkDialog _tpl-box">
         <dt>Image URL</dt>
         <dd>
-            <input type="text" name="custom_img" id="custom_img" value="https://via.placeholder.com/600x400">
+            <input type="text" name="custom_img" id="custom_img" value="">
             <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_img')">Browse</button>
         </dd>
     </dl>

--- a/theme/templates/blocks/basic.image.php
+++ b/theme/templates/blocks/basic.image.php
@@ -4,7 +4,7 @@
     <dl class="sparkDialog _tpl-box">
         <dt>Source</dt>
         <dd>
-            <input type="text" name="custom_src" id="custom_src" value="https://via.placeholder.com/600x400">
+            <input type="text" name="custom_src" id="custom_src" value="">
             <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_src')">Browse</button>
         </dd>
     </dl>


### PR DESCRIPTION
## Summary
- trim default placeholder URLs from card and image template inputs

## Testing
- `grep -r "600x400" -r theme/templates/blocks`

------
https://chatgpt.com/codex/tasks/task_e_68721303b5e0833189dedfd718447dc6