### PR TITLE
Add thumbnail previews to media picker folders

### DIFF
--- a/CMS/modules/media/list_media.php
+++ b/CMS/modules/media/list_media.php
@@ -22,7 +22,26 @@ $results = array_filter($media, function($item) use ($query, $folder) {
 $root = dirname(__DIR__,2);
 $default = $root.'/uploads/general';
 if(!is_dir($default)) mkdir($default, 0777, true);
-$folders = array_map('basename', array_filter(glob($root.'/uploads/*'), 'is_dir'));
+$folderDirs = array_filter(glob($root.'/uploads/*'), 'is_dir');
+$folders = [];
+foreach ($folderDirs as $dir) {
+    $name = basename($dir);
+    $thumb = null;
+    foreach ($media as $m) {
+        if (($m['folder'] ?? '') === $name && ($m['type'] ?? '') === 'images') {
+            $thumb = $m['thumbnail'] ?: $m['file'];
+            break;
+        }
+    }
+    if (!$thumb) {
+        $candidates = glob($dir . '/thumbs/*.{jpg,jpeg,png,gif,webp}', GLOB_BRACE);
+        if (!$candidates) $candidates = glob($dir.'/*.{jpg,jpeg,png,gif,webp}', GLOB_BRACE);
+        if ($candidates) {
+            $thumb = str_replace($root.'/', '', $candidates[0]);
+        }
+    }
+    $folders[] = ['name' => $name, 'thumbnail' => $thumb];
+}
 
 foreach ($results as &$item) {
     $path = $root . '/' . $item['file'];

--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -16,15 +16,19 @@ $(function(){
             const list = $('#folderList').empty();
             const media = res.media || [];
             (res.folders || []).forEach(f => {
-                const folderMedia = media.filter(m => m.folder === f);
+                const name = typeof f === 'string' ? f : f.name;
+                const thumb = f.thumbnail ? f.thumbnail : null;
+                const folderMedia = media.filter(m => m.folder === name);
                 const count = folderMedia.length;
                 const totalBytes = folderMedia.reduce((s,m)=>s+parseInt(m.size||0),0);
                 const lastMod = folderMedia.reduce((m,i)=>i.modified_at && i.modified_at>m?i.modified_at:m,0);
                 const meta = count+' files • '+formatFileSize(totalBytes)+' • Last edited '+(lastMod?new Date(lastMod*1000).toLocaleDateString():'');
-                const item = $('<div class="folder-item" data-folder="'+f+'">\
-                    <div class="folder-info"><h3>'+f+'</h3><p class="folder-meta">'+meta+'</p></div>\
-                </div>');
-                item.click(function(){ selectFolder(f); });
+                const item = $('<div class="folder-item" data-folder="'+name+'"></div>');
+                if(thumb){
+                    item.append('<img class="folder-thumb" src="'+thumb+'" alt="">');
+                }
+                item.append('<div class="folder-info"><h3>'+name+'</h3><p class="folder-meta">'+meta+'</p></div>');
+                item.click(function(){ selectFolder(name); });
                 list.append(item);
             });
 

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1005,6 +1005,7 @@
 .media-sidebar .folder-item{display:flex;align-items:center;gap:12px;padding:12px;border-radius:6px;cursor:pointer;transition:0.2s;border:1px solid transparent;}
 .media-sidebar .folder-item:hover{background:#f8fafc;}
 .media-sidebar .folder-item.active{background:#dbeafe;border-color:#93c5fd;color:#1d4ed8;}
+.media-sidebar .folder-item img.folder-thumb{width:40px;height:40px;object-fit:cover;border-radius:4px;}
 .gallery-header{padding:24px;border-bottom:1px solid #e2e8f0;display:flex;justify-content:space-between;align-items:center;}
 .gallery-actions{display:flex;gap:8px;align-items:center;}
 .folder-stats{font-size:12px;color:#6b7280;margin-top:8px;}

--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -787,6 +787,15 @@
   padding: 6px 8px;
   cursor: pointer;
   border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+#pickerFolderList li img {
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
+  border-radius: 4px;
 }
 #pickerFolderList li.active {
   background: #3182ce;

--- a/liveed/modules/mediaPicker.js
+++ b/liveed/modules/mediaPicker.js
@@ -112,10 +112,22 @@ function loadPickerFolders() {
     .then((data) => {
       if (!pickerFolderList) return;
       pickerFolderList.innerHTML = '';
+      const cmsBase = basePath + '/CMS';
       (data.folders || []).forEach((f) => {
+        const name = typeof f === 'string' ? f : f.name;
+        const thumb = f.thumbnail ? cmsBase + '/' + f.thumbnail : null;
         const li = document.createElement('li');
-        li.textContent = f;
-        li.dataset.folder = f;
+        li.dataset.folder = name;
+        li.className = 'picker-folder-item';
+        if (thumb) {
+          const img = document.createElement('img');
+          img.src = thumb;
+          img.alt = name;
+          li.appendChild(img);
+        }
+        const span = document.createElement('span');
+        span.textContent = name;
+        li.appendChild(span);
         pickerFolderList.appendChild(li);
       });
     });


### PR DESCRIPTION
## Summary
- compute thumbnail for media folders in `list_media.php`
- display folder thumbnails in builder media picker
- style folder list with thumbnails
- show thumbnails in CMS media manager sidebar

## Testing
- `php -l CMS/modules/media/list_media.php`
- `find CMS/modules -name '*.php' -print0 | xargs -0 -n1 php -l`
- `node -e "require('./liveed/modules/mediaPicker.js');"`

------
https://chatgpt.com/codex/tasks/task_e_68721343548c8331a53ff207d3a26154