### PR TITLE
Fix palette snap position

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -243,6 +243,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const rect = palette.getBoundingClientRect();
       if (rect.left < SNAP_THRESHOLD) {
         palette.style.left = '0px';
+        palette.style.top = '0px';
       }
       localStorage.setItem(
         'palettePosition',


### PR DESCRIPTION
## Summary
- adjust palette drag logic to also reset top position when snapped to the left edge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872159a24bc8331927d8a23cda49c2a