### PR TITLE
Remove Font Awesome after-icon from builder

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -436,14 +436,6 @@
   left: 100%;
 }
 
-.block-item::after {
-  content: '\f0c4';
-  font-family: 'Font Awesome 6 Free';
-  font-weight: 900;
-  color: #a0aec0;
-  margin-left: 8px;
-}
-
 .block-item.dragging {
   opacity: 0.5;
   transform: rotate(3deg) scale(0.95);


### PR DESCRIPTION
## Summary
- remove the `.block-item::after` rule from `builder.css`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68721ae78880833184523de79d9d7985