### PR TITLE
Add button alignment and new window options

### DIFF
--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -56,7 +56,13 @@ export function initSettings(options = {}) {
       const input = e.target.closest('input[name], textarea[name], select[name]');
       const block = settingsPanel.block;
       if (input && block) {
-        setSetting(block, input.name, input.value);
+        let val;
+        if (input.type === 'checkbox') {
+          val = input.checked ? (input.value || 'on') : '';
+        } else {
+          val = input.value;
+        }
+        setSetting(block, input.name, val);
         renderBlock(block);
       }
     });
@@ -135,7 +141,9 @@ function initTemplateSettingValues(block) {
   inputs.forEach((input) => {
     const name = input.name;
     const val = getSetting(block, name);
-    if (val !== undefined) {
+    if (input.type === 'checkbox') {
+      input.checked = !!val;
+    } else if (val !== undefined) {
       input.value = val;
     }
   });
@@ -166,7 +174,14 @@ function renderBlock(block) {
   const inputs = templateSetting.querySelectorAll('input[name], textarea[name], select[name]');
   inputs.forEach((input) => {
     const name = input.name;
-    const value = settings[name] !== undefined ? settings[name] : input.value || '';
+    let value;
+    if (settings[name] !== undefined) {
+      value = settings[name];
+    } else if (input.type === 'checkbox') {
+      value = input.checked ? (input.value || 'on') : '';
+    } else {
+      value = input.value || '';
+    }
     settings[name] = value;
     html = html.split('{' + name + '}').join(value);
   });
@@ -207,7 +222,7 @@ function applySettings(template, block) {
   const inputs = settingsPanel.querySelectorAll('input[name], textarea[name], select[name]');
   inputs.forEach((input) => {
     const name = input.name;
-    const value = input.value;
+    const value = input.type === 'checkbox' ? (input.checked ? (input.value || 'on') : '') : input.value;
     setSetting(block, name, value);
   });
   renderBlock(block);

--- a/theme/templates/blocks/basic.button.php
+++ b/theme/templates/blocks/basic.button.php
@@ -9,5 +9,19 @@
         <dt>Link</dt>
         <dd><input type="text" name="custom_link" value="#"></dd>
     </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Open in New Window</dt>
+        <dd><label><input type="checkbox" name="custom_new_window" value=' target="_blank"'> New window</label></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Alignment</dt>
+        <dd>
+            <label><input type="checkbox" name="custom_align_left" value=" _text-left"> Left</label>
+            <label><input type="checkbox" name="custom_align_center" value=" _text-center"> Center</label>
+            <label><input type="checkbox" name="custom_align_right" value=" _text-right"> Right</label>
+        </dd>
+    </dl>
 </templateSetting>
-<a href="{custom_link}" class="btn btn-primary" data-tpl-tooltip="Button" data-editable>{custom_text}</a>
+<div class="{custom_align_left}{custom_align_center}{custom_align_right}">
+    <a href="{custom_link}" class="btn btn-primary"{custom_new_window} data-tpl-tooltip="Button" data-editable>{custom_text}</a>
+</div>


### PR DESCRIPTION
## Summary
- expand button block with alignment and new window options
- handle checkbox settings in the builder

## Testing
- `php -l theme/templates/blocks/basic.button.php`

------
https://chatgpt.com/codex/tasks/task_e_68721a7985f883319786e867b398b270