### PR TITLE
Enhance palette repositioning controls

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -60,6 +60,11 @@
   border: none;
   cursor: pointer;
 }
+.palette-dock-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
 
 .builder .canvas-container {
   margin-left: 260px;

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -193,6 +193,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const builderEl = document.querySelector('.builder');
   const viewToggle = document.getElementById('viewModeToggle');
   const toggleBtn = palette.querySelector('.palette-toggle-btn');
+  const dockBtn = palette.querySelector('.palette-dock-btn');
   const paletteHeader = palette.querySelector('.builder-header');
 
   // Restore palette position
@@ -224,6 +225,14 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  if (dockBtn) {
+    dockBtn.addEventListener('click', () => {
+      palette.style.left = '0px';
+      palette.style.top = '0px';
+      localStorage.setItem('palettePosition', JSON.stringify({ left: '0px', top: '0px' }));
+    });
+  }
+
   // Dragging
   if (paletteHeader) {
     let dragging = false;
@@ -251,7 +260,7 @@ document.addEventListener('DOMContentLoaded', () => {
       );
     };
     paletteHeader.addEventListener('mousedown', (e) => {
-      if (e.target.closest('.palette-toggle-btn')) return;
+      if (e.target.closest('.palette-toggle-btn') || e.target.closest('.palette-dock-btn')) return;
       dragging = true;
       const rect = palette.getBoundingClientRect();
       offsetX = e.clientX - rect.left;

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -43,8 +43,9 @@ $headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/liveed/builder.css\
     "<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css\"/>";
 $themeHtml = preg_replace('/<head>/', '<head>' . $headInject, $themeHtml, 1);
 
-$builderHeader = '<header class="builder-header"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span>'
+$builderHeader = '<header class="builder-header" title="Drag to reposition"><span class="title">Editing: ' . htmlspecialchars($page['title']) . '</span>'
     . '<div class="header-actions"><button type="button" class="palette-toggle-btn" title="Collapse Palette"><i class="fa-solid fa-chevron-left"></i></button>'
+    . '<button type="button" class="palette-dock-btn" title="Dock palette"><i class="fa-solid fa-up-down-left-right"></i></button>'
     . '<button type="button" class="manual-save-btn btn btn-primary">Save</button>'
     . '<span id="saveStatus" class="save-status"></span>'
     . '<span id="a11yStatus" class="a11y-status"></span></div></header>';


### PR DESCRIPTION
## Summary
- add a dock button to the palette header with drag hint
- support docking via JavaScript and ignore dock button when dragging
- style the new dock button

## Testing
- `php -l liveed/builder.php`
- `node --check liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_6872b08b80e88331a8dc094a2597b1ca