### PR TITLE
Add placeholders for non-image media

### DIFF
--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -134,10 +134,19 @@ $(function(){
             $('#emptyFolderState').hide();
             grid.show();
             images.forEach(img=>{
+                const isImage = img.type === 'images';
                 const src = img.thumbnail ? img.thumbnail : img.file;
+                let preview = '';
+                if(isImage){
+                    preview = '<img src="'+src+'" alt="'+img.name+'">';
+                }else{
+                    const ext = img.file.split('.').pop().toLowerCase();
+                    const icons = {pdf:'📄',doc:'📄',docx:'📄',txt:'📄',mp4:'🎥',webm:'🎥',mov:'🎥'};
+                    const icon = icons[ext] || '📄';
+                    preview = '<div class="file-icon">'+icon+'</div>';
+                }
                 const card = $('<div class="image-card" data-id="'+img.id+'">\
-                        <div class="image-preview">\
-                            <img src="'+src+'" alt="'+img.name+'">\
+                        <div class="image-preview">'+preview+'\
                             <div class="image-overlay">\
                                 <div>\
                                     <button class="info-btn" data-id="'+img.id+'">ℹ</button>\

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1016,6 +1016,7 @@
 .image-card.drag-over{border-color:#3b82f6;background:#dbeafe;}
 .image-preview{aspect-ratio:1;overflow:hidden;position:relative;}
 .image-preview img{width:100%;height:100%;object-fit:cover;}
+.image-preview .file-icon{display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:48px;background:#f8fafc;color:#6b7280;}
 .image-overlay{position:absolute;inset:0;background:rgba(0,0,0,0);transition:0.2s;display:flex;align-items:flex-start;justify-content:space-between;padding:8px;}
 .image-card:hover .image-overlay{background:rgba(0,0,0,0.2);}
 .image-card .drag-handle{width:16px;height:16px;opacity:0;filter:drop-shadow(0 1px 2px rgba(0,0,0,0.5));transition:opacity 0.2s;}


### PR DESCRIPTION
## Summary
- show placeholder icons for documents and videos in media library
- style new `.file-icon` blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872b18002f0833199ab0862e6fd9841