### PR TITLE
Improve builder header layout

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -10,6 +10,8 @@
   justify-content: space-between;
   align-items: center;
   height: 60px;
+  flex-wrap: wrap;
+  gap: 4px 8px;
 }
 .block-palette .builder-header {
   cursor: move;
@@ -22,11 +24,13 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 .save-status {
-  margin-left: 10px;
+  margin-left: 0;
   font-size: 14px;
   color: #4a5568;
+  flex-basis: 100%;
 }
 .save-status.saving {
   color: #3182ce;
@@ -35,9 +39,10 @@
   color: #e53e3e;
 }
 .a11y-status {
-  margin-left: 10px;
+  margin-left: 0;
   font-size: 14px;
   color: #e53e3e;
+  flex-basis: 100%;
 }
 .block-palette {
   width: 260px;


### PR DESCRIPTION
## Summary
- make builder header flexible with wrapping
- place status messages on a new line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872b24ffc6883319377139758684805