### PR TITLE
Close builder palette accordions on load

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -51,7 +51,6 @@ function renderPalette(palette, files = []) {
     .forEach((g) => {
       const details = document.createElement('details');
       details.className = 'palette-group';
-      details.open = true;
 
       const summary = document.createElement('summary');
       summary.textContent = g.charAt(0).toUpperCase() + g.slice(1);


### PR DESCRIPTION
## Summary
- default all palette accordions to closed in builder

## Testing
- `php -l liveed/builder.php`
- `node --check liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_6872b359213c8331a712e01bcf049672