### PR TITLE
Add hero section block

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -684,3 +684,25 @@ section.container-fluid {
     margin: 0;
     color: #555;
 }
+
+/* Hero Section */
+.hero-section {
+    position: relative;
+    background-size: cover;
+    background-position: center;
+    padding: 6rem 0;
+    color: #fff;
+    text-align: center;
+}
+.hero-section::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+}
+.hero-section .hero-content {
+    position: relative;
+    z-index: 1;
+    max-width: 800px;
+    margin: 0 auto;
+}

--- a/theme/templates/blocks/basic.hero.php
+++ b/theme/templates/blocks/basic.hero.php
@@ -1,0 +1,38 @@
+<!-- File: basic.hero.php -->
+<!-- Template: basic.hero -->
+<templateSetting caption="Hero Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Background Image</dt>
+        <dd>
+            <input type="text" name="custom_bg" id="custom_bg" value="https://via.placeholder.com/1920x600">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_bg')">Browse</button>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Heading</dt>
+        <dd><input type="text" name="custom_heading" value="Welcome to Our Site"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Subheading</dt>
+        <dd><textarea name="custom_subheading">We are glad you are here.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Button Text</dt>
+        <dd><input type="text" name="custom_btn_text" value="Learn More"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Button Link</dt>
+        <dd><input type="text" name="custom_btn_link" value="#"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Open in New Window</dt>
+        <dd><label><input type="checkbox" name="custom_btn_new" value=' target="_blank"'> New window</label></dd>
+    </dl>
+</templateSetting>
+<section class="hero-section" style="background-image:url('{custom_bg}');" data-tpl-tooltip="Hero">
+    <div class="container hero-content">
+        <h1 data-editable>{custom_heading}</h1>
+        <p data-editable>{custom_subheading}</p>
+        <a href="{custom_btn_link}" class="btn btn-primary"{custom_btn_new} data-editable>{custom_btn_text}</a>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- create Hero section block template
- style hero section in override stylesheet

## Testing
- `php -l theme/templates/blocks/basic.hero.php`
- `php -l theme/css/override.css`


------
https://chatgpt.com/codex/tasks/task_e_6872be5b3de08331b88ea62276ce426a