### PR TITLE
Add CTA banner theme block

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -706,3 +706,20 @@ section.container-fluid {
     max-width: 800px;
     margin: 0 auto;
 }
+
+/* CTA Banner */
+.cta-banner {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: #fff;
+    text-align: center;
+    padding: 3rem 1rem;
+}
+
+.cta-banner-content {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.cta-banner .btn {
+    margin-top: 1rem;
+}

--- a/theme/templates/blocks/basic.cta-banner.php
+++ b/theme/templates/blocks/basic.cta-banner.php
@@ -1,0 +1,31 @@
+<!-- File: basic.cta-banner.php -->
+<!-- Template: basic.cta-banner -->
+<templateSetting caption="CTA Banner Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Heading</dt>
+        <dd><input type="text" name="custom_heading" value="Join Us Today"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Subtext</dt>
+        <dd><textarea name="custom_subtext">Start your journey with us.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Button Text</dt>
+        <dd><input type="text" name="custom_btn_text" value="Get Started"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Button Link</dt>
+        <dd><input type="text" name="custom_btn_link" value="#"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Open in New Window</dt>
+        <dd><label><input type="checkbox" name="custom_btn_new" value=' target="_blank"'> New window</label></dd>
+    </dl>
+</templateSetting>
+<div class="cta-banner" data-tpl-tooltip="CTA Banner">
+    <div class="container cta-banner-content">
+        <h2 data-editable>{custom_heading}</h2>
+        <p data-editable>{custom_subtext}</p>
+        <a href="{custom_btn_link}" class="btn btn-primary"{custom_btn_new} data-editable>{custom_btn_text}</a>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add basic.cta-banner block template
- add styles for CTA banner in override.css

## Testing
- `php -l theme/templates/blocks/basic.cta-banner.php`


------
https://chatgpt.com/codex/tasks/task_e_6872bf7792c4833191392db6f1485a26