### PR TITLE
Add background color picker

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1359,6 +1359,14 @@
     margin-top: 5px;
 }
 
+.color-picker input[type="radio"] {
+    display: none;
+}
+
+.color-picker input[type="radio"]:checked + .color-swatch {
+    outline: 3px solid #667eea;
+}
+
 .color-swatch {
     width: 30px;
     height: 30px;

--- a/theme/templates/blocks/layout.section.php
+++ b/theme/templates/blocks/layout.section.php
@@ -10,14 +10,53 @@
             </select>
         </dd>
     </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Background Color</dt>
+        <dd>
+            <div class="color-picker">
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--primary)">
+                    <span class="color-swatch" style="background-color: var(--primary);"></span>
+                </label>
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--secondary)">
+                    <span class="color-swatch" style="background-color: var(--secondary);"></span>
+                </label>
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--third)">
+                    <span class="color-swatch" style="background-color: var(--third);"></span>
+                </label>
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--fourth)">
+                    <span class="color-swatch" style="background-color: var(--fourth);"></span>
+                </label>
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--white)" checked>
+                    <span class="color-swatch" style="background-color: var(--white);"></span>
+                </label>
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--black)">
+                    <span class="color-swatch" style="background-color: var(--black);"></span>
+                </label>
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--light)">
+                    <span class="color-swatch" style="background-color: var(--light);"></span>
+                </label>
+                <label>
+                    <input type="radio" name="custom_bg_color" value="var(--gray)">
+                    <span class="color-swatch" style="background-color: var(--gray);"></span>
+                </label>
+            </div>
+        </dd>
+    </dl>
 </templateSetting>
 <toggle rel="custom_type" value="container">
-    <section class="container" data-tpl-tooltip="Section">
-        <div class="drop-area"></div></section>
+    <section class="container" style="background-color:{custom_bg_color};" data-tpl-tooltip="Section">
+        <div class="drop-area"></div>
+    </section>
 </toggle>
 <toggle rel="custom_type" value="container-fluid">
-    <section class="container-fluid" data-tpl-tooltip="Section">
+    <section class="container-fluid" style="background-color:{custom_bg_color};" data-tpl-tooltip="Section">
         <div class="drop-area"></div>
-        
-        </section>
+    </section>
 </toggle>


### PR DESCRIPTION
## Summary
- allow setting a background color for sections
- style builder color picker radios

## Testing
- `php -l theme/templates/blocks/layout.section.php`
- `csslint CMS/spark-cms.css` *(fails: csslint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872c43c038c8331873d29f0bf2f5437