### PR TITLE
Add hero size dropdown

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -707,6 +707,22 @@ section.container-fluid {
     margin: 0 auto;
 }
 
+.hero-section.hero-small {
+    padding: 3rem 0;
+}
+
+.hero-section.hero-medium {
+    padding: 6rem 0;
+}
+
+.hero-section.hero-large {
+    padding: 9rem 0;
+}
+
+.hero-section.hero-side {
+    text-align: left;
+}
+
 /* CTA Banner */
 .cta-banner {
     background: linear-gradient(135deg, #667eea, #764ba2);

--- a/theme/templates/blocks/basic.hero.php
+++ b/theme/templates/blocks/basic.hero.php
@@ -28,8 +28,19 @@
         <dt>Open in New Window</dt>
         <dd><label><input type="checkbox" name="custom_btn_new" value=' target="_blank"'> New window</label></dd>
     </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Size</dt>
+        <dd>
+            <select name="custom_size">
+                <option value="side">Side</option>
+                <option value="small">Small</option>
+                <option value="medium" selected="selected">Medium</option>
+                <option value="large">Large</option>
+            </select>
+        </dd>
+    </dl>
 </templateSetting>
-<section class="hero-section" style="background-image:url('{custom_bg}');" data-tpl-tooltip="Hero">
+<section class="hero-section hero-{custom_size}" style="background-image:url('{custom_bg}');" data-tpl-tooltip="Hero">
     <div class="container hero-content">
         <h1 data-editable>{custom_heading}</h1>
         <p data-editable>{custom_subheading}</p>


### PR DESCRIPTION
## Summary
- add a size dropdown to the Hero block template
- support new hero size options in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872c4ba0f5083318266ee6b371bc61c