### PR TITLE
Merge spacer into divider block

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -578,6 +578,15 @@ hr[class^="divider"] {
     display: block;
     width: 100%;
 }
+.spacer-small {
+    height: 20px;
+}
+.spacer-medium {
+    height: 40px;
+}
+.spacer-large {
+    height: 60px;
+}
 
 /* Columns Block */
 .row {

--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -83,6 +83,9 @@ img[data-tpl-tooltip="Image"] {
     display: block;
     width: 100%;
 }
+.spacer-small { height: 20px; }
+.spacer-medium { height: 40px; }
+.spacer-large { height: 60px; }
 
 /* Columns Block */
 .row {

--- a/theme/templates/blocks/basic.divider.php
+++ b/theme/templates/blocks/basic.divider.php
@@ -5,11 +5,33 @@
         <dt>Style</dt>
         <dd>
             <select name="custom_style">
+                <option value="none">Spacer Only</option>
                 <option value="solid" selected="selected">Solid</option>
                 <option value="dashed">Dashed</option>
                 <option value="dotted">Dotted</option>
             </select>
         </dd>
     </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Height</dt>
+        <dd>
+            <select name="custom_height">
+                <option value="small">Small</option>
+                <option value="medium" selected="selected">Medium</option>
+                <option value="large">Large</option>
+            </select>
+        </dd>
+    </dl>
 </templateSetting>
-<hr class="divider-{custom_style}" data-tpl-tooltip="Divider"/>
+<toggle rel="custom_style" value="none">
+    <div class="spacer spacer-{custom_height}" data-tpl-tooltip="Spacer"></div>
+</toggle>
+<toggle rel="custom_style" value="solid">
+    <hr class="divider-solid spacer-{custom_height}" data-tpl-tooltip="Divider"/>
+</toggle>
+<toggle rel="custom_style" value="dashed">
+    <hr class="divider-dashed spacer-{custom_height}" data-tpl-tooltip="Divider"/>
+</toggle>
+<toggle rel="custom_style" value="dotted">
+    <hr class="divider-dotted spacer-{custom_height}" data-tpl-tooltip="Divider"/>
+</toggle>

--- a/theme/templates/blocks/basic.spacer.php
+++ b/theme/templates/blocks/basic.spacer.php
@@ -1,9 +1,0 @@
-<!-- File: basic.spacer.php -->
-<!-- Template: basic.spacer -->
-<templateSetting caption="Spacer Settings" order="1">
-    <dl class="sparkDialog _tpl-box">
-        <dt>Height (px)</dt>
-        <dd><input type="number" name="custom_height" value="40"></dd>
-    </dl>
-</templateSetting>
-<div class="spacer" style="height:{custom_height}px" data-tpl-tooltip="Spacer"></div>


### PR DESCRIPTION
## Summary
- merge spacer and divider blocks
- support small, medium (default) and large heights via dropdown
- add spacing classes in theme CSS
- remove unused spacer block file

## Testing
- `php -v`
- `find theme -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6872c720017c8331b0f09b9f9957808d