### PR TITLE
Add alignment setting to heading block

### DIFF
--- a/theme/templates/blocks/basic.heading.php
+++ b/theme/templates/blocks/basic.heading.php
@@ -18,10 +18,20 @@
             </select>
         </dd>
     </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Alignment</dt>
+        <dd class="align-options">
+            <label><input type="radio" name="custom_align" value=" _text-left" checked> Left</label>
+            <label><input type="radio" name="custom_align" value=" _text-center"> Center</label>
+            <label><input type="radio" name="custom_align" value=" _text-right"> Right</label>
+        </dd>
+    </dl>
 </templateSetting>
-<toggle rel="custom_level" value="h1"><h1 data-tpl-tooltip="Heading" data-editable>{custom_text}</h1></toggle>
-<toggle rel="custom_level" value="h2"><h2 data-tpl-tooltip="Heading" data-editable>{custom_text}</h2></toggle>
-<toggle rel="custom_level" value="h3"><h3 data-tpl-tooltip="Heading" data-editable>{custom_text}</h3></toggle>
-<toggle rel="custom_level" value="h4"><h4 data-tpl-tooltip="Heading" data-editable>{custom_text}</h4></toggle>
-<toggle rel="custom_level" value="h5"><h5 data-tpl-tooltip="Heading" data-editable>{custom_text}</h5></toggle>
-<toggle rel="custom_level" value="h6"><h6 data-tpl-tooltip="Heading" data-editable>{custom_text}</h6></toggle>
+<div class="{custom_align}">
+    <toggle rel="custom_level" value="h1"><h1 data-tpl-tooltip="Heading" data-editable>{custom_text}</h1></toggle>
+    <toggle rel="custom_level" value="h2"><h2 data-tpl-tooltip="Heading" data-editable>{custom_text}</h2></toggle>
+    <toggle rel="custom_level" value="h3"><h3 data-tpl-tooltip="Heading" data-editable>{custom_text}</h3></toggle>
+    <toggle rel="custom_level" value="h4"><h4 data-tpl-tooltip="Heading" data-editable>{custom_text}</h4></toggle>
+    <toggle rel="custom_level" value="h5"><h5 data-tpl-tooltip="Heading" data-editable>{custom_text}</h5></toggle>
+    <toggle rel="custom_level" value="h6"><h6 data-tpl-tooltip="Heading" data-editable>{custom_text}</h6></toggle>
+</div>


### PR DESCRIPTION
## Summary
- add alignment radio options to `basic.heading.php`
- wrap output headings in a container that uses the selected alignment

## Testing
- `php -l theme/templates/blocks/basic.heading.php`

------
https://chatgpt.com/codex/tasks/task_e_6873bac130e88331a0e87c315f73485c