### PR TITLE
Add accordion block template

### DIFF
--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -142,3 +142,31 @@ section.container-fluid {
     margin: 0;
     color: #555;
 }
+
+/* Accordion Block */
+.accordion {
+    border: 1px solid #e2e8f0;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+.accordion-header {
+    margin: 0;
+}
+.accordion-button {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    background: #f7fafc;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+}
+.accordion-panel {
+    padding: 0.75rem 1rem;
+    display: none;
+}
+.accordion.open .accordion-panel {
+    display: block;
+}

--- a/theme/js/script.js
+++ b/theme/js/script.js
@@ -7,4 +7,31 @@ document.addEventListener('DOMContentLoaded', function () {
       nav.classList.toggle('active');
     });
   }
+
+  var accordions = document.querySelectorAll('.accordion');
+  accordions.forEach(function (acc) {
+    var btn = acc.querySelector('.accordion-button');
+    var panel = acc.querySelector('.accordion-panel');
+    if (!btn || !panel) return;
+
+    if (acc.classList.contains('open')) {
+      btn.setAttribute('aria-expanded', 'true');
+      panel.style.display = 'block';
+    } else {
+      btn.setAttribute('aria-expanded', 'false');
+      panel.style.display = 'none';
+    }
+
+    btn.addEventListener('click', function () {
+      if (acc.classList.contains('open')) {
+        acc.classList.remove('open');
+        btn.setAttribute('aria-expanded', 'false');
+        panel.style.display = 'none';
+      } else {
+        acc.classList.add('open');
+        btn.setAttribute('aria-expanded', 'true');
+        panel.style.display = 'block';
+      }
+    });
+  });
 });

--- a/theme/templates/blocks/basic.accordion.php
+++ b/theme/templates/blocks/basic.accordion.php
@@ -1,0 +1,83 @@
+<!-- File: basic.accordion.php -->
+<!-- Template: basic.accordion -->
+<templateSetting caption="Accordion Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dd>
+            <label><input type="checkbox" name="custom_open" value=" open"> Open by default</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Heading Text</dt>
+        <dd><input type="text" name="custom_heading" value="Accordion Heading"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Heading Level</dt>
+        <dd>
+            <select name="custom_heading_tag">
+                <option value="h2">H2</option>
+                <option value="h3" selected="selected">H3</option>
+                <option value="h4">H4</option>
+                <option value="h5">H5</option>
+                <option value="h6">H6</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Icon</dt>
+        <dd>
+            <label><input type="radio" name="custom_icon" value="" checked> None</label>
+            <label><input type="radio" name="custom_icon" value="fa-solid fa-plus"> +</label>
+            <label><input type="radio" name="custom_icon" value="fa-solid fa-chevron-down"> &#xf078;</label>
+            <label><input type="radio" name="custom_icon" value="fa-solid fa-caret-down"> &#xf0d7;</label>
+        </dd>
+    </dl>
+</templateSetting>
+<div class="accordion accordion-style-1{custom_open}" data-tpl-tooltip="Accordion">
+    <div class="accordion-wrap">
+        <toggle rel="custom_heading_tag" value="h2">
+            <h2 class="accordion-header">
+                <button type="button" class="accordion-button" aria-expanded="false">
+                    <span>{custom_heading}</span>
+                    <i class="{custom_icon}" aria-hidden="true"></i>
+                </button>
+            </h2>
+        </toggle>
+        <toggle rel="custom_heading_tag" value="h3">
+            <h3 class="accordion-header">
+                <button type="button" class="accordion-button" aria-expanded="false">
+                    <span>{custom_heading}</span>
+                    <i class="{custom_icon}" aria-hidden="true"></i>
+                </button>
+            </h3>
+        </toggle>
+        <toggle rel="custom_heading_tag" value="h4">
+            <h4 class="accordion-header">
+                <button type="button" class="accordion-button" aria-expanded="false">
+                    <span>{custom_heading}</span>
+                    <i class="{custom_icon}" aria-hidden="true"></i>
+                </button>
+            </h4>
+        </toggle>
+        <toggle rel="custom_heading_tag" value="h5">
+            <h5 class="accordion-header">
+                <button type="button" class="accordion-button" aria-expanded="false">
+                    <span>{custom_heading}</span>
+                    <i class="{custom_icon}" aria-hidden="true"></i>
+                </button>
+            </h5>
+        </toggle>
+        <toggle rel="custom_heading_tag" value="h6">
+            <h6 class="accordion-header">
+                <button type="button" class="accordion-button" aria-expanded="false">
+                    <span>{custom_heading}</span>
+                    <i class="{custom_icon}" aria-hidden="true"></i>
+                </button>
+            </h6>
+        </toggle>
+        <div class="accordion-panel">
+            <div class="accordion-panel-inner">
+                <mwPageArea rel="mainContent" info="Drag and drop widgets or sub-templates here." sortable="page"></mwPageArea>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add an Accordion block template to `theme/templates/blocks`
- support toggling open/closed in `theme/js/script.js`
- style the accordion in `theme/css/skin.css`

## Testing
- `php -l theme/templates/blocks/basic.accordion.php`

------
https://chatgpt.com/codex/tasks/task_e_6873bc8062b08331bdf9e68410391663