### PR TITLE
Add new content width layout template

### DIFF
--- a/theme/templates/blocks/layout.content-width.php
+++ b/theme/templates/blocks/layout.content-width.php
@@ -1,0 +1,33 @@
+<!-- File: layout.content-width.php -->
+<!-- Template: layout.content-width -->
+<templateSetting caption="Options" order="1">
+    <dl class="mwDialog">
+        <dt>Width:</dt>
+        <dd>
+            <select name="custom_width">
+                <option value="480">480 pixel wide</option>
+                <option value="570">570 pixel wide</option>
+                <option value="670" selected="selected">670 pixel wide (default)</option>
+                <option value="770">770 pixel wide</option>
+                <option value="870">870 pixel wide</option>
+                <option value="970">970 pixel wide</option>
+                <option value="1170">1170 pixel wide</option>
+                <option value="1240">1240 pixel wide</option>
+            </select>
+        </dd>
+        <dt>Position:</dt>
+        <dd>
+            <select name="custom_position">
+                <option value="_mx-auto" selected="selected">Center (default)</option>
+                <option value="_mr-auto">Left</option>
+                <option value="_ml-auto">Right</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<div class="content-width _content-style" data-tpl-tooltip="Content Width">
+    <div class="content-width-wrap {custom_position}" style="max-width: {custom_width}px;">
+        <mwPageArea rel="mainContent" info="{custom_width} Pixel Wide Content Area" sortable="page"></mwPageArea>
+    </div>
+</div>
+


### PR DESCRIPTION
## Summary
- add `layout.content-width` block template for customizing content width and alignment

## Testing
- `php -l theme/templates/blocks/layout.content-width.php`

------
https://chatgpt.com/codex/tasks/task_e_6873c0283af08331b75669569224e4f1