### PR TITLE
Add blog post list theme block

### DIFF
--- a/CMS/data/blog_posts.json
+++ b/CMS/data/blog_posts.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": 1,
+    "title": "Getting Started with Web Development",
+    "slug": "getting-started-web-development",
+    "excerpt": "A comprehensive guide for beginners looking to start their journey in web development.",
+    "content": "<p>Welcome to the world of web development! This guide will help you understand the basics...</p>",
+    "category": "Technology",
+    "author": "John Doe",
+    "status": "published",
+    "publishDate": "2024-01-15T10:00:00",
+    "tags": "web development, beginner, tutorial",
+    "createdAt": "2024-01-15T10:00:00"
+  },
+  {
+    "id": 2,
+    "title": "Advanced JavaScript Techniques",
+    "slug": "advanced-javascript-techniques",
+    "excerpt": "Explore advanced JavaScript concepts and techniques used by professional developers.",
+    "content": "<p>JavaScript has evolved significantly over the years. In this post, we'll explore...</p>",
+    "category": "Programming",
+    "author": "Jane Smith",
+    "status": "draft",
+    "publishDate": "",
+    "tags": "javascript, advanced, programming",
+    "createdAt": "2024-01-20T14:30:00"
+  },
+  {
+    "id": 3,
+    "title": "The Future of AI in Web Design",
+    "slug": "future-ai-web-design",
+    "excerpt": "How artificial intelligence is revolutionizing the way we approach web design and user experience.",
+    "content": "<p>Artificial Intelligence is changing every industry, and web design is no exception...</p>",
+    "category": "Design",
+    "author": "Mike Johnson",
+    "status": "scheduled",
+    "publishDate": "2024-02-01T09:00:00",
+    "tags": "ai, web design, future, ux",
+    "createdAt": "2024-01-25T16:45:00"
+  }
+]

--- a/CMS/modules/blogs/list_posts.php
+++ b/CMS/modules/blogs/list_posts.php
@@ -1,0 +1,7 @@
+<?php
+// File: list_posts.php
+$postsFile = __DIR__ . '/../../data/blog_posts.json';
+$posts = file_exists($postsFile) ? json_decode(file_get_contents($postsFile), true) : [];
+header('Content-Type: application/json');
+echo json_encode($posts);
+?>

--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -874,3 +874,21 @@ section.container-fluid {
         flex-shrink: 0;
     }
 }
+
+/* Blog Post List */
+.blog-post-list .blog-item {
+    margin-bottom: 1.5rem;
+}
+.blog-post-list .blog-title {
+    margin: 0 0 0.25rem;
+    font-size: 1.25rem;
+}
+.blog-post-list .blog-title a {
+    text-decoration: none;
+    color: var(--primary, #333);
+}
+.blog-post-list .blog-excerpt {
+    margin: 0;
+    color: #555;
+    font-size: 0.95rem;
+}

--- a/theme/templates/blocks/module.blog-post-list.php
+++ b/theme/templates/blocks/module.blog-post-list.php
@@ -1,0 +1,39 @@
+<!-- File: module.blog-post-list.php -->
+<!-- Template: module.blog-post-list -->
+<templateSetting caption="Blog List Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Categories (comma separated)</dt>
+        <dd><input type="text" name="custom_categories" value=""></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Number of Posts</dt>
+        <dd><input type="number" name="custom_count" value="3" min="1" max="20"></dd>
+    </dl>
+</templateSetting>
+<div class="blog-post-list" data-categories="{custom_categories}" data-count="{custom_count}" data-tpl-tooltip="Blog List">
+    <div class="blog-posts"></div>
+</div>
+<script>
+(function(){
+    const script = document.currentScript;
+    const block = script.previousElementSibling;
+    if(!block) return;
+    const container = block.querySelector('.blog-posts');
+    const count = parseInt(block.dataset.count) || 3;
+    const cats = block.dataset.categories.split(',').map(c=>c.trim()).filter(c=>c);
+    fetch('CMS/modules/blogs/list_posts.php')
+        .then(r=>r.json())
+        .then(posts=>{
+            posts = posts.filter(p => p.status === 'published');
+            if(cats.length) posts = posts.filter(p => cats.includes(p.category));
+            posts.sort((a,b)=> new Date(b.publishDate || b.createdAt) - new Date(a.publishDate || a.createdAt));
+            posts.slice(0, count).forEach(p=>{
+                const el = document.createElement('article');
+                el.className = 'blog-item';
+                el.innerHTML = '<h3 class="blog-title"><a href="'+p.slug+'">'+p.title+'</a></h3>'+
+                               '<p class="blog-excerpt">'+p.excerpt+'</p>';
+                container.appendChild(el);
+            });
+        });
+})();
+</script>


### PR DESCRIPTION
## Summary
- provide example blog data and posts API
- add a blog post list block template to themes
- style blog post list block

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873c03b51c08331b3d6141c392607a8