### PR TITLE
Add alignment option to hero block

### DIFF
--- a/theme/templates/blocks/basic.hero.php
+++ b/theme/templates/blocks/basic.hero.php
@@ -39,9 +39,17 @@
             </select>
         </dd>
     </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Alignment</dt>
+        <dd class="align-options">
+            <label><input type="radio" name="custom_align" value=" _text-left"> Left</label>
+            <label><input type="radio" name="custom_align" value=" _text-center" checked> Center</label>
+            <label><input type="radio" name="custom_align" value=" _text-right"> Right</label>
+        </dd>
+    </dl>
 </templateSetting>
 <section class="hero-section hero-{custom_size}" style="background-image:url('{custom_bg}');" data-tpl-tooltip="Hero">
-    <div class="container hero-content">
+    <div class="container hero-content{custom_align}">
         <h1 data-editable>{custom_heading}</h1>
         <p data-editable>{custom_subheading}</p>
         <a href="{custom_btn_link}" class="btn btn-primary"{custom_btn_new} data-editable>{custom_btn_text}</a>


### PR DESCRIPTION
## Summary
- add alignment radio buttons in `basic.hero.php`
- apply alignment class to hero content container

## Testing
- `php -l theme/templates/blocks/basic.hero.php`


------
https://chatgpt.com/codex/tasks/task_e_6873c09a13b88331991b02c18a6d2cb8