### PR TITLE
Update blog post list block to use categories

### DIFF
--- a/CMS/modules/blogs/list_categories.php
+++ b/CMS/modules/blogs/list_categories.php
@@ -1,0 +1,13 @@
+<?php
+// File: list_categories.php
+$postsFile = __DIR__ . '/../../data/blog_posts.json';
+$posts = file_exists($postsFile) ? json_decode(file_get_contents($postsFile), true) : [];
+$categories = [];
+foreach ($posts as $p) {
+    if (!empty($p['category']) && !in_array($p['category'], $categories)) {
+        $categories[] = $p['category'];
+    }
+}
+header('Content-Type: application/json');
+echo json_encode(array_values($categories));
+?>

--- a/theme/templates/blocks/module.blog-post-list.php
+++ b/theme/templates/blocks/module.blog-post-list.php
@@ -1,9 +1,13 @@
 <!-- File: module.blog-post-list.php -->
 <!-- Template: module.blog-post-list -->
 <templateSetting caption="Blog List Settings" order="1">
+    <?php $listId = 'blog-cat-' . uniqid(); ?>
     <dl class="sparkDialog _tpl-box">
         <dt>Categories (comma separated)</dt>
-        <dd><input type="text" name="custom_categories" value=""></dd>
+        <dd>
+            <input type="text" name="custom_categories" value="" list="<?php echo $listId; ?>">
+            <datalist id="<?php echo $listId; ?>"></datalist>
+        </dd>
     </dl>
     <dl class="sparkDialog _tpl-box">
         <dt>Number of Posts</dt>
@@ -21,6 +25,15 @@
     const container = block.querySelector('.blog-posts');
     const count = parseInt(block.dataset.count) || 3;
     const cats = block.dataset.categories.split(',').map(c=>c.trim()).filter(c=>c);
+
+    const datalist = block.querySelector('#<?php echo $listId; ?>');
+    if(datalist){
+        fetch('CMS/modules/blogs/list_categories.php')
+            .then(r=>r.json())
+            .then(catsData=>{
+                datalist.innerHTML = catsData.map(c=>`<option value="${c}"></option>`).join('');
+            });
+    }
     fetch('CMS/modules/blogs/list_posts.php')
         .then(r=>r.json())
         .then(posts=>{


### PR DESCRIPTION
## Summary
- add endpoint for listing blog categories
- update blog post list block to load categories from the new endpoint and display them in a datalist

## Testing
- `php -l CMS/modules/blogs/list_categories.php`
- `php -l theme/templates/blocks/module.blog-post-list.php`


------
https://chatgpt.com/codex/tasks/task_e_6873c3e302388331ba945a513a9b64d0