### PR TITLE
Add template settings for 3 column layout block

### DIFF
--- a/theme/templates/blocks/layout.column_3.php
+++ b/theme/templates/blocks/layout.column_3.php
@@ -1,6 +1,28 @@
 <!-- File: layout.column_3.php -->
 <!-- Template: layout.column_3 -->
-<div class="row drop-area" data-tpl-tooltip="3 Columns">
+<templateSetting caption="Column Settings" order="1">
+    <dl class="mwDialog">
+        <dt>Gap:</dt>
+        <dd>
+            <select name="custom_gap">
+                <option value="_gutter-0">None</option>
+                <option value="_gutter-10">Small</option>
+                <option value="_gutter-30" selected="selected">Medium (default)</option>
+                <option value="_gutter-60">Large</option>
+                <option value="_gutter-80">Extra Large</option>
+            </select>
+        </dd>
+        <dt>Alignment:</dt>
+        <dd>
+            <select name="custom_alignment">
+                <option value="" selected="selected">Align columns top (default)</option>
+                <option value="_align-items-center">Align columns centered</option>
+                <option value="_align-items-end">Align columns bottom</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<div class="row {custom_gap}{custom_alignment} drop-area" data-tpl-tooltip="3 Columns">
     <div class="col"><div class="drop-area"></div></div>
     <div class="col"><div class="drop-area"></div></div>
     <div class="col"><div class="drop-area"></div></div>


### PR DESCRIPTION
## Summary
- add a `templateSetting` block to the `layout.column_3.php` template so column gaps and alignment can be configured

## Testing
- `php -l theme/templates/blocks/layout.column_3.php`

------
https://chatgpt.com/codex/tasks/task_e_6873ce4a72408331824b662c7ed999ca