### PR TITLE
Fix blog list module

### DIFF
--- a/theme/templates/blocks/module.blog-post-list.php
+++ b/theme/templates/blocks/module.blog-post-list.php
@@ -1,12 +1,11 @@
 <!-- File: module.blog-post-list.php -->
 <!-- Template: module.blog-post-list -->
 <templateSetting caption="Blog List Settings" order="1">
-    <?php $listId = 'blog-cat-' . uniqid(); ?>
     <dl class="sparkDialog _tpl-box">
         <dt>Categories (comma separated)</dt>
         <dd>
-            <input type="text" name="custom_categories" value="" list="<?php echo $listId; ?>">
-            <datalist id="<?php echo $listId; ?>"></datalist>
+            <input type="text" name="custom_categories" value="" list="">
+            <datalist></datalist>
         </dd>
     </dl>
     <dl class="sparkDialog _tpl-box">
@@ -26,15 +25,19 @@
     const count = parseInt(block.dataset.count) || 3;
     const cats = block.dataset.categories.split(',').map(c=>c.trim()).filter(c=>c);
 
-    const datalist = block.querySelector('#<?php echo $listId; ?>');
-    if(datalist){
-        fetch('CMS/modules/blogs/list_categories.php')
+    const input = block.querySelector('input[list]');
+    const datalist = block.querySelector('datalist');
+    if(input && datalist){
+        const listId = 'blog-cat-' + Math.random().toString(36).substr(2,8);
+        datalist.id = listId;
+        input.setAttribute('list', listId);
+        fetch((window.cmsBase || '') + '/CMS/modules/blogs/list_categories.php')
             .then(r=>r.json())
             .then(catsData=>{
                 datalist.innerHTML = catsData.map(c=>`<option value="${c}"></option>`).join('');
             });
     }
-    fetch('CMS/modules/blogs/list_posts.php')
+    fetch((window.cmsBase || '') + '/CMS/modules/blogs/list_posts.php')
         .then(r=>r.json())
         .then(posts=>{
             posts = posts.filter(p => p.status === 'published');

--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -136,9 +136,10 @@ function renderFooterMenu($items){
 
 		</div>
 
-		<!-- Vendor Javascript -->
+                <!-- Vendor Javascript -->
 
-		<!-- Javascript -->
+                <!-- Javascript -->
+                <script>window.cmsBase = <?php echo json_encode($scriptBase); ?>;</script>
                 <script src="<?php echo $themeBase; ?>/js/global.js?v=mw3.2"></script>
                 <script src="<?php echo $themeBase; ?>/js/script.js?v=mw3.2"></script>
 


### PR DESCRIPTION
## Summary
- generate datalist IDs using JavaScript instead of PHP
- prefix blog module fetch URLs with `window.cmsBase`
- expose `window.cmsBase` in `page.php`

## Testing
- `php -l theme/templates/blocks/module.blog-post-list.php`
- `php -l theme/templates/pages/page.php`
- `find . -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_687421f0acc483319b536c2f4d72c915