### PR TITLE
Fix builder scripts for dynamic blocks

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -6,6 +6,7 @@ import { initUndoRedo } from './modules/undoRedo.js';
 import { initWysiwyg } from './modules/wysiwyg.js';
 import { initMediaPicker, openMediaPicker } from './modules/mediaPicker.js';
 import { initAccessibility } from './modules/accessibility.js';
+import { executeScripts } from "./modules/executeScripts.js";
 
 let allBlockFiles = [];
 let favorites = [];
@@ -439,6 +440,7 @@ document.addEventListener('DOMContentLoaded', () => {
   canvas.addEventListener('change', scheduleSave);
 
   canvas.querySelectorAll('.block-wrapper').forEach(addBlockControls);
+  executeScripts(canvas);
 
   function updateCanvasPlaceholder() {
     const placeholder = canvas.querySelector('.canvas-placeholder');
@@ -470,6 +472,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       addBlockControls(clone);
       applyStoredSettings(clone);
+      executeScripts(clone);
       if (gridActive) snapBlockToGrid(clone);
       document.dispatchEvent(new Event('canvasUpdated'));
     } else if (e.target.closest('.block-controls .delete')) {

--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -1,5 +1,6 @@
 // File: dragDrop.js
 import { ensureBlockState } from './state.js';
+import { executeScripts } from "./executeScripts.js";
 
 let palette;
 let canvas;
@@ -203,6 +204,7 @@ function handleDrop(e) {
             .replace(/\b\w/g, (c) => c.toUpperCase());
           wrapper.setAttribute('data-tpl-tooltip', label);
           wrapper.innerHTML = cleaned;
+          executeScripts(wrapper);
           if (applyStoredSettings) applyStoredSettings(wrapper);
           addBlockControls(wrapper);
           if (after == null) area.appendChild(wrapper);

--- a/liveed/modules/executeScripts.js
+++ b/liveed/modules/executeScripts.js
@@ -1,0 +1,16 @@
+/**
+ * Ensure any script tags within the provided element are executed.
+ * Replaces each script with a new one so the browser runs it.
+ * @param {Element} container
+ */
+export function executeScripts(container) {
+  if (!container) return;
+  container.querySelectorAll('script').forEach((oldScript) => {
+    const newScript = document.createElement('script');
+    [...oldScript.attributes].forEach((attr) => {
+      newScript.setAttribute(attr.name, attr.value);
+    });
+    newScript.textContent = oldScript.textContent;
+    oldScript.replaceWith(newScript);
+  });
+}

--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -1,6 +1,7 @@
 // File: settings.js
 import { ensureBlockState, getSetting, setSetting, getSettings } from './state.js';
 import { addBlockControls } from './dragDrop.js';
+import { executeScripts } from "./executeScripts.js";
 
 let canvas;
 let settingsPanel;
@@ -205,6 +206,7 @@ function renderBlock(block) {
     if (contents) contents.forEach((n) => area.appendChild(n));
   });
   block.innerHTML = temp.innerHTML;
+  executeScripts(block);
   block.querySelectorAll('.drop-area').forEach((a) => (a.dataset.dropArea = 'true'));
   inputs.forEach((input) => {
     const name = input.name;


### PR DESCRIPTION
## Summary
- ensure scripts within blocks execute
- handle script execution when adding blocks, applying settings, and duplicating blocks

## Testing
- `node --check liveed/builder.js`
- `node --check liveed/modules/dragDrop.js`
- `node --check liveed/modules/settings.js`
- `node --check liveed/modules/executeScripts.js`


------
https://chatgpt.com/codex/tasks/task_e_6874254f84508331af4c6cef1c4c22c1