### PR TITLE
Sort page history from newest to oldest

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -412,7 +412,10 @@ document.addEventListener('DOMContentLoaded', () => {
           cont.innerHTML = '';
           if (data.history && data.history.length) {
             const ul = document.createElement('ul');
-            data.history.forEach((h) => {
+            const entries = data.history
+              .slice()
+              .sort((a, b) => b.time - a.time);
+            entries.forEach((h) => {
               const li = document.createElement('li');
               const d = new Date(h.time * 1000);
               const action = h.action ? ' - ' + h.action : '';


### PR DESCRIPTION
## Summary
- reorder history entries from newest to oldest

## Testing
- `php -l liveed/builder.js`

------
https://chatgpt.com/codex/tasks/task_e_687466751b50833192105fd9704cd71f