### PR TITLE
Improve page history details

### DIFF
--- a/CMS/modules/pages/delete_page.php
+++ b/CMS/modules/pages/delete_page.php
@@ -8,6 +8,10 @@ if (!file_exists($pagesFile)) {
 }
 $pages = json_decode(file_get_contents($pagesFile), true) ?: [];
 $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$deletedPage = null;
+foreach ($pages as $p) {
+    if ($p['id'] == $id) { $deletedPage = $p; break; }
+}
 $pages = array_filter($pages, function($p) use ($id) { return $p['id'] != $id; });
 file_put_contents($pagesFile, json_encode(array_values($pages), JSON_PRETTY_PRINT));
 // Update sitemap after a page is deleted
@@ -17,7 +21,11 @@ $historyFile = __DIR__ . '/../../data/page_history.json';
 $historyData = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
 if (!isset($historyData[$id])) $historyData[$id] = [];
 $user = $_SESSION['user']['username'] ?? 'Unknown';
-$historyData[$id][] = ['time' => time(), 'user' => $user, 'action' => 'deleted page'];
+$action = 'deleted page';
+if ($deletedPage && !empty($deletedPage['template'])) {
+    $action .= ' (' . $deletedPage['template'] . ')';
+}
+$historyData[$id][] = ['time' => time(), 'user' => $user, 'action' => $action];
 $historyData[$id] = array_slice($historyData[$id], -20);
 file_put_contents($historyFile, json_encode($historyData, JSON_PRETTY_PRINT));
 

--- a/CMS/modules/pages/save_page.php
+++ b/CMS/modules/pages/save_page.php
@@ -43,8 +43,10 @@ if ($title === '') {
 
 if ($id) {
     // Update existing
+    $old = null;
     foreach ($pages as &$p) {
         if ($p['id'] == $id) {
+            $old = $p;
             $p['title'] = $title;
             $p['slug'] = $slug;
             $p['content'] = $content;
@@ -61,7 +63,17 @@ if ($id) {
             break;
         }
     }
-    $action = 'updated page';
+    $changes = [];
+    if ($old) {
+        if ($old['template'] !== $template) {
+            $changes[] = 'changed template from ' . $old['template'] . ' to ' . $template;
+        }
+        if ($old['published'] != $published) {
+            $changes[] = $published ? 'published page' : 'unpublished page';
+        }
+    }
+    if (!$changes) $changes[] = 'updated page';
+    $action = implode('; ', $changes);
     unset($p);
 } else {
     $id = 1;
@@ -85,7 +97,7 @@ $pages[] = [
         'last_modified' => time()
     ];
     $timestamp = $pages[array_key_last($pages)]['last_modified'];
-    $action = 'created page';
+    $action = 'created page with template ' . $template;
 }
 
 $historyFile = __DIR__ . '/../../data/page_history.json';


### PR DESCRIPTION
## Summary
- record template changes in page history
- log deleted page templates

## Testing
- `php -l CMS/modules/pages/save_page.php`
- `php -l CMS/modules/pages/delete_page.php`
- `php -l liveed/save-content.php`


------
https://chatgpt.com/codex/tasks/task_e_68746860e5cc8331b9d51af54b2c77ac