### PR TITLE
Enable drag-and-drop uploads in media library

### DIFF
--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -342,6 +342,33 @@ $(function(){
     $('#uploadBtn').click(function(){ $('#fileInput').click(); });
     $('#fileInput').change(function(){ uploadFiles(this.files); });
 
+    let dragCounter = 0;
+    const dropZone = $('#dropZone');
+    $('#galleryContent').on('dragenter', function(e){
+        if(!currentFolder) return;
+        e.preventDefault();
+        dragCounter++;
+        dropZone.addClass('dragging').show();
+    }).on('dragover', function(e){
+        if(!currentFolder) return;
+        e.preventDefault();
+    }).on('dragleave', function(e){
+        if(!currentFolder) return;
+        dragCounter--;
+        if(dragCounter<=0){
+            dragCounter = 0;
+            dropZone.removeClass('dragging').hide();
+        }
+    }).on('drop', function(e){
+        if(!currentFolder) return;
+        e.preventDefault();
+        dragCounter = 0;
+        dropZone.removeClass('dragging').hide();
+        const files = e.originalEvent.dataTransfer.files;
+        uploadFiles(files);
+    });
+    dropZone.click(function(){ $('#fileInput').click(); });
+
     $('#renameFolderBtn').click(renameFolder);
     $('#deleteFolderBtn').click(deleteFolder);
     $('#createFolderBtn').click(function(){ openModal('createFolderModal'); $('#newFolderName').focus(); });

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -100,6 +100,7 @@
                                         <p>Click "Upload Images" to add some photos</p>
                                     </div>
                                     <div class="image-grid" id="imageGrid" style="display: none;"></div>
+                                    <div id="dropZone" class="upload-drop">Drop images here</div>
                                 </div>
                             </div>
                         </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -970,6 +970,17 @@
 }
 .upload-drop.dragging { background: #f0f0f0; }
 
+#galleryContent{position:relative;}
+#dropZone{
+    position:absolute;
+    inset:0;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    background:rgba(255,255,255,0.8);
+    z-index:1000;
+}
+
 .media-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));


### PR DESCRIPTION
## Summary
- add drop area markup to media gallery
- style drop zone overlay in media CSS
- handle drag events and upload dropped files via JavaScript

## Testing
- `php -l CMS/modules/media/view.php`

------
https://chatgpt.com/codex/tasks/task_e_6875cce10a588331980536b6efb7354c