### PR TITLE
Rename block templates

### DIFF
--- a/theme/templates/blocks/advanced.blog-post-list.php
+++ b/theme/templates/blocks/advanced.blog-post-list.php
@@ -1,5 +1,5 @@
-<!-- File: advanced.module.blog-post-list.php -->
-<!-- Template: advanced.module.blog-post-list -->
+<!-- File: advanced.blog-post-list.php -->
+<!-- Template: advanced.blog-post-list -->
 <?php
 $postsFile = __DIR__ . '/../../../CMS/data/blog_posts.json';
 $blogCategories = [];

--- a/theme/templates/blocks/content-elements.cta-banner.php
+++ b/theme/templates/blocks/content-elements.cta-banner.php
@@ -1,5 +1,5 @@
-<!-- File: content-elements.basic.cta-banner.php -->
-<!-- Template: content-elements.basic.cta-banner -->
+<!-- File: content-elements.cta-banner.php -->
+<!-- Template: content-elements.cta-banner -->
 <templateSetting caption="CTA Banner Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Heading</dt>

--- a/theme/templates/blocks/content-elements.heading.php
+++ b/theme/templates/blocks/content-elements.heading.php
@@ -1,5 +1,5 @@
-<!-- File: content-elements.basic.heading.php -->
-<!-- Template: content-elements.basic.heading -->
+<!-- File: content-elements.heading.php -->
+<!-- Template: content-elements.heading -->
 <templateSetting caption="Heading Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Text</dt>

--- a/theme/templates/blocks/content-elements.hero.php
+++ b/theme/templates/blocks/content-elements.hero.php
@@ -1,5 +1,5 @@
-<!-- File: content-elements.basic.hero.php -->
-<!-- Template: content-elements.basic.hero -->
+<!-- File: content-elements.hero.php -->
+<!-- Template: content-elements.hero -->
 <templateSetting caption="Hero Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Background Image</dt>


### PR DESCRIPTION
## Summary
- rename block template filenames for simplicity
- update template comments accordingly

## Testing
- `php -l theme/templates/blocks/advanced.blog-post-list.php`
- `php -l theme/templates/blocks/content-elements.cta-banner.php`
- `php -l theme/templates/blocks/content-elements.heading.php`
- `php -l theme/templates/blocks/content-elements.hero.php`

------
https://chatgpt.com/codex/tasks/task_e_6875cd2bf00c8331859f2aaf6448f08d