### PR TITLE
Add margin to a11y status style

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -1131,6 +1131,7 @@
   background: rgba(239, 68, 68, 0.15);
   color: #f87171;
   font-size: 10px;
+  margin: 0 0 15px;
   padding: 6px 6px;
   border-radius: 4px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add spacing below the accessibility status label in the editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875d32dbef483319ec54b9e303cf3ec