### PR TITLE
Rename block template files

### DIFF
--- a/theme/templates/blocks/content-elements.image-gallery.php
+++ b/theme/templates/blocks/content-elements.image-gallery.php
@@ -1,5 +1,5 @@
-<!-- File: content-elements.basic.image-gallery.php -->
-<!-- Template: content-elements.basic.image-gallery -->
+<!-- File: content-elements.image-gallery.php -->
+<!-- Template: content-elements.image-gallery -->
 <templateSetting caption="Gallery Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Image 1 URL</dt>

--- a/theme/templates/blocks/content-elements.image.php
+++ b/theme/templates/blocks/content-elements.image.php
@@ -1,5 +1,5 @@
-<!-- File: content-elements.basic.image.php -->
-<!-- Template: content-elements.basic.image -->
+<!-- File: content-elements.image.php -->
+<!-- Template: content-elements.image -->
 <templateSetting caption="Image Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Source</dt>

--- a/theme/templates/blocks/content-elements.paragraph.php
+++ b/theme/templates/blocks/content-elements.paragraph.php
@@ -1,5 +1,5 @@
-<!-- File: content-elements.basic.paragraph.php -->
-<!-- Template: content-elements.basic.paragraph -->
+<!-- File: content-elements.paragraph.php -->
+<!-- Template: content-elements.paragraph -->
 <templateSetting caption="Paragraph Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Text</dt>

--- a/theme/templates/blocks/content-elements.video.php
+++ b/theme/templates/blocks/content-elements.video.php
@@ -1,5 +1,5 @@
-<!-- File: content-elements.basic.video.php -->
-<!-- Template: content-elements.basic.video -->
+<!-- File: content-elements.video.php -->
+<!-- Template: content-elements.video -->
 <templateSetting caption="Video Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Embed URL</dt>

--- a/theme/templates/blocks/interactive.button.php
+++ b/theme/templates/blocks/interactive.button.php
@@ -1,5 +1,5 @@
-<!-- File: interactive.basic.button.php -->
-<!-- Template: interactive.basic.button -->
+<!-- File: interactive.button.php -->
+<!-- Template: interactive.button -->
 <templateSetting caption="Button Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Text</dt>

--- a/theme/templates/blocks/layout.column_2.php
+++ b/theme/templates/blocks/layout.column_2.php
@@ -1,7 +1,19 @@
-<!-- File: layout.layout.column_4.php -->
-<!-- Template: layout.layout.column_4 -->
+<!-- File: layout.column_2.php -->
+<!-- Template: layout.column_2 -->
 <templateSetting caption="Column Settings" order="1">
     <dl class="mwDialog">
+        <dt>Layout:</dt>
+        <dd>
+            <select name="custom_layout">
+                <option value="20_80">20% | 80%</option>
+                <option value="30_70">30% | 70%</option>
+                <option value="40_60">40% | 60%</option>
+                <option value="50_50" selected="selected">50% | 50% (default)</option>
+                <option value="60_40">60% | 40%</option>
+                <option value="70_30">70% | 30%</option>
+                <option value="80_20">80% | 20%</option>
+            </select>
+        </dd>
         <dt>Gap:</dt>
         <dd>
             <select name="custom_gap">
@@ -22,9 +34,7 @@
         </dd>
     </dl>
 </templateSetting>
-<div class="row {custom_gap} {custom_alignment} " data-tpl-tooltip="4 Columns">
-    <div class="col"><div class="drop-area"></div></div>
-    <div class="col"><div class="drop-area"></div></div>
+<div class="row {custom_layout} {custom_gap} {custom_alignment}" data-tpl-tooltip="2 Columns">
     <div class="col"><div class="drop-area"></div></div>
     <div class="col"><div class="drop-area"></div></div>
 </div>

--- a/theme/templates/blocks/layout.column_4.php
+++ b/theme/templates/blocks/layout.column_4.php
@@ -1,19 +1,7 @@
-<!-- File: layout.layout.column_2.php -->
-<!-- Template: layout.layout.column_2 -->
+<!-- File: layout.column_4.php -->
+<!-- Template: layout.column_4 -->
 <templateSetting caption="Column Settings" order="1">
     <dl class="mwDialog">
-        <dt>Layout:</dt>
-        <dd>
-            <select name="custom_layout">
-                <option value="20_80">20% | 80%</option>
-                <option value="30_70">30% | 70%</option>
-                <option value="40_60">40% | 60%</option>
-                <option value="50_50" selected="selected">50% | 50% (default)</option>
-                <option value="60_40">60% | 40%</option>
-                <option value="70_30">70% | 30%</option>
-                <option value="80_20">80% | 20%</option>
-            </select>
-        </dd>
         <dt>Gap:</dt>
         <dd>
             <select name="custom_gap">
@@ -34,7 +22,9 @@
         </dd>
     </dl>
 </templateSetting>
-<div class="row {custom_layout} {custom_gap} {custom_alignment}" data-tpl-tooltip="2 Columns">
+<div class="row {custom_gap} {custom_alignment} " data-tpl-tooltip="4 Columns">
+    <div class="col"><div class="drop-area"></div></div>
+    <div class="col"><div class="drop-area"></div></div>
     <div class="col"><div class="drop-area"></div></div>
     <div class="col"><div class="drop-area"></div></div>
 </div>

--- a/theme/templates/blocks/layout.section.php
+++ b/theme/templates/blocks/layout.section.php
@@ -1,5 +1,5 @@
-<!-- File: layout.layout.section.php -->
-<!-- Template: layout.layout.section -->
+<!-- File: layout.section.php -->
+<!-- Template: layout.section -->
 <templateSetting caption="Section Settings" order="1">
     <dl class="sparkDialog _tpl-box">
         <dt>Width</dt>

--- a/theme/templates/blocks/layout.sidebar.php
+++ b/theme/templates/blocks/layout.sidebar.php
@@ -1,5 +1,5 @@
-<!-- File: layout.layout.sidebar.php -->
-<!-- Template: layout.layout.sidebar -->
+<!-- File: layout.sidebar.php -->
+<!-- Template: layout.sidebar -->
 <?php $tpl_id = uniqid('tpl-'); ?>
 <templateSetting caption="Options" order="1">
     <dl class="sparkDialog">


### PR DESCRIPTION
## Summary
- rename template files for content-elements, interactive elements, and layout blocks
- update their internal header comments to match new filenames

## Testing
- `php -l` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6875d2e4cc5483319a615bba70d8113a