### PR TITLE
Add new field types to forms module

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -24,7 +24,7 @@ $(function(){
         body.append('<div class="form-group"><label class="form-label">Label</label><input type="text" class="form-input field-label"></div>');
         body.append('<div class="form-group"><label class="form-label">Name</label><input type="text" class="form-input field-name"></div>');
         body.append('<div class="form-group"><label><input type="checkbox" class="field-required"> Required</label></div>');
-        if(type==='select'){
+        if(['select','radio','checkbox'].includes(type)){
             body.append('<div class="form-group field-options"><label class="form-label">Options (comma separated)</label><input type="text" class="form-input field-options-input"></div>');
         }
         $li.append(body);
@@ -90,7 +90,7 @@ $(function(){
                 name: $li.find('.field-name').val(),
                 required: $li.find('.field-required').is(':checked')
             };
-            if(f.type==='select') f.options = $li.find('.field-options-input').val();
+            if(['select','radio','checkbox'].includes(f.type)) f.options = $li.find('.field-options-input').val();
             fields.push(f);
         });
         $.post('modules/forms/save_form.php',{

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -31,8 +31,14 @@
                 <div id="fieldPalette">
                     <div class="palette-item" data-type="text" role="button" tabindex="0">Text Input</div>
                     <div class="palette-item" data-type="email" role="button" tabindex="0">Email</div>
+                    <div class="palette-item" data-type="password" role="button" tabindex="0">Password</div>
+                    <div class="palette-item" data-type="number" role="button" tabindex="0">Number</div>
+                    <div class="palette-item" data-type="date" role="button" tabindex="0">Date</div>
                     <div class="palette-item" data-type="textarea" role="button" tabindex="0">Textarea</div>
                     <div class="palette-item" data-type="select" role="button" tabindex="0">Select</div>
+                    <div class="palette-item" data-type="checkbox" role="button" tabindex="0">Checkbox</div>
+                    <div class="palette-item" data-type="radio" role="button" tabindex="0">Radio</div>
+                    <div class="palette-item" data-type="file" role="button" tabindex="0">File</div>
                 </div>
                 <ul id="formFields" class="field-list" aria-label="Form fields"></ul>
             </div>


### PR DESCRIPTION
## Summary
- expand form builder palette with common input types
- handle checkbox and radio options in form builder logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875d4c18bb88331807b47c5dfc733c1