### PR TITLE
Add submit buttons to forms

### DIFF
--- a/CMS/data/forms.json
+++ b/CMS/data/forms.json
@@ -1,1 +1,55 @@
-[]
+[
+    {
+        "id": 1,
+        "name": "Newsletter Signup",
+        "fields": [
+            {
+                "type": "text",
+                "label": "Name",
+                "name": "name",
+                "required": false
+            },
+            {
+                "type": "email",
+                "label": "Email",
+                "name": "email",
+                "required": true
+            },
+            {
+                "type": "submit",
+                "label": "Subscribe",
+                "name": "submit"
+            }
+        ]
+    },
+    {
+        "id": 2,
+        "name": "Contact Form",
+        "fields": [
+            {
+                "type": "text",
+                "label": "Name",
+                "name": "name",
+                "required": true
+            },
+            {
+                "type": "email",
+                "label": "Email",
+                "name": "email",
+                "required": true
+            },
+            {
+                "type": "textarea",
+                "label": "Message",
+                "name": "message",
+                "required": true
+            },
+            {
+                "type": "submit",
+                "label": "Send Message",
+                "name": "submit"
+            }
+        ]
+    }
+]
+


### PR DESCRIPTION
## Summary
- append a submit button field to newsletter signup and contact forms

## Testing
- `jq '.' CMS/data/forms.json`

------
https://chatgpt.com/codex/tasks/task_e_6875d790601c8331a2c83e305db24e70