### PR TITLE
Show placeholder drop zone in forms module

### DIFF
--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -40,7 +40,7 @@
                     <div class="palette-item" data-type="radio" role="button" tabindex="0">Radio</div>
                     <div class="palette-item" data-type="file" role="button" tabindex="0">File</div>
                 </div>
-                <ul id="formFields" class="field-list" aria-label="Form fields"></ul>
+                <ul id="formFields" class="field-list" aria-label="Form fields" data-placeholder="Drop fields here"></ul>
             </div>
             <div class="form-actions">
                 <button type="submit" class="btn btn-primary">Save Form</button>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -612,6 +612,16 @@
             flex: 1;
             border: 2px dashed #e2e8f0;
             min-height: 120px;
+            position: relative;
+        }
+        .field-list:empty::before {
+            content: attr(data-placeholder);
+            color: #a0aec0;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            pointer-events: none;
         }
         .field-item {
             background: #fff;


### PR DESCRIPTION
## Summary
- show a visual drop area for form fields
- style the drop zone placeholder text

## Testing
- `php -l CMS/modules/forms/view.php`


------
https://chatgpt.com/codex/tasks/task_e_6875db12b6e083319c6fe1ca21690d12