### PR TITLE
Add submit button field type

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -23,14 +23,16 @@ $(function(){
         const body = $('<div class="field-body"></div>');
         body.append('<div class="form-group"><label class="form-label">Label</label><input type="text" class="form-input field-label"></div>');
         body.append('<div class="form-group"><label class="form-label">Name</label><input type="text" class="form-input field-name"></div>');
-        body.append('<div class="form-group"><label><input type="checkbox" class="field-required"> Required</label></div>');
+        if(type !== 'submit'){
+            body.append('<div class="form-group"><label><input type="checkbox" class="field-required"> Required</label></div>');
+        }
         if(['select','radio','checkbox'].includes(type)){
             body.append('<div class="form-group field-options"><label class="form-label">Options (comma separated)</label><input type="text" class="form-input field-options-input"></div>');
         }
         $li.append(body);
         if(field.label) $li.find('.field-label').val(field.label);
         if(field.name) $li.find('.field-name').val(field.name);
-        if(field.required) $li.find('.field-required').prop('checked', true);
+        if(field.required && type !== 'submit') $li.find('.field-required').prop('checked', true);
         if(field.options) $li.find('.field-options-input').val(field.options);
         $('#formFields').append($li);
     }
@@ -87,9 +89,11 @@ $(function(){
             const f = {
                 type: $li.data('type'),
                 label: $li.find('.field-label').val(),
-                name: $li.find('.field-name').val(),
-                required: $li.find('.field-required').is(':checked')
+                name: $li.find('.field-name').val()
             };
+            if(f.type !== 'submit'){
+                f.required = $li.find('.field-required').is(':checked');
+            }
             if(['select','radio','checkbox'].includes(f.type)) f.options = $li.find('.field-options-input').val();
             fields.push(f);
         });

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -39,6 +39,7 @@
                     <div class="palette-item" data-type="checkbox" role="button" tabindex="0">Checkbox</div>
                     <div class="palette-item" data-type="radio" role="button" tabindex="0">Radio</div>
                     <div class="palette-item" data-type="file" role="button" tabindex="0">File</div>
+                    <div class="palette-item" data-type="submit" role="button" tabindex="0">Submit Button</div>
                 </div>
                 <ul id="formFields" class="field-list" aria-label="Form fields"></ul>
             </div>


### PR DESCRIPTION
## Summary
- add "Submit Button" option in forms palette
- ensure required checkbox not shown for submit fields
- exclude required flag for submit fields when saving

## Testing
- `php -l CMS/modules/forms/view.php`
- `node --check CMS/modules/forms/forms.js`


------
https://chatgpt.com/codex/tasks/task_e_6875db6d1b8883318fa647e7cfec5983