### PR TITLE
Improve form builder layout

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -16,10 +16,30 @@ $(function(){
         });
     }
 
+    function createPreview(type){
+        switch(type){
+            case 'text': return $('<input type="text" class="form-input" disabled>');
+            case 'email': return $('<input type="email" class="form-input" disabled>');
+            case 'password': return $('<input type="password" class="form-input" disabled>');
+            case 'number': return $('<input type="number" class="form-input" disabled>');
+            case 'date': return $('<input type="date" class="form-input" disabled>');
+            case 'textarea': return $('<textarea class="form-textarea" disabled></textarea>');
+            case 'select': return $('<select class="form-select" disabled><option>Option</option></select>');
+            case 'checkbox': return $('<input type="checkbox" disabled>');
+            case 'radio': return $('<input type="radio" disabled>');
+            case 'file': return $('<input type="file" disabled>');
+            default: return $('<input type="text" disabled>');
+        }
+    }
+
     function addField(type, field){
         field = field || {};
         const $li = $('<li class="field-item" data-type="'+type+'"></li>');
         $li.append('<div class="field-bar"><span class="drag-handle">&#9776;</span> <span class="field-type">'+type+'</span> <button type="button" class="btn btn-danger btn-sm removeField">X</button></div>');
+        const preview = $('<div class="field-preview"></div>');
+        preview.append('<label class="preview-label"></label>');
+        preview.append(createPreview(type));
+        $li.append(preview);
         const body = $('<div class="field-body"></div>');
         body.append('<div class="form-group"><label class="form-label">Label</label><input type="text" class="form-input field-label"></div>');
         body.append('<div class="form-group"><label class="form-label">Name</label><input type="text" class="form-input field-name"></div>');
@@ -28,11 +48,22 @@ $(function(){
             body.append('<div class="form-group field-options"><label class="form-label">Options (comma separated)</label><input type="text" class="form-input field-options-input"></div>');
         }
         $li.append(body);
+
         if(field.label) $li.find('.field-label').val(field.label);
         if(field.name) $li.find('.field-name').val(field.name);
         if(field.required) $li.find('.field-required').prop('checked', true);
         if(field.options) $li.find('.field-options-input').val(field.options);
+        $li.find('.preview-label').text(field.label || 'Label');
+
+        attachFieldEvents($li);
         $('#formFields').append($li);
+    }
+
+    function attachFieldEvents($li){
+        const preview = $li.find('.preview-label');
+        $li.find('.field-label').on('input', function(){
+            preview.text(this.value || 'Label');
+        });
     }
 
     $('.palette-item').draggable({ helper:'clone', revert:'invalid' });
@@ -54,6 +85,7 @@ $(function(){
         $('#formBuilderCard').hide();
         $('#formBuilderForm')[0].reset();
         $('#formFields').empty();
+        $('#fieldSettings').empty().hide();
     });
 
     $('#formsTable').on('click', '.editForm', function(){
@@ -101,12 +133,29 @@ $(function(){
             $('#formBuilderCard').hide();
             $('#formBuilderForm')[0].reset();
             $('#formFields').empty();
+            $('#fieldSettings').empty().hide();
             loadForms();
         });
     });
 
     $('#formFields').on('click','.removeField',function(){
-        $(this).closest('li').remove();
+        const li = $(this).closest('li');
+        if(li.hasClass('active')){
+            $('#fieldSettings').empty().hide();
+        }
+        li.remove();
+    });
+
+    let activeField = null;
+    $('#formFields').on('click', '.field-item', function(e){
+        if($(e.target).hasClass('removeField') || $(e.target).closest('.field-bar').length && $(e.target).hasClass('drag-handle')) return;
+        if(activeField){
+            activeField.removeClass('active');
+            activeField.append($('#fieldSettings').children().hide());
+        }
+        activeField = $(this);
+        activeField.addClass('active');
+        $('#fieldSettings').empty().append(activeField.find('.field-body').show()).show();
     });
 
     loadForms();

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -40,7 +40,10 @@
                     <div class="palette-item" data-type="radio" role="button" tabindex="0">Radio</div>
                     <div class="palette-item" data-type="file" role="button" tabindex="0">File</div>
                 </div>
-                <ul id="formFields" class="field-list" aria-label="Form fields"></ul>
+                <div id="formPreview" class="form-preview">
+                    <ul id="formFields" class="field-list" aria-label="Form fields"></ul>
+                </div>
+                <div id="fieldSettings" class="field-settings"></div>
             </div>
             <div class="form-actions">
                 <button type="submit" class="btn btn-primary">Save Form</button>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -598,6 +598,12 @@
         #fieldPalette {
             width: 200px;
         }
+        .form-preview {
+            flex: 1;
+        }
+        .field-settings {
+            width: 250px;
+        }
         .palette-item {
             background: #e2e8f0;
             margin-bottom: 10px;
@@ -620,11 +626,17 @@
             padding: 10px;
             margin-bottom: 10px;
         }
+        .field-item.active {
+            border-color: #667eea;
+        }
         .field-bar {
             display: flex;
             justify-content: space-between;
             align-items: center;
             margin-bottom: 10px;
+        }
+        .field-body {
+            display: none;
         }
 
         /* Modal */


### PR DESCRIPTION
## Summary
- add preview and settings panels to form builder view
- style new layout with preview and settings columns
- update form builder JavaScript to manage previews and settings panel

## Testing
- `php -l CMS/modules/forms/view.php`

------
https://chatgpt.com/codex/tasks/task_e_6875db2e6b548331bd2e2cb39b10a2cd