### PR TITLE
Update search to include blog posts

### DIFF
--- a/CMS/index.php
+++ b/CMS/index.php
@@ -21,6 +21,9 @@ if (file_exists($menusFile)) {
     $menus = json_decode(file_get_contents($menusFile), true) ?: [];
 }
 
+$blogFile = __DIR__ . '/data/blog_posts.json';
+$blogPosts = file_exists($blogFile) ? json_decode(file_get_contents($blogFile), true) : [];
+
 // Base paths used by theme templates
 $scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
 if (substr($scriptBase, -4) === '/CMS') {
@@ -59,6 +62,11 @@ if ($slug === 'search') {
         }
         if ($q === '' || stripos($p['title'], $lower) !== false || stripos($p['slug'], $lower) !== false || stripos($p['content'], $lower) !== false) {
             $results[] = $p;
+        }
+    }
+    foreach ($blogPosts as $b) {
+        if ($q === '' || stripos($b['title'], $lower) !== false || stripos($b['slug'], $lower) !== false || stripos($b['excerpt'], $lower) !== false || stripos($b['content'], $lower) !== false || stripos($b['tags'], $lower) !== false) {
+            $results[] = ['title' => $b['title'], 'slug' => $b['slug']];
         }
     }
     $content = '<div class="search-results"><h1>Search Results';

--- a/CMS/modules/search/view.php
+++ b/CMS/modules/search/view.php
@@ -5,6 +5,8 @@ require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
 $pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$postsFile = __DIR__ . '/../../data/blog_posts.json';
+$posts = file_exists($postsFile) ? json_decode(file_get_contents($postsFile), true) : [];
 
 $q = isset($_GET['q']) ? trim($_GET['q']) : '';
 $lower = strtolower($q);
@@ -12,7 +14,14 @@ $results = [];
 if ($lower !== '') {
     foreach ($pages as $p) {
         if (stripos($p['title'], $lower) !== false || stripos($p['slug'], $lower) !== false || stripos($p['content'], $lower) !== false) {
+            $p['type'] = 'Page';
             $results[] = $p;
+        }
+    }
+    foreach ($posts as $b) {
+        if (stripos($b['title'], $lower) !== false || stripos($b['slug'], $lower) !== false || stripos($b['excerpt'], $lower) !== false || stripos($b['content'], $lower) !== false || stripos($b['tags'], $lower) !== false) {
+            $b['type'] = 'Post';
+            $results[] = $b;
         }
     }
 }
@@ -24,25 +33,33 @@ if ($lower !== '') {
         </div>
         <table class="data-table">
             <thead>
-                <tr><th>Title</th><th>Slug</th><th>Status</th><th>Actions</th></tr>
+                <tr><th>Type</th><th>Title</th><th>Slug</th><th>Status</th><th>Actions</th></tr>
             </thead>
             <tbody>
                 <?php if ($results): ?>
                     <?php foreach ($results as $r): ?>
-                        <?php $viewUrl = '../?page=' . urlencode($r['slug']);
-                              if(isset($_SESSION['user'])) {
-                                  $viewUrl = '../liveed/builder.php?id=' . urlencode($r['id']);
-                              }
+                        <?php
+                            if(($r['type'] ?? '') === 'Post') {
+                                $viewUrl = '../' . urlencode($r['slug']);
+                                $status = ucfirst($r['status'] ?? 'draft');
+                            } else {
+                                $viewUrl = '../?page=' . urlencode($r['slug']);
+                                if(isset($_SESSION['user'])) {
+                                    $viewUrl = '../liveed/builder.php?id=' . urlencode($r['id']);
+                                }
+                                $status = !empty($r['published']) ? 'Published' : 'Draft';
+                            }
                         ?>
                         <tr data-id="<?php echo $r['id']; ?>">
+                            <td><?php echo htmlspecialchars($r['type'] ?? ''); ?></td>
                             <td><?php echo htmlspecialchars($r['title']); ?></td>
                             <td><?php echo htmlspecialchars($r['slug']); ?></td>
-                            <td><?php echo !empty($r['published']) ? 'Published' : 'Draft'; ?></td>
+                            <td><?php echo htmlspecialchars($status); ?></td>
                             <td><a class="btn btn-secondary" href="<?php echo $viewUrl; ?>" target="_blank">View</a></td>
                         </tr>
                     <?php endforeach; ?>
                 <?php else: ?>
-                    <tr><td colspan="4">No results found</td></tr>
+                    <tr><td colspan="5">No results found</td></tr>
                 <?php endif; ?>
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- extend backend search module to include blog posts
- include posts in frontend search results

## Testing
- `php -l CMS/modules/search/view.php`
- `php -l CMS/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6875dc70bc28833190ffbaaa65fe5607