### PR TITLE
Set logs as default admin module

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -47,7 +47,7 @@ if (file_exists($settingsFile)) {
             <nav class="sidebar-nav">
                 <div class="nav-section">
                     <div class="nav-section-title">Overview</div>
-                    <div class="nav-item active" data-section="dashboard">
+                    <div class="nav-item" data-section="dashboard">
                         <div class="nav-icon"><i class="fas fa-tachometer-alt"></i></div>
                         <div class="nav-text">Dashboard</div>
                     </div>
@@ -103,7 +103,7 @@ if (file_exists($settingsFile)) {
                         <div class="nav-icon"><i class="fas fa-chart-line"></i></div>
                         <div class="nav-text">Analytics</div>
                     </div>
-                    <div class="nav-item" data-section="logs">
+                    <div class="nav-item active" data-section="logs">
                         <div class="nav-icon"><i class="fas fa-clipboard-list"></i></div>
                         <div class="nav-text">Logs</div>
                     </div>
@@ -178,7 +178,7 @@ $(function(){
       }
     }
   });
-  loadModule("dashboard");
+  loadModule("logs");
 });
     </script>
 </div>


### PR DESCRIPTION
## Summary
- adjust sidebar active state to highlight Logs
- load logs module by default

## Testing
- `php -l CMS/admin.php`

------
https://chatgpt.com/codex/tasks/task_e_6875df145c208331b6bf692655d9adad