### PR TITLE
Limit undo history to 15 entries

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -393,7 +393,7 @@ document.addEventListener('DOMContentLoaded', () => {
     applyStoredSettings,
   });
 
-  const history = initUndoRedo({ canvas, onChange: scheduleSave });
+  const history = initUndoRedo({ canvas, onChange: scheduleSave, maxHistory: 15 });
   const undoBtn = palette.querySelector('.undo-btn');
   const redoBtn = palette.querySelector('.redo-btn');
   const historyBtn = palette.querySelector('.page-history-btn');

--- a/liveed/modules/undoRedo.js
+++ b/liveed/modules/undoRedo.js
@@ -3,6 +3,7 @@ export function initUndoRedo(options = {}) {
   const canvas = options.canvas;
   const restore = options.restore;
   const onChange = options.onChange;
+  const maxHistory = options.maxHistory || 15;
   if (!canvas) return;
   let history = [];
   let index = -1;
@@ -15,6 +16,9 @@ export function initUndoRedo(options = {}) {
     if (history[index] === html) return;
     history = history.slice(0, index + 1);
     history.push(html);
+    if (history.length > maxHistory) {
+      history.shift();
+    }
     index = history.length - 1;
     if (typeof onChange === 'function') onChange(html);
   };


### PR DESCRIPTION
## Summary
- limit history length in undo/redo module
- wire history limit into the builder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875e00d31688331952ef18463256b58