### PR TITLE
Auto-save media selections

### DIFF
--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -79,6 +79,10 @@ export function initSettings(options = {}) {
         setSetting(block, input.name, val);
         if (input.name === 'custom_src') suggestAltText(block);
         renderBlock(block);
+        // Automatically schedule a save whenever a setting changes so that
+        // media selections are persisted even if the user forgets to press
+        // the "Apply" button.
+        if (typeof savePageFn === 'function') savePageFn();
       }
     });
   }


### PR DESCRIPTION
## Summary
- trigger save routine when settings change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875e46be9808331a06f5d264aaaa76c