### PR TITLE
Remove a11y status

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -51,12 +51,6 @@
 .save-status.error {
   color: #e53e3e;
 }
-.a11y-status {
-  margin-left: 0;
-  font-size: 14px;
-  color: #e53e3e;
-  flex-basis: 100%;
-}
 .block-palette {
   width: 320px;
   background: rgba(12, 14, 20, 0.95);
@@ -131,8 +125,7 @@
 .block-palette.collapsed .palette-search,
 .block-palette.collapsed .builder-header .title,
 .block-palette.collapsed .manual-save-btn,
-.block-palette.collapsed #saveStatus,
-.block-palette.collapsed #a11yStatus {
+.block-palette.collapsed #saveStatus {
   display: none;
 }
 .history-toolbar {
@@ -1126,15 +1119,6 @@
   color: #64748b;
   font-size: 11px;
   margin-left: 8px;
-}
-.a11y-status {
-  background: rgba(239, 68, 68, 0.15);
-  color: #f87171;
-  font-size: 10px;
-  margin: 0 0 15px;
-  padding: 6px 6px;
-  border-radius: 4px;
-  font-weight: 600;
 }
 .preview-btn {
   padding: 8px 10px;

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -58,7 +58,6 @@ $builderHeader = '<header class="builder-header" title="Drag to reposition">'
     . '<div  class="title-top"><div class="title">Editing: ' . htmlspecialchars($page['title']) . '</div> '
     . '<button type="button" class="manual-save-btn btn btn-primary">Save</button></div>'
     . '<div id="saveStatus" class="save-status"></div>'
-    . '<div id="a11yStatus" class="a11y-status" title=""></div>'
     . $previewToolbar
     . '</header>';
 

--- a/liveed/modules/accessibility.js
+++ b/liveed/modules/accessibility.js
@@ -3,19 +3,6 @@ let canvas;
 
 export function initAccessibility(options = {}) {
   canvas = options.canvas;
-  if (!canvas) return;
-  const update = () => {
-    const { count, messages } = checkAccessibility();
-    const statusEl = document.getElementById('a11yStatus');
-    if (statusEl) {
-      statusEl.textContent = count
-        ? `${count} accessibility issue${count > 1 ? 's' : ''}`
-        : '';
-      statusEl.title = messages.join('\n');
-    }
-  };
-  update();
-  document.addEventListener('canvasUpdated', update);
 }
 
 export function checkAccessibility() {


### PR DESCRIPTION
## Summary
- drop the `a11yStatus` element from the builder UI
- delete related styles
- simplify accessibility initialization

## Testing
- `php -l liveed/builder.php`
- `node --check liveed/builder.js`
- `node --check liveed/modules/accessibility.js`


------
https://chatgpt.com/codex/tasks/task_e_6875e7c3f190833199356449430c6853