### PR TITLE
Improve responsive preview

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -1044,6 +1044,31 @@
   margin-bottom: 10px;
 }
 
+/* Preview iframe modal */
+#previewModal .modal-content.preview-frame {
+  max-width: 90%;
+  width: 90%;
+  height: 90vh;
+  padding: 0;
+}
+
+#previewModal iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+}
+
+#previewModal.tablet .modal-content.preview-frame {
+  width: 768px;
+  max-width: 100%;
+}
+
+#previewModal.phone .modal-content.preview-frame {
+  width: 375px;
+  max-width: 100%;
+}
+
 /* Grid overlay styles */
 .canvas.grid-overlay::before {
   content: '';

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -249,6 +249,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const settingsPanel = document.getElementById('settingsPanel');
   const previewContainer = document.querySelector('.canvas-container');
   const previewButtons = document.querySelectorAll('.preview-toolbar button');
+  const previewModal = document.getElementById('previewModal');
+  const previewFrame = document.getElementById('previewFrame');
+  const previewClose = document.getElementById('previewClose');
   const gridToggle = document.getElementById('gridToggle');
   const builderEl = document.querySelector('.builder');
   const viewToggle = document.getElementById('viewModeToggle');
@@ -366,8 +369,29 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function showIframePreview(size) {
+    if (!previewModal || !previewFrame) return;
+    previewModal.classList.add('active');
+    previewModal.classList.remove('desktop', 'tablet', 'phone');
+    previewModal.classList.add(size);
+    previewFrame.src = window.builderBase + '/liveed/preview.php?id=' + window.builderPageId;
+  }
+
+  if (previewClose) {
+    previewClose.addEventListener('click', () => {
+      previewModal.classList.remove('active', 'desktop', 'tablet', 'phone');
+      if (previewFrame) previewFrame.src = '';
+    });
+  }
+
   previewButtons.forEach((btn) => {
-    btn.addEventListener('click', () => updatePreview(btn.dataset.size));
+    btn.addEventListener('click', () => {
+      if (btn.dataset.size === 'tablet' || btn.dataset.size === 'phone') {
+        showIframePreview(btn.dataset.size);
+      } else {
+        updatePreview(btn.dataset.size);
+      }
+    });
   });
 
   updatePreview('desktop');

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -95,10 +95,16 @@ $mediaPickerHtml = '<div id="mediaPickerModal" class="modal">'
     . '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.css">'
     . '<script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>';
 
+$previewModal = '<div id="previewModal" class="modal">'
+    . '<div class="modal-content preview-frame">'
+    . '<iframe id="previewFrame" src="" loading="lazy"></iframe>'
+    . '<div class="modal-footer"><button type="button" class="btn btn-secondary" id="previewClose">Close</button></div>'
+    . '</div></div>';
+
 $builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><span class="title">Settings</span><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div>'
     . '<div id="historyPanel" class="history-panel"><div class="history-header"><span class="title">Page History</span><button type="button" class="close-btn">&times;</button></div><div class="history-content"></div></div>'
-    . $mediaPickerHtml . '</div>'
-    . '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';</script>'
+    . $mediaPickerHtml . $previewModal . '</div>'
+    . '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';window.builderPageSlug = ' . json_encode($page['slug']) . ';</script>'
     . '<script type="module" src="' . $scriptBase . '/liveed/builder.js"></script>';
 
 $themeHtml = preg_replace('/<body([^>]*)>/', '<body$1>' . $builderStart, $themeHtml, 1);

--- a/liveed/preview.php
+++ b/liveed/preview.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/../CMS/includes/auth.php';
+require_login();
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+$pagesFile = __DIR__ . '/../CMS/data/pages.json';
+$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$page = null;
+foreach ($pages as $p) {
+    if ((int)$p['id'] === $id) { $page = $p; break; }
+}
+if (!$page) {
+    http_response_code(404);
+    echo 'Page not found';
+    exit;
+}
+
+$settingsFile = __DIR__ . '/../CMS/data/settings.json';
+$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
+$menusFile = __DIR__ . '/../CMS/data/menus.json';
+$menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
+
+$scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+if (substr($scriptBase, -7) === '/liveed') {
+    $scriptBase = substr($scriptBase, 0, -7);
+}
+$themeBase = $scriptBase . '/theme';
+
+$template = !empty($page['template']) ? $page['template'] : 'page.php';
+$templateFile = realpath(__DIR__ . '/../theme/templates/pages/' . $template);
+if (!$templateFile || !file_exists($templateFile)) {
+    http_response_code(500);
+    echo 'Template not found';
+    exit;
+}
+
+ob_start();
+include $templateFile;
+$html = ob_get_clean();
+$html = preg_replace('/<div class="drop-area"><\\/div>/', $page['content'], $html);
+$html = preg_replace('#<templateSetting[^>]*>.*?</templateSetting>#si', '', $html);
+$html = preg_replace('#<div class="block-controls"[^>]*>.*?</div>#si', '', $html);
+$html = str_replace('draggable="true"', '', $html);
+$html = preg_replace('#\sdata-ts="[^"]*"#i', '', $html);
+
+$headInject = "<link rel=\"stylesheet\" href=\"{$scriptBase}/theme/css/root.css\">" .
+    "<link rel=\"stylesheet\" href=\"{$scriptBase}/theme/css/combined.css\">" .
+    "<link rel=\"stylesheet\" href=\"{$scriptBase}/theme/css/override.css\">";
+$html = preg_replace('/<head>/', '<head>' . $headInject, $html, 1);
+
+echo $html;


### PR DESCRIPTION
## Summary
- add server-side preview endpoint
- show page preview in an iframe for phone/tablet buttons
- style iframe modal

## Testing
- `php -l liveed/preview.php`
- `php -l liveed/builder.php`
- `node -c liveed/builder.js`

------
https://chatgpt.com/codex/tasks/task_e_6875e735f79083318c98aab1ad696086