### PR TITLE
Enable device preview in builder

### DIFF
--- a/CMS/index.php
+++ b/CMS/index.php
@@ -53,6 +53,7 @@ function render_theme_page($templateFile, $page, $scriptBase) {
 $slug = isset($_GET['page']) ? $_GET['page'] : ($settings['homepage'] ?? 'home');
 
 $logged_in = is_logged_in();
+$preview_mode = isset($_GET['preview']) && $logged_in;
 
 if ($slug === 'search') {
     $q = isset($_GET['q']) ? trim($_GET['q']) : '';
@@ -154,10 +155,14 @@ if ($pageIndex !== null) {
 }
 
 // If logged in show the page builder instead of the static page
-if ($logged_in) {
+if ($logged_in && !$preview_mode) {
     $_GET['id'] = $page['id'];
     require __DIR__ . '/../liveed/builder.php';
     return;
+}
+
+if ($preview_mode) {
+    $logged_in = false;
 }
 
 $templateFile = null;
@@ -167,7 +172,7 @@ if (!empty($page['template'])) {
         $templateFile = $candidate;
     }
 }
-if ($templateFile && !$logged_in) {
+if ($templateFile && (!$logged_in || $preview_mode)) {
     render_theme_page($templateFile, $page, $scriptBase);
     return;
 }

--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -1037,6 +1037,27 @@
   margin-bottom: 10px;
 }
 
+#previewModal .modal-content.preview-frame {
+  max-width: 100%;
+  width: auto;
+  padding: 0;
+  background: none;
+}
+
+#previewModal .frame-wrapper {
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  margin: auto;
+}
+
+#previewModal iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  display: block;
+}
+
 
 
 /* View mode */

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -236,6 +236,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const settingsPanel = document.getElementById('settingsPanel');
   const previewContainer = document.querySelector('.canvas-container');
   const previewButtons = document.querySelectorAll('.preview-toolbar button');
+  const previewModal = document.getElementById('previewModal');
+  const previewFrame = document.getElementById('previewFrame');
+  const closePreview = document.getElementById('closePreview');
+  const previewWrapper = previewModal
+    ? previewModal.querySelector('.frame-wrapper')
+    : null;
   const builderEl = document.querySelector('.builder');
   const viewToggle = document.getElementById('viewModeToggle');
   const toggleBtn = palette.querySelector('.palette-toggle-btn');
@@ -330,15 +336,50 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function updatePreview(size) {
     if (!previewContainer) return;
-    previewContainer.classList.remove('preview-desktop', 'preview-tablet', 'preview-phone');
-    previewContainer.classList.add('preview-' + size);
+    previewContainer.classList.remove(
+      'preview-desktop',
+      'preview-tablet',
+      'preview-phone'
+    );
+    if (size === 'desktop') {
+      previewContainer.classList.add('preview-desktop');
+    }
     previewButtons.forEach((btn) => {
       btn.classList.toggle('active', btn.dataset.size === size);
     });
   }
 
+  function openPreview(size) {
+    if (!previewModal || !previewFrame) return;
+    if (previewWrapper) {
+      if (size === 'tablet') previewWrapper.style.width = '768px';
+      else if (size === 'phone') previewWrapper.style.width = '375px';
+      else previewWrapper.style.width = '100%';
+      previewWrapper.style.height = '90vh';
+    }
+    previewFrame.src =
+      window.builderBase + '/' + window.builderSlug + '?preview=1';
+    previewModal.classList.add('active');
+    updatePreview(size);
+  }
+
+  if (closePreview) {
+    closePreview.addEventListener('click', () => {
+      previewModal.classList.remove('active');
+      previewFrame.src = '';
+      updatePreview('desktop');
+    });
+  }
+
   previewButtons.forEach((btn) => {
-    btn.addEventListener('click', () => updatePreview(btn.dataset.size));
+    btn.addEventListener('click', () => {
+      const size = btn.dataset.size;
+      if (size === 'desktop') {
+        updatePreview('desktop');
+      } else {
+        openPreview(size);
+      }
+    });
   });
 
   updatePreview('desktop');

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -93,10 +93,16 @@ $mediaPickerHtml = '<div id="mediaPickerModal" class="modal">'
     . '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.css">'
     . '<script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>';
 
+$previewModalHtml = '<div id="previewModal" class="modal">'
+    . '<div class="modal-content preview-frame">'
+    . '<div class="frame-wrapper"><iframe id="previewFrame" src=""></iframe></div>'
+    . '<div class="modal-footer"><button type="button" class="btn btn-secondary" id="closePreview">Close</button></div>'
+    . '</div></div>';
+
 $builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><span class="title">Settings</span><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div>'
     . '<div id="historyPanel" class="history-panel"><div class="history-header"><span class="title">Page History</span><button type="button" class="close-btn">&times;</button></div><div class="history-content"></div></div>'
-    . $mediaPickerHtml . '</div>'
-    . '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';</script>'
+    . $mediaPickerHtml . $previewModalHtml . '</div>'
+    . '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';window.builderSlug = ' . json_encode($page['slug']) . ';</script>'
     . '<script type="module" src="' . $scriptBase . '/liveed/builder.js"></script>';
 
 $themeHtml = preg_replace('/<body([^>]*)>/', '<body$1>' . $builderStart, $themeHtml, 1);


### PR DESCRIPTION
## Summary
- add preview modal in builder for responsive device sizes
- support `?preview=1` parameter to bypass builder and show public view
- style preview iframe
- open preview modal when Tablet or Phone buttons clicked

## Testing
- `php -l liveed/builder.php`
- `php -l CMS/index.php`
- `node --check liveed/builder.js`


------
https://chatgpt.com/codex/tasks/task_e_6875e9d4aeb88331b072b0dbd70309ba