### PR TITLE
Implement block template caching

### DIFF
--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -2,6 +2,24 @@
 import { ensureBlockState } from './state.js';
 import { executeScripts } from "./executeScripts.js";
 
+const templateCache = new Map();
+
+function loadTemplate(file) {
+  if (templateCache.has(file)) {
+    return templateCache.get(file);
+  }
+  const p = fetch(
+    basePath + '/liveed/load-block.php?file=' + encodeURIComponent(file)
+  )
+    .then((r) => r.text())
+    .then((html) => {
+      templateCache.set(file, Promise.resolve(html));
+      return html;
+    });
+  templateCache.set(file, p);
+  return p;
+}
+
 let palette;
 let canvas;
 let basePath = '';
@@ -184,9 +202,7 @@ function handleDrop(e) {
   if (fromPalette && dragSource) {
     const file = dragSource.dataset.file;
     if (file) {
-      fetch(basePath + '/liveed/load-block.php?file=' + encodeURIComponent(file))
-        .then((r) => r.text())
-        .then((html) => {
+      loadTemplate(file).then((html) => {
           const wrapper = document.createElement('div');
           wrapper.className = 'block-wrapper';
           wrapper.dataset.template = file;


### PR DESCRIPTION
## Summary
- cache loaded block templates on the client side
- use cached templates when dropping blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876617bb4b88331a9811208bec86cde