### PR TITLE
Reduce JSON file I/O with cached loader

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -1,19 +1,14 @@
 <?php
 // File: admin.php
 require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/data/pages.json';
-$pages = [];
-if (file_exists($pagesFile)) {
-    $pages = json_decode(file_get_contents($pagesFile), true) ?: [];
-}
+$pages = get_cached_json($pagesFile);
 
 $settingsFile = __DIR__ . '/data/settings.json';
-$settings = [];
-if (file_exists($settingsFile)) {
-    $settings = json_decode(file_get_contents($settingsFile), true) ?: [];
-}
+$settings = get_cached_json($settingsFile);
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/CMS/includes/data.php
+++ b/CMS/includes/data.php
@@ -1,0 +1,23 @@
+<?php
+// File: data.php
+// Utility functions for loading JSON data with simple in-memory caching
+
+/**
+ * Load and decode a JSON file while caching the result within the request.
+ *
+ * @param string $file Path to the JSON file
+ * @return array Decoded JSON data or empty array on failure
+ */
+function get_cached_json($file) {
+    static $cache = [];
+    if (!isset($cache[$file])) {
+        if (file_exists($file)) {
+            $data = json_decode(file_get_contents($file), true);
+            $cache[$file] = $data ?: [];
+        } else {
+            $cache[$file] = [];
+        }
+    }
+    return $cache[$file];
+}
+?>

--- a/CMS/index.php
+++ b/CMS/index.php
@@ -1,30 +1,21 @@
 <?php
 // File: index.php
 require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/data.php';
 // Load pages from JSON
 $pagesFile = __DIR__ . '/data/pages.json';
-$pages = [];
-if (file_exists($pagesFile)) {
-    $json = file_get_contents($pagesFile);
-    $pages = json_decode($json, true) ?: [];
-}
+$pages = get_cached_json($pagesFile);
 
 $settingsFile = __DIR__ . '/data/settings.json';
-$settings = [];
-if (file_exists($settingsFile)) {
-    $settings = json_decode(file_get_contents($settingsFile), true) ?: [];
-}
+$settings = get_cached_json($settingsFile);
 
 $menusFile = __DIR__ . '/data/menus.json';
-$menus = [];
-if (file_exists($menusFile)) {
-    $menus = json_decode(file_get_contents($menusFile), true) ?: [];
-}
+$menus = get_cached_json($menusFile);
 
 $blogFile = __DIR__ . '/data/blog_posts.json';
-$blogPosts = file_exists($blogFile) ? json_decode(file_get_contents($blogFile), true) : [];
+$blogPosts = get_cached_json($blogFile);
 $mediaFile = __DIR__ . '/data/media.json';
-$mediaItems = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$mediaItems = get_cached_json($mediaFile);
 
 // Base paths used by theme templates
 $scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');


### PR DESCRIPTION
## Summary
- create `CMS/includes/data.php` with `get_cached_json()`
- use cached loading for settings, pages, menus and other data in admin and front-end index

## Testing
- `php -l CMS/includes/data.php`
- `php -l CMS/admin.php`
- `php -l CMS/index.php`
- `find CMS/modules -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68766197033c8331b92aee73e508515c