### PR TITLE
Improve input sanitation across CMS

### DIFF
--- a/CMS/includes/sanitize.php
+++ b/CMS/includes/sanitize.php
@@ -1,0 +1,16 @@
+<?php
+// Simple sanitization helpers
+// Returns a trimmed string with tags stripped
+function sanitize_text(string $str): string {
+    return trim(strip_tags($str));
+}
+// Sanitizes url
+function sanitize_url(string $url): string {
+    return filter_var(trim($url), FILTER_SANITIZE_URL) ?: '';
+}
+// Sanitizes an array of tags by running sanitize_text on each
+function sanitize_tags($tags) {
+    if (!is_array($tags)) return [];
+    return array_values(array_filter(array_map('sanitize_text', $tags)));
+}
+?>

--- a/CMS/index.php
+++ b/CMS/index.php
@@ -2,6 +2,7 @@
 // File: index.php
 require_once __DIR__ . '/includes/auth.php';
 require_once __DIR__ . '/includes/data.php';
+require_once __DIR__ . '/includes/sanitize.php';
 // Load pages from JSON
 $pagesFile = __DIR__ . '/data/pages.json';
 $pages = get_cached_json($pagesFile);
@@ -42,13 +43,13 @@ function render_theme_page($templateFile, $page, $scriptBase) {
 }
 
 // Determine page slug
-$slug = isset($_GET['page']) ? $_GET['page'] : ($settings['homepage'] ?? 'home');
+$slug = isset($_GET['page']) ? sanitize_text($_GET['page']) : ($settings['homepage'] ?? 'home');
 
 $logged_in = is_logged_in();
 $preview_mode = isset($_GET['preview']) && $logged_in;
 
 if ($slug === 'search') {
-    $q = isset($_GET['q']) ? trim($_GET['q']) : '';
+    $q = isset($_GET['q']) ? sanitize_text($_GET['q']) : '';
     $results = [];
     $lower = strtolower($q);
     foreach ($pages as $p) {

--- a/CMS/login.php
+++ b/CMS/login.php
@@ -1,6 +1,7 @@
 <?php
 // File: login.php
 require_once __DIR__ . '/includes/auth.php';
+require_once __DIR__ . '/includes/sanitize.php';
 
 $settingsFile = __DIR__ . '/data/settings.json';
 $settings = [];
@@ -10,7 +11,7 @@ if (file_exists($settingsFile)) {
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-$username = trim($_POST['username'] ?? '');
+$username = sanitize_text($_POST['username'] ?? '');
 $password = $_POST['password'] ?? '';
 $user = find_user($username);
     if ($user && password_verify($password, $user['password'])) {

--- a/CMS/modules/forms/delete_form.php
+++ b/CMS/modules/forms/delete_form.php
@@ -1,12 +1,13 @@
 <?php
 // File: delete_form.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $formsFile = __DIR__ . '/../../data/forms.json';
 $forms = file_exists($formsFile) ? json_decode(file_get_contents($formsFile), true) : [];
 
-$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $forms = array_values(array_filter($forms, function($f) use ($id) {
     return $f['id'] != $id;
 }));

--- a/CMS/modules/forms/save_form.php
+++ b/CMS/modules/forms/save_form.php
@@ -1,14 +1,27 @@
 <?php
 // File: save_form.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $formsFile = __DIR__ . '/../../data/forms.json';
 $forms = file_exists($formsFile) ? json_decode(file_get_contents($formsFile), true) : [];
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
-$name = trim($_POST['name'] ?? '');
-$fields = isset($_POST['fields']) ? json_decode($_POST['fields'], true) : [];
+$name = sanitize_text($_POST['name'] ?? '');
+$fieldsData = isset($_POST['fields']) ? json_decode($_POST['fields'], true) : [];
+$fields = [];
+foreach ($fieldsData as $field) {
+    if (!is_array($field)) continue;
+    $item = [
+        'type' => sanitize_text($field['type'] ?? 'text'),
+        'label' => sanitize_text($field['label'] ?? ''),
+        'name' => sanitize_text($field['name'] ?? '')
+    ];
+    if (isset($field['required'])) $item['required'] = !empty($field['required']);
+    if (isset($field['options'])) $item['options'] = sanitize_text($field['options']);
+    $fields[] = $item;
+}
 
 if ($name === '') {
     http_response_code(400);

--- a/CMS/modules/media/create_folder.php
+++ b/CMS/modules/media/create_folder.php
@@ -1,9 +1,10 @@
 <?php
 // File: create_folder.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
-$folder = trim($_POST['folder'] ?? '');
+$folder = sanitize_text($_POST['folder'] ?? '');
 if ($folder === '') {
     echo json_encode(['status' => 'error', 'message' => 'Folder name required']);
     exit;

--- a/CMS/modules/media/crop_media.php
+++ b/CMS/modules/media/crop_media.php
@@ -1,15 +1,16 @@
 <?php
 // File: crop_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
 
-$id = $_POST['id'] ?? '';
+$id = sanitize_text($_POST['id'] ?? '');
 $imageData = $_POST['image'] ?? '';
 $newVersion = isset($_POST['new_version']) && $_POST['new_version'] == '1';
-$format = $_POST['format'] ?? 'jpeg';
+$format = sanitize_text($_POST['format'] ?? 'jpeg');
 
 if ($id === '' || strpos($imageData, 'data:image') !== 0) {
     echo json_encode(['status' => 'error']);

--- a/CMS/modules/media/delete_folder.php
+++ b/CMS/modules/media/delete_folder.php
@@ -1,9 +1,10 @@
 <?php
 // File: delete_folder.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
-$folder = trim($_POST['folder'] ?? '');
+$folder = sanitize_text($_POST['folder'] ?? '');
 if ($folder === '') {
     echo json_encode(['status' => 'error', 'message' => 'Invalid folder']);
     exit;

--- a/CMS/modules/media/delete_media.php
+++ b/CMS/modules/media/delete_media.php
@@ -1,11 +1,12 @@
 <?php
 // File: delete_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
-$id = $_POST['id'] ?? '';
+$id = sanitize_text($_POST['id'] ?? '');
 if ($id === '') {
     echo json_encode(['status' => 'error']);
     exit;

--- a/CMS/modules/media/list_media.php
+++ b/CMS/modules/media/list_media.php
@@ -1,12 +1,13 @@
 <?php
 // File: list_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
-$query = strtolower($_GET['q'] ?? '');
-$folder = $_GET['folder'] ?? '';
+$query = strtolower(sanitize_text($_GET['q'] ?? ''));
+$folder = sanitize_text($_GET['folder'] ?? '');
 
 usort($media, function($a,$b){
     return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);

--- a/CMS/modules/media/picker.php
+++ b/CMS/modules/media/picker.php
@@ -1,9 +1,10 @@
 <?php
 // File: picker.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
-$base = rtrim($_GET['base'] ?? '', '/');
+$base = rtrim(sanitize_text($_GET['base'] ?? ''), '/');
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
 ?>

--- a/CMS/modules/media/rename_folder.php
+++ b/CMS/modules/media/rename_folder.php
@@ -1,10 +1,11 @@
 <?php
 // File: rename_folder.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
-$old = trim($_POST['old'] ?? '');
-$new = trim($_POST['new'] ?? '');
+$old = sanitize_text($_POST['old'] ?? '');
+$new = sanitize_text($_POST['new'] ?? '');
 if ($old === '' || $new === '') {
     echo json_encode(['status' => 'error', 'message' => 'Invalid folder']);
     exit;

--- a/CMS/modules/media/rename_media.php
+++ b/CMS/modules/media/rename_media.php
@@ -1,13 +1,14 @@
 <?php
 // File: rename_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
 
-$id = $_POST['id'] ?? '';
-$newName = trim($_POST['name'] ?? '');
+$id = sanitize_text($_POST['id'] ?? '');
+$newName = sanitize_text($_POST['name'] ?? '');
 if ($id === '' || $newName === '') {
     echo json_encode(['status' => 'error', 'message' => 'Invalid request']);
     exit;

--- a/CMS/modules/media/update_order.php
+++ b/CMS/modules/media/update_order.php
@@ -1,12 +1,14 @@
 <?php
 // File: update_order.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
 
 $order = json_decode($_POST['order'] ?? '[]', true);
+if (!is_array($order)) $order = [];
 $index = array_flip($order);
 foreach ($media as &$item) {
     if (isset($index[$item['id']])) {

--- a/CMS/modules/media/update_tags.php
+++ b/CMS/modules/media/update_tags.php
@@ -1,13 +1,14 @@
 <?php
 // File: update_tags.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
 
-$id = $_POST['id'] ?? '';
-$tags = array_filter(array_map('trim', explode(',', $_POST['tags'] ?? '')));
+$id = sanitize_text($_POST['id'] ?? '');
+$tags = sanitize_tags(explode(',', $_POST['tags'] ?? ''));
 
 foreach ($media as &$item) {
     if ($item['id'] === $id) {

--- a/CMS/modules/media/upload_media.php
+++ b/CMS/modules/media/upload_media.php
@@ -1,6 +1,7 @@
 <?php
 // File: upload_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $allowed = [
@@ -10,8 +11,8 @@ $allowed = [
 ];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $folder = trim($_POST['folder'] ?? '');
-    $tags = array_filter(array_map('trim', explode(',', $_POST['tags'] ?? '')));
+    $folder = sanitize_text($_POST['folder'] ?? '');
+    $tags = sanitize_tags(explode(',', $_POST['tags'] ?? ''));
     $root = dirname(__DIR__, 2);
     $baseDir = $root . '/uploads';
     if ($folder) {

--- a/CMS/modules/menus/delete_menu.php
+++ b/CMS/modules/menus/delete_menu.php
@@ -1,11 +1,12 @@
 <?php
 // File: delete_menu.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $menusFile = __DIR__ . '/../../data/menus.json';
 $menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
-$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $menus = array_filter($menus, function($m) use ($id) { return $m['id'] != $id; });
 file_put_contents($menusFile, json_encode(array_values($menus), JSON_PRETTY_PRINT));
 echo 'OK';

--- a/CMS/modules/menus/save_menu.php
+++ b/CMS/modules/menus/save_menu.php
@@ -1,6 +1,7 @@
 <?php
 // File: save_menu.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $menusFile = __DIR__ . '/../../data/menus.json';
@@ -10,7 +11,7 @@ $pagesFile = __DIR__ . '/../../data/pages.json';
 $pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
-$name = trim($_POST['name'] ?? '');
+$name = sanitize_text($_POST['name'] ?? '');
 $itemsData = isset($_POST['items']) ? json_decode($_POST['items'], true) : [];
 
 $items = process_items($itemsData, $pages);
@@ -19,8 +20,8 @@ function process_items($itemsData, $pages){
     $items = [];
     if(!is_array($itemsData)) return $items;
     foreach ($itemsData as $it) {
-        $label = trim($it['label'] ?? '');
-        $type = $it['type'] ?? 'custom';
+        $label = sanitize_text($it['label'] ?? '');
+        $type = sanitize_text($it['type'] ?? 'custom');
         $newTab = !empty($it['new_tab']);
         if ($type === 'page') {
             $pageId = (int)($it['page'] ?? 0);
@@ -37,7 +38,7 @@ function process_items($itemsData, $pages){
                 'new_tab' => $newTab
             ];
         } else {
-            $link = trim($it['link'] ?? '');
+            $link = sanitize_url($it['link'] ?? '');
             if ($link === '') continue;
             $item = [
                 'label' => $label !== '' ? $label : $link,

--- a/CMS/modules/pages/delete_page.php
+++ b/CMS/modules/pages/delete_page.php
@@ -1,13 +1,14 @@
 <?php
 // File: delete_page.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 $pagesFile = __DIR__ . '/../../data/pages.json';
 if (!file_exists($pagesFile)) {
     exit('No pages');
 }
 $pages = json_decode(file_get_contents($pagesFile), true) ?: [];
-$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $deletedPage = null;
 foreach ($pages as $p) {
     if ($p['id'] == $id) { $deletedPage = $p; break; }

--- a/CMS/modules/pages/save_page.php
+++ b/CMS/modules/pages/save_page.php
@@ -1,6 +1,7 @@
 <?php
 // File: save_page.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 $pagesFile = __DIR__ . '/../../data/pages.json';
 $pages = [];
 if (file_exists($pagesFile)) {
@@ -8,8 +9,8 @@ if (file_exists($pagesFile)) {
 }
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
-$title = trim($_POST['title'] ?? '');
-$slug = trim($_POST['slug'] ?? '');
+$title = sanitize_text($_POST['title'] ?? '');
+$slug = sanitize_text($_POST['slug'] ?? '');
 
 function slugify($text){
     $text = strtolower(trim($text));
@@ -23,17 +24,19 @@ if ($slug === '') {
 }
 $slug = slugify($slug);
 $content = trim($_POST['content'] ?? '');
+// strip script tags to avoid XSS in stored content
+$content = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $content);
 $published = isset($_POST['published']) ? (bool)$_POST['published'] : false;
-$template = trim($_POST['template'] ?? '');
+$template = sanitize_text($_POST['template'] ?? '');
 if ($template === '') {
     $template = 'page.php';
 }
-$meta_title = trim($_POST['meta_title'] ?? '');
-$meta_description = trim($_POST['meta_description'] ?? '');
-$og_title = trim($_POST['og_title'] ?? '');
-$og_description = trim($_POST['og_description'] ?? '');
-$og_image = trim($_POST['og_image'] ?? '');
-$access = trim($_POST['access'] ?? 'public');
+$meta_title = sanitize_text($_POST['meta_title'] ?? '');
+$meta_description = sanitize_text($_POST['meta_description'] ?? '');
+$og_title = sanitize_text($_POST['og_title'] ?? '');
+$og_description = sanitize_text($_POST['og_description'] ?? '');
+$og_image = sanitize_url($_POST['og_image'] ?? '');
+$access = sanitize_text($_POST['access'] ?? 'public');
 
 if ($title === '') {
     http_response_code(400);

--- a/CMS/modules/pages/set_home.php
+++ b/CMS/modules/pages/set_home.php
@@ -1,9 +1,10 @@
 <?php
 // File: set_home.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
-$slug = trim($_POST['slug'] ?? '');
+$slug = sanitize_text($_POST['slug'] ?? '');
 if ($slug === '') {
     http_response_code(400);
     echo 'Missing slug';

--- a/CMS/modules/settings/save_settings.php
+++ b/CMS/modules/settings/save_settings.php
@@ -1,14 +1,15 @@
 <?php
 // File: save_settings.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $settingsFile = __DIR__ . '/../../data/settings.json';
 $settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
 
-$settings['site_name'] = trim($_POST['site_name'] ?? ($settings['site_name'] ?? ''));
-$settings['tagline'] = trim($_POST['tagline'] ?? ($settings['tagline'] ?? ''));
-$settings['admin_email'] = trim($_POST['admin_email'] ?? ($settings['admin_email'] ?? ''));
+$settings['site_name'] = sanitize_text($_POST['site_name'] ?? ($settings['site_name'] ?? ''));
+$settings['tagline'] = sanitize_text($_POST['tagline'] ?? ($settings['tagline'] ?? ''));
+$settings['admin_email'] = sanitize_text($_POST['admin_email'] ?? ($settings['admin_email'] ?? ''));
 
 $uploadDir = __DIR__ . '/../../uploads';
 if (!is_dir($uploadDir)) {

--- a/CMS/modules/users/delete_user.php
+++ b/CMS/modules/users/delete_user.php
@@ -1,11 +1,12 @@
 <?php
 // File: delete_user.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
 $users = file_exists($usersFile) ? json_decode(file_get_contents($usersFile), true) : [];
-$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $users = array_filter($users, function($u) use ($id) { return $u['id'] != $id; });
 file_put_contents($usersFile, json_encode(array_values($users), JSON_PRETTY_PRINT));
 echo 'OK';

--- a/CMS/modules/users/save_user.php
+++ b/CMS/modules/users/save_user.php
@@ -1,16 +1,25 @@
 <?php
 // File: save_user.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
 $users = file_exists($usersFile) ? json_decode(file_get_contents($usersFile), true) : [];
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
-$username = trim($_POST['username'] ?? '');
-$password = $_POST['password'] ?? '';
-$role = trim($_POST['role'] ?? 'editor');
-$status = trim($_POST['status'] ?? 'active');
+$username = sanitize_text($_POST['username'] ?? '');
+$password = trim($_POST['password'] ?? '');
+$role = sanitize_text($_POST['role'] ?? 'editor');
+$status = sanitize_text($_POST['status'] ?? 'active');
+$allowedRoles = ['admin', 'editor'];
+if (!in_array($role, $allowedRoles, true)) {
+    $role = 'editor';
+}
+$allowedStatus = ['active', 'inactive'];
+if (!in_array($status, $allowedStatus, true)) {
+    $status = 'active';
+}
 
 if ($username === '') {
     http_response_code(400);


### PR DESCRIPTION
## Summary
- add shared sanitization helpers
- sanitize inputs in login and admin handlers
- filter script tags from page content
- validate menu and media fields

## Testing
- `php -l CMS/index.php`
- `for f in CMS/modules/pages/save_page.php CMS/modules/forms/save_form.php CMS/modules/forms/delete_form.php CMS/modules/menus/save_menu.php CMS/modules/menus/delete_menu.php CMS/modules/users/save_user.php CMS/modules/users/delete_user.php CMS/modules/media/update_tags.php CMS/modules/media/update_order.php CMS/modules/media/upload_media.php CMS/modules/media/rename_media.php CMS/modules/media/crop_media.php CMS/modules/media/delete_media.php CMS/modules/media/create_folder.php CMS/modules/media/rename_folder.php CMS/modules/media/delete_folder.php CMS/modules/settings/save_settings.php CMS/modules/pages/set_home.php CMS/modules/pages/delete_page.php CMS/login.php; do php -l $f; done`

------
https://chatgpt.com/codex/tasks/task_e_68766274242c8331aa446604ac314633