### PR TITLE
Add informative error pages

### DIFF
--- a/403.php
+++ b/403.php
@@ -10,7 +10,15 @@ if (substr($scriptBase, -4) === '/CMS') {
     $scriptBase = substr($scriptBase, 0, -4);
 }
 $scriptBase = rtrim($scriptBase, '/');
-$page = ['title' => 'Restricted', 'content' => '<h1>Restricted</h1>'];
+$page = [
+    'title' => 'Restricted',
+    'content' =>
+        '<h1>Restricted</h1>' .
+        '<p>You do not have permission to view this page.</p>' .
+        '<p><a href="' . htmlspecialchars($scriptBase) . '/">Return to homepage</a>' .
+        ' or <a href="' . htmlspecialchars($scriptBase) . '/CMS/login.php">log in</a> ' .
+        'with an account that has access.</p>'
+];
 $themeBase = $scriptBase . '/theme';
 $templateFile = __DIR__ . '/theme/templates/pages/errors/403.php';
 ob_start();

--- a/404.php
+++ b/404.php
@@ -10,7 +10,14 @@ if (substr($scriptBase, -4) === '/CMS') {
     $scriptBase = substr($scriptBase, 0, -4);
 }
 $scriptBase = rtrim($scriptBase, '/');
-$page = ['title' => 'Page Not Found', 'content' => '<h1>Page Not Found</h1>'];
+$page = [
+    'title' => 'Page Not Found',
+    'content' =>
+        '<h1>Page Not Found</h1>' .
+        '<p>The page you are looking for might have been moved or deleted.</p>' .
+        '<p><a href="' . htmlspecialchars($scriptBase) . '/">Return to homepage</a>' .
+        ' or use the site search to find what you are looking for.</p>'
+];
 $themeBase = $scriptBase . '/theme';
 $templateFile = __DIR__ . '/theme/templates/pages/errors/404.php';
 ob_start();

--- a/CMS/index.php
+++ b/CMS/index.php
@@ -105,7 +105,14 @@ foreach ($pages as $i => $p) {
 
 if (!$page) {
     http_response_code(404);
-    $page = ['title' => 'Page Not Found', 'content' => '<h1>Page Not Found</h1>'];
+    $page = [
+        'title' => 'Page Not Found',
+        'content' =>
+            '<h1>Page Not Found</h1>' .
+            '<p>The page you are looking for might have been moved or deleted.</p>' .
+            '<p><a href="' . htmlspecialchars($scriptBase) . '/">Return to homepage</a>' .
+            ' or use the site search to find what you are looking for.</p>'
+    ];
     $templateFile = realpath(__DIR__ . '/../theme/templates/pages/errors/404.php');
     if ($templateFile && file_exists($templateFile)) {
         render_theme_page($templateFile, $page, $scriptBase);
@@ -117,7 +124,14 @@ if (!$page) {
 
 if (empty($page['published']) && !$logged_in) {
     http_response_code(404);
-    $page = ['title' => 'Page Not Found', 'content' => '<h1>Page Not Found</h1>'];
+    $page = [
+        'title' => 'Page Not Found',
+        'content' =>
+            '<h1>Page Not Found</h1>' .
+            '<p>The page you are looking for might have been moved or deleted.</p>' .
+            '<p><a href="' . htmlspecialchars($scriptBase) . '/">Return to homepage</a>' .
+            ' or use the site search to find what you are looking for.</p>'
+    ];
     $templateFile = realpath(__DIR__ . '/../theme/templates/pages/errors/404.php');
     if ($templateFile && file_exists($templateFile)) {
         render_theme_page($templateFile, $page, $scriptBase);
@@ -129,7 +143,15 @@ if (empty($page['published']) && !$logged_in) {
 
 if (($page['access'] ?? 'public') !== 'public' && !$logged_in) {
     http_response_code(403);
-    $page = ['title' => 'Restricted', 'content' => '<h1>Restricted</h1>'];
+    $page = [
+        'title' => 'Restricted',
+        'content' =>
+            '<h1>Restricted</h1>' .
+            '<p>You do not have permission to view this page.</p>' .
+            '<p><a href="' . htmlspecialchars($scriptBase) . '/">Return to homepage</a>' .
+            ' or <a href="' . htmlspecialchars($scriptBase) . '/CMS/login.php">log in</a> ' .
+            'with an account that has access.</p>'
+    ];
     $templateFile = realpath(__DIR__ . '/../theme/templates/pages/errors/403.php');
     if ($templateFile && file_exists($templateFile)) {
         render_theme_page($templateFile, $page, $scriptBase);


### PR DESCRIPTION
## Summary
- show more helpful messages on `404` and `403` pages
- update `CMS/index.php` to use the new messages

## Testing
- `php -l 403.php`
- `php -l 404.php`
- `php -l CMS/index.php`


------
https://chatgpt.com/codex/tasks/task_e_687662ea368c83318845e2862984eca6