### PR TITLE
Improve debounce for builder auto-save

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -12,6 +12,9 @@ let allBlockFiles = [];
 let favorites = [];
 let builderDraftKey = '';
 let lastSavedTimestamp = 0;
+// Delay before auto-saving after a change. A longer delay prevents rapid
+// successive saves while the user is still actively editing.
+const SAVE_DEBOUNCE_DELAY = 1000;
 
 function storeDraft() {
   const canvas = document.getElementById('canvas');
@@ -228,7 +231,7 @@ function savePage() {
 function scheduleSave() {
   clearTimeout(saveTimer);
   storeDraft();
-  saveTimer = setTimeout(savePage, 200);
+  saveTimer = setTimeout(savePage, SAVE_DEBOUNCE_DELAY);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- define a `SAVE_DEBOUNCE_DELAY` constant
- delay auto-save longer using this constant

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68766368e29c8331a81d06ac144f0a97