### PR TITLE
Improve drag event delegation

### DIFF
--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -70,12 +70,9 @@ export function initDragDrop(options = {}) {
 
   if (palette) palette.addEventListener('dragstart', paletteDragStart);
   if (canvas) {
-    canvas.addEventListener('dragstart', canvasDragStart);
-    canvas.addEventListener('dragenter', handleDragEnter, true);
-    canvas.addEventListener('dragleave', handleDragLeave, true);
-    canvas.addEventListener('dragover', throttledDragOver, true);
-    canvas.addEventListener('drop', throttledDrop, true);
-    canvas.addEventListener('dragend', handleDragEnd, true);
+    ['dragstart', 'dragenter', 'dragleave', 'dragover', 'drop', 'dragend'].forEach(
+      (ev) => canvas.addEventListener(ev, delegateDragEvents, true)
+    );
   }
   setupDropArea(canvas);
   if (canvas) {
@@ -282,3 +279,26 @@ function getDragAfterElement(container, y) {
 
 const throttledDragOver = throttleRAF(handleDragOver);
 const throttledDrop = throttleRAF(handleDrop);
+
+function delegateDragEvents(e) {
+  switch (e.type) {
+    case 'dragstart':
+      canvasDragStart(e);
+      break;
+    case 'dragenter':
+      handleDragEnter(e);
+      break;
+    case 'dragleave':
+      handleDragLeave(e);
+      break;
+    case 'dragover':
+      throttledDragOver(e);
+      break;
+    case 'drop':
+      throttledDrop(e);
+      break;
+    case 'dragend':
+      handleDragEnd(e);
+      break;
+  }
+}


### PR DESCRIPTION
## Summary
- reduce duplicate drag listeners by routing drag events through a single delegate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687664db1bbc8331937ac46f850beeb9