### PR TITLE
Add server-side draft support

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -24,6 +24,14 @@ function storeDraft() {
     timestamp: Date.now(),
   };
   localStorage.setItem(builderDraftKey, JSON.stringify(data));
+  const fd = new FormData();
+  fd.append('id', window.builderPageId);
+  fd.append('content', data.html);
+  fd.append('timestamp', data.timestamp);
+  fetch(window.builderBase + '/liveed/save-draft.php', {
+    method: 'POST',
+    body: fd,
+  }).catch(() => {});
 }
 
 function renderGroupItems(details) {
@@ -283,6 +291,19 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.removeItem(builderDraftKey);
     }
   }
+
+  fetch(
+    window.builderBase + '/liveed/load-draft.php?id=' + window.builderPageId
+  )
+    .then((r) => (r.ok ? r.json() : null))
+    .then((serverDraft) => {
+      if (serverDraft && serverDraft.timestamp > lastSavedTimestamp) {
+        canvas.innerHTML = serverDraft.content;
+        lastSavedTimestamp = serverDraft.timestamp;
+        localStorage.setItem(builderDraftKey, JSON.stringify(serverDraft));
+      }
+    })
+    .catch(() => {});
 
   // Restore palette position
   const storedPos = localStorage.getItem('palettePosition');

--- a/liveed/load-draft.php
+++ b/liveed/load-draft.php
@@ -1,0 +1,19 @@
+<?php
+// File: load-draft.php
+require_once __DIR__ . '/../CMS/includes/auth.php';
+require_login();
+
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if(!$id){
+    http_response_code(400);
+    echo 'Invalid ID';
+    exit;
+}
+$dir = __DIR__ . '/../CMS/data/drafts';
+$file = $dir . '/page-' . $id . '.json';
+header('Content-Type: application/json');
+if(is_file($file)){
+    readfile($file);
+} else {
+    echo json_encode(['content'=>'','timestamp'=>0]);
+}

--- a/liveed/save-content.php
+++ b/liveed/save-content.php
@@ -38,4 +38,10 @@ file_put_contents($historyFile, json_encode($historyData, JSON_PRETTY_PRINT));
 file_put_contents($pagesFile, json_encode($pages, JSON_PRETTY_PRINT));
 require_once __DIR__ . '/../CMS/modules/sitemap/generate.php';
 
+// remove saved draft if exists
+$draftFile = __DIR__ . '/../CMS/data/drafts/page-' . $id . '.json';
+if (is_file($draftFile)) {
+    unlink($draftFile);
+}
+
 echo 'OK';

--- a/liveed/save-draft.php
+++ b/liveed/save-draft.php
@@ -1,0 +1,24 @@
+<?php
+// File: save-draft.php
+require_once __DIR__ . '/../CMS/includes/auth.php';
+require_login();
+
+$id = isset($_POST['id']) ? intval($_POST['id']) : 0;
+$content = $_POST['content'] ?? '';
+$timestamp = isset($_POST['timestamp']) ? intval($_POST['timestamp']) : time();
+
+if(!$id){
+    http_response_code(400);
+    echo 'Invalid ID';
+    exit;
+}
+
+$dir = __DIR__ . '/../CMS/data/drafts';
+if(!is_dir($dir)){
+    mkdir($dir, 0755, true);
+}
+$file = $dir . '/page-' . $id . '.json';
+$data = ['content'=>$content,'timestamp'=>$timestamp];
+file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
+
+echo 'OK';


### PR DESCRIPTION
## Summary
- save drafts server-side to enable cross-device editing
- load latest draft when opening the editor
- clear server draft when content is saved

## Testing
- `php -l liveed/save-draft.php`
- `php -l liveed/load-draft.php`
- `php -l liveed/save-content.php`

------
https://chatgpt.com/codex/tasks/task_e_687664b7dfac8331a7fe7e08bdc792ee