### PR TITLE
Optimize settings loading for 404 page

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,10 +1,12 @@
 <?php
 // File: 404.php
 http_response_code(404);
+// Reuse cached settings data if available to avoid redundant disk access
+require_once __DIR__ . '/CMS/includes/data.php';
 $settingsFile = __DIR__ . '/CMS/data/settings.json';
 $menusFile = __DIR__ . '/CMS/data/menus.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
-$menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
+$settings = get_cached_json($settingsFile);
+$menus = get_cached_json($menusFile);
 $scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
 if (substr($scriptBase, -4) === '/CMS') {
     $scriptBase = substr($scriptBase, 0, -4);


### PR DESCRIPTION
## Summary
- avoid redundant JSON reads in `404.php`

## Testing
- `php -l 404.php`

------
https://chatgpt.com/codex/tasks/task_e_68766566174483319c49db757ba827b8