### PR TITLE
Centralize JSON helpers

### DIFF
--- a/403.php
+++ b/403.php
@@ -1,10 +1,11 @@
 <?php
 // File: 403.php
+require_once __DIR__ . '/CMS/includes/data.php';
 http_response_code(403);
 $settingsFile = __DIR__ . '/CMS/data/settings.json';
 $menusFile = __DIR__ . '/CMS/data/menus.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
-$menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
+$settings = read_json_file($settingsFile);
+$menus = read_json_file($menusFile);
 $scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
 if (substr($scriptBase, -4) === '/CMS') {
     $scriptBase = substr($scriptBase, 0, -4);

--- a/CMS/includes/auth.php
+++ b/CMS/includes/auth.php
@@ -1,6 +1,7 @@
 <?php
 // File: auth.php
 session_start();
+require_once __DIR__ . '/data.php';
 
 // Path to users.json
 $usersFile = __DIR__ . '/../data/users.json';
@@ -20,7 +21,7 @@ if (!file_exists($usersFile)) {
         ], JSON_PRETTY_PRINT)
     );
 }
-$users = json_decode(file_get_contents($usersFile), true) ?: [];
+$users = read_json_file($usersFile);
 
 function find_user($username) {
     global $users;

--- a/CMS/includes/data.php
+++ b/CMS/includes/data.php
@@ -1,6 +1,31 @@
 <?php
 // File: data.php
-// Utility functions for loading JSON data with simple in-memory caching
+// Utility functions for reading/writing JSON files with simple in-memory caching
+
+/**
+ * Read and decode a JSON file.
+ *
+ * @param string $file Path to the JSON file
+ * @return array Decoded JSON data or empty array on failure
+ */
+function read_json_file($file) {
+    if (!file_exists($file)) {
+        return [];
+    }
+    $data = json_decode(file_get_contents($file), true);
+    return $data ?: [];
+}
+
+/**
+ * Write an array to a JSON file using pretty print formatting.
+ *
+ * @param string $file  Path to the JSON file
+ * @param mixed  $data  Data to encode
+ * @return bool True on success, false on failure
+ */
+function write_json_file($file, $data) {
+    return file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT)) !== false;
+}
 
 /**
  * Load and decode a JSON file while caching the result within the request.
@@ -11,12 +36,7 @@
 function get_cached_json($file) {
     static $cache = [];
     if (!isset($cache[$file])) {
-        if (file_exists($file)) {
-            $data = json_decode(file_get_contents($file), true);
-            $cache[$file] = $data ?: [];
-        } else {
-            $cache[$file] = [];
-        }
+        $cache[$file] = read_json_file($file);
     }
     return $cache[$file];
 }

--- a/CMS/login.php
+++ b/CMS/login.php
@@ -2,11 +2,12 @@
 // File: login.php
 require_once __DIR__ . '/includes/auth.php';
 require_once __DIR__ . '/includes/sanitize.php';
+require_once __DIR__ . '/includes/data.php';
 
 $settingsFile = __DIR__ . '/data/settings.json';
 $settings = [];
 if (file_exists($settingsFile)) {
-    $settings = json_decode(file_get_contents($settingsFile), true) ?: [];
+    $settings = read_json_file($settingsFile);
 }
 
 $error = '';

--- a/CMS/modules/analytics/analytics_data.php
+++ b/CMS/modules/analytics/analytics_data.php
@@ -1,10 +1,11 @@
 <?php
 // File: analytics_data.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 
 $data = [];
 foreach ($pages as $p) {

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -1,10 +1,11 @@
 <?php
 // File: view.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 $totalViews = 0;
 foreach ($pages as $p) {
     $totalViews += $p['views'] ?? 0;

--- a/CMS/modules/blogs/list_categories.php
+++ b/CMS/modules/blogs/list_categories.php
@@ -1,7 +1,7 @@
 <?php
 // File: list_categories.php
 $postsFile = __DIR__ . '/../../data/blog_posts.json';
-$posts = file_exists($postsFile) ? json_decode(file_get_contents($postsFile), true) : [];
+$posts = read_json_file($postsFile);
 $categories = [];
 foreach ($posts as $p) {
     if (!empty($p['category']) && !in_array($p['category'], $categories)) {

--- a/CMS/modules/blogs/list_posts.php
+++ b/CMS/modules/blogs/list_posts.php
@@ -1,7 +1,7 @@
 <?php
 // File: list_posts.php
 $postsFile = __DIR__ . '/../../data/blog_posts.json';
-$posts = file_exists($postsFile) ? json_decode(file_get_contents($postsFile), true) : [];
+$posts = read_json_file($postsFile);
 header('Content-Type: application/json');
 echo json_encode($posts);
 ?>

--- a/CMS/modules/dashboard/dashboard_data.php
+++ b/CMS/modules/dashboard/dashboard_data.php
@@ -1,15 +1,16 @@
 <?php
 // File: dashboard_data.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
 $mediaFile = __DIR__ . '/../../data/media.json';
 $usersFile = __DIR__ . '/../../data/users.json';
 
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
-$users = file_exists($usersFile) ? json_decode(file_get_contents($usersFile), true) : [];
+$pages = read_json_file($pagesFile);
+$media = read_json_file($mediaFile);
+$users = read_json_file($usersFile);
 
 $views = 0;
 foreach ($pages as $p) {

--- a/CMS/modules/forms/delete_form.php
+++ b/CMS/modules/forms/delete_form.php
@@ -1,11 +1,12 @@
 <?php
 // File: delete_form.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $formsFile = __DIR__ . '/../../data/forms.json';
-$forms = file_exists($formsFile) ? json_decode(file_get_contents($formsFile), true) : [];
+$forms = read_json_file($formsFile);
 
 $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $forms = array_values(array_filter($forms, function($f) use ($id) {

--- a/CMS/modules/forms/list_forms.php
+++ b/CMS/modules/forms/list_forms.php
@@ -1,10 +1,11 @@
 <?php
 // File: list_forms.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $formsFile = __DIR__ . '/../../data/forms.json';
-$forms = file_exists($formsFile) ? json_decode(file_get_contents($formsFile), true) : [];
+$forms = read_json_file($formsFile);
 
 echo json_encode($forms);
 ?>

--- a/CMS/modules/forms/save_form.php
+++ b/CMS/modules/forms/save_form.php
@@ -1,11 +1,12 @@
 <?php
 // File: save_form.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $formsFile = __DIR__ . '/../../data/forms.json';
-$forms = file_exists($formsFile) ? json_decode(file_get_contents($formsFile), true) : [];
+$forms = read_json_file($formsFile);
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
 $name = sanitize_text($_POST['name'] ?? '');

--- a/CMS/modules/logs/list_logs.php
+++ b/CMS/modules/logs/list_logs.php
@@ -1,17 +1,18 @@
 <?php
 // File: list_logs.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 $pageLookup = [];
 foreach ($pages as $p) {
     $pageLookup[$p['id']] = $p['title'];
 }
 
 $historyFile = __DIR__ . '/../../data/page_history.json';
-$historyData = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
+$historyData = read_json_file($historyFile);
 
 $logs = [];
 foreach ($historyData as $pid => $entries) {

--- a/CMS/modules/logs/view.php
+++ b/CMS/modules/logs/view.php
@@ -1,17 +1,18 @@
 <?php
 // File: view.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 $pageLookup = [];
 foreach ($pages as $p) {
     $pageLookup[$p['id']] = $p['title'];
 }
 
 $historyFile = __DIR__ . '/../../data/page_history.json';
-$historyData = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
+$historyData = read_json_file($historyFile);
 
 $logs = [];
 foreach ($historyData as $pid => $entries) {

--- a/CMS/modules/media/crop_media.php
+++ b/CMS/modules/media/crop_media.php
@@ -1,11 +1,12 @@
 <?php
 // File: crop_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 
 $id = sanitize_text($_POST['id'] ?? '');
 $imageData = $_POST['image'] ?? '';

--- a/CMS/modules/media/delete_folder.php
+++ b/CMS/modules/media/delete_folder.php
@@ -1,6 +1,7 @@
 <?php
 // File: delete_folder.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
@@ -18,7 +19,7 @@ if (!is_dir($dir)) {
 }
 
 $mediaFile = $root . '/data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 $new = [];
 foreach ($media as $m) {
     if ($m['folder'] === $folder) {

--- a/CMS/modules/media/delete_media.php
+++ b/CMS/modules/media/delete_media.php
@@ -1,11 +1,12 @@
 <?php
 // File: delete_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 $id = sanitize_text($_POST['id'] ?? '');
 if ($id === '') {
     echo json_encode(['status' => 'error']);

--- a/CMS/modules/media/list_media.php
+++ b/CMS/modules/media/list_media.php
@@ -1,11 +1,12 @@
 <?php
 // File: list_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 $query = strtolower(sanitize_text($_GET['q'] ?? ''));
 $folder = sanitize_text($_GET['folder'] ?? '');
 

--- a/CMS/modules/media/picker.php
+++ b/CMS/modules/media/picker.php
@@ -1,12 +1,13 @@
 <?php
 // File: picker.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $base = rtrim(sanitize_text($_GET['base'] ?? ''), '/');
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 ?>
 <!DOCTYPE html>
 <html lang="en">

--- a/CMS/modules/media/rename_folder.php
+++ b/CMS/modules/media/rename_folder.php
@@ -1,6 +1,7 @@
 <?php
 // File: rename_folder.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
@@ -27,7 +28,7 @@ if (!rename($oldDir, $newDir)) {
 }
 
 $mediaFile = $root . '/data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 foreach ($media as &$m) {
     if ($m['folder'] === $old) {
         $m['folder'] = basename($new);

--- a/CMS/modules/media/rename_media.php
+++ b/CMS/modules/media/rename_media.php
@@ -1,11 +1,12 @@
 <?php
 // File: rename_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 
 $id = sanitize_text($_POST['id'] ?? '');
 $newName = sanitize_text($_POST['name'] ?? '');

--- a/CMS/modules/media/update_order.php
+++ b/CMS/modules/media/update_order.php
@@ -1,11 +1,12 @@
 <?php
 // File: update_order.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 
 $order = json_decode($_POST['order'] ?? '[]', true);
 if (!is_array($order)) $order = [];

--- a/CMS/modules/media/update_tags.php
+++ b/CMS/modules/media/update_tags.php
@@ -1,11 +1,12 @@
 <?php
 // File: update_tags.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 
 $id = sanitize_text($_POST['id'] ?? '');
 $tags = sanitize_tags(explode(',', $_POST['tags'] ?? ''));

--- a/CMS/modules/media/upload_media.php
+++ b/CMS/modules/media/upload_media.php
@@ -1,6 +1,7 @@
 <?php
 // File: upload_media.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
@@ -23,7 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     $mediaFile = $root . '/data/media.json';
-    $media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+    $media = read_json_file($mediaFile);
 
     $maxOrder = -1;
     foreach ($media as $m) {

--- a/CMS/modules/menus/delete_menu.php
+++ b/CMS/modules/menus/delete_menu.php
@@ -1,11 +1,12 @@
 <?php
 // File: delete_menu.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $menusFile = __DIR__ . '/../../data/menus.json';
-$menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
+$menus = read_json_file($menusFile);
 $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $menus = array_filter($menus, function($m) use ($id) { return $m['id'] != $id; });
 file_put_contents($menusFile, json_encode(array_values($menus), JSON_PRETTY_PRINT));

--- a/CMS/modules/menus/list_menus.php
+++ b/CMS/modules/menus/list_menus.php
@@ -1,10 +1,11 @@
 <?php
 // File: list_menus.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $menusFile = __DIR__ . '/../../data/menus.json';
-$menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
+$menus = read_json_file($menusFile);
 
 echo json_encode($menus);
 ?>

--- a/CMS/modules/menus/save_menu.php
+++ b/CMS/modules/menus/save_menu.php
@@ -1,14 +1,15 @@
 <?php
 // File: save_menu.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $menusFile = __DIR__ . '/../../data/menus.json';
-$menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
+$menus = read_json_file($menusFile);
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
 $name = sanitize_text($_POST['name'] ?? '');

--- a/CMS/modules/pages/delete_page.php
+++ b/CMS/modules/pages/delete_page.php
@@ -1,13 +1,14 @@
 <?php
 // File: delete_page.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 $pagesFile = __DIR__ . '/../../data/pages.json';
 if (!file_exists($pagesFile)) {
     exit('No pages');
 }
-$pages = json_decode(file_get_contents($pagesFile), true) ?: [];
+$pages = read_json_file($pagesFile);
 $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $deletedPage = null;
 foreach ($pages as $p) {
@@ -19,7 +20,7 @@ file_put_contents($pagesFile, json_encode(array_values($pages), JSON_PRETTY_PRIN
 require_once __DIR__ . '/../sitemap/generate.php';
 
 $historyFile = __DIR__ . '/../../data/page_history.json';
-$historyData = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
+$historyData = read_json_file($historyFile);
 if (!isset($historyData[$id])) $historyData[$id] = [];
 $user = $_SESSION['user']['username'] ?? 'Unknown';
 $action = 'deleted page';

--- a/CMS/modules/pages/list_pages.php
+++ b/CMS/modules/pages/list_pages.php
@@ -1,10 +1,11 @@
 <?php
 // File: list_pages.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 $result = [];
 foreach ($pages as $p) {
     $result[] = ['id' => $p['id'], 'title' => $p['title'], 'slug' => $p['slug']];

--- a/CMS/modules/pages/save_page.php
+++ b/CMS/modules/pages/save_page.php
@@ -1,11 +1,12 @@
 <?php
 // File: save_page.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 $pagesFile = __DIR__ . '/../../data/pages.json';
 $pages = [];
 if (file_exists($pagesFile)) {
-    $pages = json_decode(file_get_contents($pagesFile), true) ?: [];
+    $pages = read_json_file($pagesFile);
 }
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
@@ -104,7 +105,7 @@ $pages[] = [
 }
 
 $historyFile = __DIR__ . '/../../data/page_history.json';
-$historyData = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
+$historyData = read_json_file($historyFile);
 if (!isset($historyData[$id])) $historyData[$id] = [];
 $user = $_SESSION['user']['username'] ?? 'Unknown';
 $historyData[$id][] = ['time' => $timestamp, 'user' => $user, 'action' => $action];

--- a/CMS/modules/pages/set_home.php
+++ b/CMS/modules/pages/set_home.php
@@ -1,6 +1,7 @@
 <?php
 // File: set_home.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
@@ -12,7 +13,7 @@ if ($slug === '') {
 }
 
 $settingsFile = __DIR__ . '/../../data/settings.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
+$settings = read_json_file($settingsFile);
 $settings['homepage'] = $slug;
 file_put_contents($settingsFile, json_encode($settings, JSON_PRETTY_PRINT));
 

--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -1,12 +1,13 @@
 <?php
 // File: view.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 $settingsFile = __DIR__ . '/../../data/settings.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
+$settings = read_json_file($settingsFile);
 $templateDir = realpath(__DIR__ . '/../../../theme/templates/pages');
 $templates = [];
 if ($templateDir) {

--- a/CMS/modules/search/view.php
+++ b/CMS/modules/search/view.php
@@ -1,14 +1,15 @@
 <?php
 // File: view.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 $postsFile = __DIR__ . '/../../data/blog_posts.json';
-$posts = file_exists($postsFile) ? json_decode(file_get_contents($postsFile), true) : [];
+$posts = read_json_file($postsFile);
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = file_exists($mediaFile) ? json_decode(file_get_contents($mediaFile), true) : [];
+$media = read_json_file($mediaFile);
 
 $q = isset($_GET['q']) ? trim($_GET['q']) : '';
 $lower = strtolower($q);

--- a/CMS/modules/settings/list_settings.php
+++ b/CMS/modules/settings/list_settings.php
@@ -1,10 +1,11 @@
 <?php
 // File: list_settings.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $settingsFile = __DIR__ . '/../../data/settings.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
+$settings = read_json_file($settingsFile);
 
 echo json_encode($settings);
 ?>

--- a/CMS/modules/settings/save_settings.php
+++ b/CMS/modules/settings/save_settings.php
@@ -1,11 +1,12 @@
 <?php
 // File: save_settings.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $settingsFile = __DIR__ . '/../../data/settings.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
+$settings = read_json_file($settingsFile);
 
 $settings['site_name'] = sanitize_text($_POST['site_name'] ?? ($settings['site_name'] ?? ''));
 $settings['tagline'] = sanitize_text($_POST['tagline'] ?? ($settings['tagline'] ?? ''));

--- a/CMS/modules/sitemap/generate.php
+++ b/CMS/modules/sitemap/generate.php
@@ -3,7 +3,7 @@
 // Generate sitemap.xml listing all published pages
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 
 $scheme = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
 $host = $_SERVER['HTTP_HOST'] ?? 'localhost';

--- a/CMS/modules/users/delete_user.php
+++ b/CMS/modules/users/delete_user.php
@@ -1,11 +1,12 @@
 <?php
 // File: delete_user.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
-$users = file_exists($usersFile) ? json_decode(file_get_contents($usersFile), true) : [];
+$users = read_json_file($usersFile);
 $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
 $users = array_filter($users, function($u) use ($id) { return $u['id'] != $id; });
 file_put_contents($usersFile, json_encode(array_values($users), JSON_PRETTY_PRINT));

--- a/CMS/modules/users/list_users.php
+++ b/CMS/modules/users/list_users.php
@@ -1,10 +1,11 @@
 <?php
 // File: list_users.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
-$users = file_exists($usersFile) ? json_decode(file_get_contents($usersFile), true) : [];
+$users = read_json_file($usersFile);
 
 $clean = [];
 foreach ($users as $u) {

--- a/CMS/modules/users/save_user.php
+++ b/CMS/modules/users/save_user.php
@@ -1,11 +1,12 @@
 <?php
 // File: save_user.php
 require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
-$users = file_exists($usersFile) ? json_decode(file_get_contents($usersFile), true) : [];
+$users = read_json_file($usersFile);
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
 $username = sanitize_text($_POST['username'] ?? '');

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 // File: index.php
+require_once __DIR__ . '/CMS/includes/data.php';
 // Determine the requested path for clean URLs.
 // When the CMS is installed in a subdirectory we need to strip that base
 // directory from the request URI so that routing works correctly.
@@ -12,7 +13,7 @@ if ($base && strpos($path, $base) === 0) {
 // If a real file is requested, serve it directly. This allows access to
 // backend scripts like CMS/login.php when using URL rewriting.
 $settingsFile = __DIR__ . '/CMS/data/settings.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
+$settings = read_json_file($settingsFile);
 $homepage = $settings['homepage'] ?? 'home';
 
 $requested = __DIR__ . '/' . $path;

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -1,11 +1,12 @@
 <?php
 // File: builder.php
 require_once __DIR__ . '/../CMS/includes/auth.php';
+require_once __DIR__ . '/../CMS/includes/data.php';
 require_login();
 
 $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 $pagesFile = __DIR__ . '/../CMS/data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 $page = null;
 foreach ($pages as $p) {
     if ((int)$p['id'] === $id) { $page = $p; break; }
@@ -24,9 +25,9 @@ $themeBase = $scriptBase . '/theme';
 
 // Load settings and menus for the theme template
 $settingsFile = __DIR__ . '/../CMS/data/settings.json';
-$settings = file_exists($settingsFile) ? json_decode(file_get_contents($settingsFile), true) : [];
+$settings = read_json_file($settingsFile);
 $menusFile = __DIR__ . '/../CMS/data/menus.json';
-$menus = file_exists($menusFile) ? json_decode(file_get_contents($menusFile), true) : [];
+$menus = read_json_file($menusFile);
 
 // Render the theme page template with a canvas placeholder
 $templateFile = realpath(__DIR__ . '/../theme/templates/pages/page.php');

--- a/liveed/get-history.php
+++ b/liveed/get-history.php
@@ -1,10 +1,11 @@
 <?php
 require_once __DIR__ . '/../CMS/includes/auth.php';
+require_once __DIR__ . '/../CMS/includes/data.php';
 require_login();
 
 $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 $historyFile = __DIR__ . '/../CMS/data/page_history.json';
-$historyData = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
+$historyData = read_json_file($historyFile);
 $entries = isset($historyData[$id]) ? array_slice($historyData[$id], -20) : [];
 header('Content-Type: application/json');
 echo json_encode(['history' => $entries]);

--- a/liveed/save-content.php
+++ b/liveed/save-content.php
@@ -1,10 +1,11 @@
 <?php
 // File: save-content.php
 require_once __DIR__ . '/../CMS/includes/auth.php';
+require_once __DIR__ . '/../CMS/includes/data.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../CMS/data/pages.json';
-$pages = file_exists($pagesFile) ? json_decode(file_get_contents($pagesFile), true) : [];
+$pages = read_json_file($pagesFile);
 
 $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
 $content = $_POST['content'] ?? '';
@@ -28,7 +29,7 @@ unset($p);
 $action = 'updated content';
 
 $historyFile = __DIR__ . '/../CMS/data/page_history.json';
-$historyData = file_exists($historyFile) ? json_decode(file_get_contents($historyFile), true) : [];
+$historyData = read_json_file($historyFile);
 if (!isset($historyData[$id])) $historyData[$id] = [];
 $user = $_SESSION['user']['username'] ?? 'Unknown';
 $historyData[$id][] = ['time' => $timestamp, 'user' => $user, 'action' => $action];

--- a/theme/templates/blocks/advanced.blog-post-list.php
+++ b/theme/templates/blocks/advanced.blog-post-list.php
@@ -1,10 +1,12 @@
 <!-- File: advanced.blog-post-list.php -->
 <!-- Template: advanced.blog-post-list -->
 <?php
+$__data = __DIR__ . '/../../../CMS/includes/data.php';
+if (file_exists($__data)) require_once $__data;
 $postsFile = __DIR__ . '/../../../CMS/data/blog_posts.json';
 $blogCategories = [];
 if (file_exists($postsFile)) {
-    $posts = json_decode(file_get_contents($postsFile), true) ?: [];
+    $posts = read_json_file($postsFile);
     foreach ($posts as $p) {
         if (!empty($p['category']) && !in_array($p['category'], $blogCategories)) {
             $blogCategories[] = $p['category'];


### PR DESCRIPTION
## Summary
- add helper functions for reading and writing JSON data
- refactor modules to use new helpers and include the helper file
- update front-end theme block with new helper

## Testing
- `php -l 403.php`
- `for f in $(git status --name-only); do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_687666b6f0d48331b1fb6a6af25f1f01