### PR TITLE
Add modal based SEO checker

### DIFF
--- a/liveed/builder.css
+++ b/liveed/builder.css
@@ -1443,3 +1443,65 @@
 h1.highlight-htag, h2.highlight-htag, h3.highlight-htag, h4.highlight-htag, h5.highlight-htag, h6.highlight-htag { position: relative; }
 .error-message.highlight-htag { padding-left: 50px; }
 .error-message.highlight-htag .accessibility-bubble.green { background: #cc0000 !important; }
+/* SEO Checker Styles */
+.seo-modal {
+  display: none;
+  position: fixed;
+  z-index: 999;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0,0,0,0.4);
+}
+.seo-modal-content {
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%;
+  max-width: 600px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 10px;
+}
+.seo-modal-content h2 {
+  font-size: 24px;
+  margin-bottom: 20px;
+  text-align: center;
+}
+.seo-modal-content ul {
+  list-style: none;
+  padding: 0;
+}
+.seo-modal-content ul li {
+  background: #f9f9f9;
+  margin: 5px 0;
+  padding: 10px;
+  border-left: 5px solid #4044c6;
+  border-radius: 5px;
+}
+.seo-modal-content ul li:nth-child(even) {
+  background: #efefef;
+}
+.seo-modal-content .close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+.seo-modal-content .close:hover,
+.seo-modal-content .close:focus {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+}
+.highlight-error {
+  border: 2px solid #cc0000 !important;
+}
+.seo-modal-content ul li.error {
+  border-left: 5px solid red;
+}
+.seo-modal-content ul li.pass {
+  border-left: 5px solid green;
+}

--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -654,15 +654,125 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
-  if (seoCheckBtn)
-    seoCheckBtn.addEventListener('click', () => {
-      const issues = checkSeo(canvas.innerHTML);
-      if (issues.length) {
-        alert('SEO issues found:\n' + issues.join('\n'));
+  if (seoCheckBtn) {
+    const seoModal = document.getElementById('seoModal');
+    const seoIssues = document.getElementById('seoIssues');
+    const seoClose = seoModal ? seoModal.querySelector('.close') : null;
+
+    const runSeoCheck = () => {
+      if (!seoModal || !seoIssues) return;
+      let results = '';
+      $('.highlight-error').removeClass('highlight-error');
+
+      if ($('title').length === 0) {
+        results += '<li class="error">Missing <code>&lt;title&gt;</code> tag.</li>';
       } else {
-        alert('No SEO issues found.');
+        results += '<li class="pass">Title tag is present.</li>';
+        if ($('title').length > 1) {
+          results += '<li class="error">Duplicate <code>&lt;title&gt;</code> tags found.</li>';
+        }
       }
+
+      if ($('meta[name="description"]').length === 0) {
+        results += '<li class="error">Missing meta description.</li>';
+      } else {
+        results += '<li class="pass">Meta description is present.</li>';
+        if ($('meta[name="description"]').length > 1) {
+          results += '<li class="error">Duplicate meta description tags found.</li>';
+        }
+      }
+
+      if ($('h1').length === 0) {
+        results += '<li class="error">Missing <code>&lt;h1&gt;</code> tag.</li>';
+      } else {
+        results += '<li class="pass">H1 tag is present.</li>';
+      }
+
+      if ($('h2').length === 0) {
+        results += '<li class="error">No <code>&lt;h2&gt;</code> tag found. Consider adding subheadings for better structure.</li>';
+      } else {
+        results += '<li class="pass">H2 tags are present.</li>';
+      }
+
+      const imagesWithoutAlt = $('img:not([alt])');
+      if (imagesWithoutAlt.length > 0) {
+        results += `<li class="error">${imagesWithoutAlt.length} image(s) missing alt attribute.</li>`;
+        imagesWithoutAlt.addClass('highlight-error');
+      } else {
+        results += '<li class="pass">All images have alt attributes.</li>';
+      }
+
+      const imagesWithoutLazy = $('img:not([loading])');
+      if (imagesWithoutLazy.length > 0) {
+        results += `<li class="error">${imagesWithoutLazy.length} image(s) missing lazy loading attribute (consider using loading=\"lazy\").</li>`;
+        imagesWithoutLazy.addClass('highlight-error');
+      } else {
+        results += '<li class="pass">All images have lazy loading attribute.</li>';
+      }
+
+      if ($('link[rel="canonical"]').length === 0) {
+        results += '<li class="error">Missing canonical tag.</li>';
+      } else {
+        results += '<li class="pass">Canonical tag is present.</li>';
+      }
+
+      if ($('link[rel="sitemap"]').length === 0) {
+        results += '<li class="error">Missing sitemap link.</li>';
+      } else {
+        results += '<li class="pass">Sitemap link is present.</li>';
+      }
+
+      if ($('meta[name="viewport"]').length === 0) {
+        results += '<li class="error">Missing viewport meta tag.</li>';
+      } else {
+        results += '<li class="pass">Viewport meta tag is present.</li>';
+      }
+
+      if ($('html').attr('lang') === undefined) {
+        results += '<li class="error">Missing language attribute on <code>&lt;html&gt;</code> tag.</li>';
+      } else {
+        results += '<li class="pass">Language attribute is present on <code>&lt;html&gt;</code> tag.</li>';
+      }
+
+      if ($('meta[name="robots"]').length === 0) {
+        results += '<li class="error">Missing meta robots tag.</li>';
+      } else {
+        results += '<li class="pass">Meta robots tag is present.</li>';
+      }
+
+      if (
+        $('meta[property="og:title"]').length === 0 ||
+        $('meta[property="og:description"]').length === 0 ||
+        $('meta[property="og:image"]').length === 0
+      ) {
+        results += '<li class="error">One or more Open Graph tags (og:title, og:description, og:image) are missing.</li>';
+      } else {
+        results += '<li class="pass">Open Graph tags are present.</li>';
+      }
+
+      if ($('meta[name="twitter:card"]').length === 0) {
+        results += '<li class="error">Missing Twitter Card meta tag (twitter:card).</li>';
+      } else {
+        results += '<li class="pass">Twitter Card meta tag is present.</li>';
+      }
+
+      if ($('script[type="application/ld+json"]').length === 0) {
+        results += '<li class="error">Missing structured data (JSON-LD).</li>';
+      } else {
+        results += '<li class="pass">Structured data (JSON-LD) is present.</li>';
+      }
+
+      seoIssues.innerHTML = results;
+      seoModal.style.display = 'block';
+    };
+
+    seoCheckBtn.addEventListener('click', runSeoCheck);
+
+    if (seoClose) seoClose.addEventListener('click', () => (seoModal.style.display = 'none'));
+    window.addEventListener('click', (e) => {
+      if (e.target === seoModal) seoModal.style.display = 'none';
     });
+  }
   if (a11yCheckBtn)
     a11yCheckBtn.addEventListener('click', () => {
       if (window.runAccessibilityCheck) {

--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -100,10 +100,17 @@ $previewModalHtml = '<div id="previewModal" class="modal">'
     . '<div class="modal-footer"><button type="button" class="btn btn-secondary" id="closePreview">Close</button></div>'
     . '</div></div>';
 
+$seoModalHtml = '<div id="seoModal" class="seo-modal">'
+    . '<div class="seo-modal-content">'
+    . '<span class="close">&times;</span>'
+    . '<h2>SEO Report</h2>'
+    . '<ul id="seoIssues"></ul>'
+    . '</div></div>';
+
 $builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><span class="title">Settings</span><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div>'
     . '<div id="historyPanel" class="history-panel"><div class="history-header"><span class="title">Page History</span><button type="button" class="close-btn">&times;</button></div><div class="history-content"></div></div>'
     . '<div id="link-check-legend" aria-live="polite"></div>'
-    . $mediaPickerHtml . $previewModalHtml . '</div>'
+    . $mediaPickerHtml . $previewModalHtml . $seoModalHtml . '</div>'
     . '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';window.builderSlug = ' . json_encode($page['slug']) . ';window.builderLastModified = ' . json_encode($page['last_modified']) . ';</script>'
     . '<script type="module" src="' . $scriptBase . '/liveed/builder.js"></script>'
     . '<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>'


### PR DESCRIPTION
## Summary
- implement a modal SEO checker for the builder
- style the SEO report modal

## Testing
- `php -l liveed/builder.php`
- `node -e "require('fs').readFileSync('liveed/builder.js','utf8'); console.log('ok');" > /dev/null && echo 'node ok'`

------
https://chatgpt.com/codex/tasks/task_e_68768750d3c883319938478871d4c38c