### PR TITLE
Optimize block listing

### DIFF
--- a/liveed/list-blocks.php
+++ b/liveed/list-blocks.php
@@ -4,12 +4,13 @@ require_once __DIR__ . '/../CMS/includes/auth.php';
 require_login();
 
 $blocksDir = __DIR__ . '/../theme/templates/blocks';
+
 $blocks = [];
 if (is_dir($blocksDir)) {
-    foreach (scandir($blocksDir) as $f) {
-        if (substr($f, -4) === '.php') {
-            $blocks[] = $f;
-        }
+    $paths = glob($blocksDir . '/*.php');
+    if ($paths !== false) {
+        $blocks = array_map('basename', $paths);
+        sort($blocks, SORT_STRING);
     }
 }
 header('Content-Type: application/json');


### PR DESCRIPTION
## Summary
- improve `list-blocks.php` by using `glob` and sorting results

## Testing
- `php -l liveed/list-blocks.php`


------
https://chatgpt.com/codex/tasks/task_e_687699faab30833187c89c6489eab30e