### PR TITLE
Optimize content width layout

### DIFF
--- a/theme/templates/blocks/layout.content-width.php
+++ b/theme/templates/blocks/layout.content-width.php
@@ -25,9 +25,7 @@
         </dd>
     </dl>
 </templateSetting>
-<div class="content-width _content-style" data-tpl-tooltip="Content Width">
-    <div class="content-width-wrap {custom_position}" style="max-width: {custom_width}px;">
-        <div class="drop-area"></div>
-    </div>
+<div class="content-width container{custom_position}" style="max-width: {custom_width}px;" data-tpl-tooltip="Content Width">
+    <div class="drop-area"></div>
 </div>
 


### PR DESCRIPTION
## Summary
- simplify layout.content-width.php to use the Bootstrap container class

## Testing
- `php -l theme/templates/blocks/layout.content-width.php`

------
https://chatgpt.com/codex/tasks/task_e_68769ba14f7083318227a6c270bb6ca4