### PR TITLE
Optimize content width layout

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -952,6 +952,16 @@ section.container-fluid {
     margin: 0 auto;
 }
 
+/* Specific width utilities for the content width block */
+.content-width-480  { max-width: 480px; }
+.content-width-570  { max-width: 570px; }
+.content-width-670  { max-width: 670px; }
+.content-width-770  { max-width: 770px; }
+.content-width-870  { max-width: 870px; }
+.content-width-970  { max-width: 970px; }
+.content-width-1170 { max-width: 1170px; }
+.content-width-1240 { max-width: 1240px; }
+
 .drop-area {
     min-height: 20px;
 }

--- a/theme/templates/blocks/layout.content-width.php
+++ b/theme/templates/blocks/layout.content-width.php
@@ -25,7 +25,7 @@
         </dd>
     </dl>
 </templateSetting>
-<div class="content-width container{custom_position}" style="max-width: {custom_width}px;" data-tpl-tooltip="Content Width">
+<div class="content-width container{custom_position} content-width-{custom_width}" data-tpl-tooltip="Content Width">
     <div class="drop-area"></div>
 </div>
 


### PR DESCRIPTION
## Summary
- use CSS width utilities instead of inline styles
- add classes for custom content widths

## Testing
- `php -l theme/templates/blocks/layout.content-width.php`


------
https://chatgpt.com/codex/tasks/task_e_68769d0ff3588331853252bb92bc159c