### PR TITLE
Add SEO and accessibility admin modules

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -98,6 +98,10 @@ $settings = get_cached_json($settingsFile);
                         <div class="nav-icon"><i class="fas fa-chart-line"></i></div>
                         <div class="nav-text">Analytics</div>
                     </div>
+                    <div class="nav-item" data-section="seo">
+                        <div class="nav-icon"><i class="fas fa-magnifying-glass-chart"></i></div>
+                        <div class="nav-text">SEO</div>
+                    </div>
                     <div class="nav-item" data-section="logs">
                         <div class="nav-icon"><i class="fas fa-clipboard-list"></i></div>
                         <div class="nav-text">Logs</div>
@@ -109,6 +113,10 @@ $settings = get_cached_json($settingsFile);
                     <div class="nav-item" data-section="import">
                         <div class="nav-icon"><i class="fas fa-file-import"></i></div>
                         <div class="nav-text">Import/Export</div>
+                    </div>
+                    <div class="nav-item" data-section="accessibility">
+                        <div class="nav-icon"><i class="fas fa-universal-access"></i></div>
+                        <div class="nav-text">Accessibility</div>
                     </div>
                 </div>
 

--- a/CMS/modules/accessibility/accessibility.js
+++ b/CMS/modules/accessibility/accessibility.js
@@ -1,0 +1,36 @@
+$(function () {
+    const $rows = $('#accessibilityTable tbody tr');
+    const $search = $('#a11ySearch');
+    let activeFilter = 'all';
+
+    function applyFilters() {
+        const query = $search.val().toLowerCase();
+
+        $rows.each(function () {
+            const $row = $(this);
+            const matchesText = query === '' || $row.text().toLowerCase().indexOf(query) !== -1;
+            const status = ($row.data('status') || '').toString();
+            const matchesFilter =
+                activeFilter === 'all' || status.split(' ').includes(activeFilter);
+
+            if (matchesText && matchesFilter) {
+                $row.show();
+            } else {
+                $row.hide();
+            }
+        });
+    }
+
+    $search.on('input', applyFilters);
+
+    $('[data-a11y-filter]').on('click', function () {
+        const $card = $(this);
+        activeFilter = $card.data('a11y-filter');
+
+        $('[data-a11y-filter]').removeClass('active');
+        $card.addClass('active');
+        applyFilters();
+    });
+
+    $('[data-a11y-filter="all"]').addClass('active');
+});

--- a/CMS/modules/accessibility/view.php
+++ b/CMS/modules/accessibility/view.php
@@ -1,0 +1,238 @@
+<?php
+// File: modules/accessibility/view.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
+
+$pagesFile = __DIR__ . '/../../data/pages.json';
+$pages = read_json_file($pagesFile);
+
+libxml_use_internal_errors(true);
+
+$report = [];
+$summary = [
+    'accessible' => 0,
+    'needs_review' => 0,
+    'missing_alt' => 0,
+];
+
+$genericLinkTerms = [
+    'click here',
+    'read more',
+    'learn more',
+    'here',
+    'more',
+    'this page',
+];
+
+foreach ($pages as $page) {
+    $title = $page['title'] ?? 'Untitled';
+    $slug = $page['slug'] ?? '';
+    $content = $page['content'] ?? '';
+
+    $doc = new DOMDocument();
+    $loaded = $content !== '' && $doc->loadHTML('<?xml encoding="utf-8" ?>' . $content);
+
+    $imageCount = 0;
+    $missingAlt = 0;
+    $headings = [
+        'h1' => 0,
+        'h2' => 0,
+    ];
+    $genericLinks = 0;
+    $landmarks = 0;
+
+    if ($loaded) {
+        $images = $doc->getElementsByTagName('img');
+        $imageCount = $images->length;
+        foreach ($images as $img) {
+            $alt = trim($img->getAttribute('alt'));
+            if ($alt === '') {
+                $missingAlt++;
+            }
+        }
+
+        $h1s = $doc->getElementsByTagName('h1');
+        $headings['h1'] = $h1s->length;
+        $h2s = $doc->getElementsByTagName('h2');
+        $headings['h2'] = $h2s->length;
+
+        $anchors = $doc->getElementsByTagName('a');
+        foreach ($anchors as $anchor) {
+            $text = strtolower(trim($anchor->textContent));
+            if ($text !== '') {
+                foreach ($genericLinkTerms as $term) {
+                    if ($text === $term) {
+                        $genericLinks++;
+                        break;
+                    }
+                }
+            }
+        }
+
+        $landmarkTags = ['main', 'nav', 'header', 'footer'];
+        foreach ($landmarkTags as $tag) {
+            $landmarks += $doc->getElementsByTagName($tag)->length;
+        }
+    }
+
+    $issues = [];
+
+    if ($missingAlt > 0) {
+        $issues[] = sprintf('%d images missing alt text', $missingAlt);
+        $summary['missing_alt'] += $missingAlt;
+    }
+
+    if ($headings['h1'] === 0) {
+        $issues[] = 'No H1 heading found';
+    } elseif ($headings['h1'] > 1) {
+        $issues[] = 'Multiple H1 headings detected';
+    }
+
+    if ($genericLinks > 0) {
+        $issues[] = sprintf('%d link(s) use generic text', $genericLinks);
+    }
+
+    if ($landmarks === 0) {
+        $issues[] = 'Consider adding landmark elements (main, nav, header, footer)';
+    }
+
+    if (empty($issues)) {
+        $summary['accessible']++;
+    } else {
+        $summary['needs_review']++;
+    }
+
+    $report[] = [
+        'title' => $title,
+        'slug' => $slug,
+        'image_count' => $imageCount,
+        'missing_alt' => $missingAlt,
+        'headings' => $headings,
+        'generic_links' => $genericLinks,
+        'landmarks' => $landmarks,
+        'issues' => $issues,
+    ];
+}
+?>
+<div class="content-section" id="accessibility">
+    <div class="table-card">
+        <div class="table-header">
+            <div class="table-title">Accessibility Insights</div>
+            <div class="table-actions">
+                <input type="text" id="a11ySearch" class="table-search" placeholder="Filter pages..." aria-label="Filter accessibility rows">
+            </div>
+        </div>
+
+        <div class="stats-grid">
+            <div class="stat-card" data-a11y-filter="all">
+                <div class="stat-header">
+                    <div class="stat-icon accessibility">♿</div>
+                    <div class="stat-content">
+                        <div class="stat-label">Total Pages</div>
+                        <div class="stat-number"><?php echo count($report); ?></div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card" data-a11y-filter="accessible">
+                <div class="stat-header">
+                    <div class="stat-icon accessibility">✅</div>
+                    <div class="stat-content">
+                        <div class="stat-label">No Issues</div>
+                        <div class="stat-number"><?php echo $summary['accessible']; ?></div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card" data-a11y-filter="review">
+                <div class="stat-header">
+                    <div class="stat-icon accessibility">⚠️</div>
+                    <div class="stat-content">
+                        <div class="stat-label">Needs Review</div>
+                        <div class="stat-number"><?php echo $summary['needs_review']; ?></div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card" data-a11y-filter="alt">
+                <div class="stat-header">
+                    <div class="stat-icon accessibility">🖼️</div>
+                    <div class="stat-content">
+                        <div class="stat-label">Missing Alt Text</div>
+                        <div class="stat-number"><?php echo $summary['missing_alt']; ?></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <table class="data-table" id="accessibilityTable">
+            <thead>
+                <tr>
+                    <th>Page</th>
+                    <th>Images</th>
+                    <th>Headings</th>
+                    <th>Links</th>
+                    <th>Landmarks</th>
+                    <th>Issues</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($report as $entry): ?>
+                    <?php
+                        $statuses = [];
+                        if (empty($entry['issues'])) {
+                            $statuses[] = 'accessible';
+                        } else {
+                            $statuses[] = 'review';
+                        }
+                        if ($entry['missing_alt'] > 0) {
+                            $statuses[] = 'alt';
+                        }
+                        $rowStatus = implode(' ', $statuses);
+                    ?>
+                    <tr data-status="<?php echo htmlspecialchars($rowStatus); ?>">
+                        <td>
+                            <div class="cell-title"><?php echo htmlspecialchars($entry['title']); ?></div>
+                            <div class="cell-subtext">/<?php echo htmlspecialchars($entry['slug']); ?></div>
+                        </td>
+                        <td>
+                            <div><?php echo $entry['image_count']; ?> total</div>
+                            <?php if ($entry['missing_alt'] > 0): ?>
+                                <span class="status-badge status-critical"><?php echo $entry['missing_alt']; ?> missing alt</span>
+                            <?php else: ?>
+                                <span class="status-badge status-good">All described</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <div>H1: <?php echo $entry['headings']['h1']; ?></div>
+                            <div>H2: <?php echo $entry['headings']['h2']; ?></div>
+                        </td>
+                        <td>
+                            <?php if ($entry['generic_links'] > 0): ?>
+                                <span class="status-badge status-warning"><?php echo $entry['generic_links']; ?> generic</span>
+                            <?php else: ?>
+                                <span class="status-badge status-good">Descriptive</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php if ($entry['landmarks'] > 0): ?>
+                                <span class="status-badge status-good"><?php echo $entry['landmarks']; ?> landmark(s)</span>
+                            <?php else: ?>
+                                <span class="status-badge status-warning">None detected</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php if (!empty($entry['issues'])): ?>
+                                <ul class="issue-list">
+                                    <?php foreach ($entry['issues'] as $issue): ?>
+                                        <li><?php echo htmlspecialchars($issue); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php else: ?>
+                                <span class="issue-none">No outstanding issues</span>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/CMS/modules/seo/seo.js
+++ b/CMS/modules/seo/seo.js
@@ -1,0 +1,36 @@
+$(function () {
+    const $rows = $('#seoTable tbody tr');
+    const $search = $('#seoSearch');
+    let activeFilter = 'all';
+
+    function applyFilters() {
+        const query = $search.val().toLowerCase();
+
+        $rows.each(function () {
+            const $row = $(this);
+            const matchesText = query === '' || $row.text().toLowerCase().indexOf(query) !== -1;
+            const status = ($row.data('status') || '').toString();
+            const matchesFilter =
+                activeFilter === 'all' || status.split(' ').includes(activeFilter);
+
+            if (matchesText && matchesFilter) {
+                $row.show();
+            } else {
+                $row.hide();
+            }
+        });
+    }
+
+    $search.on('input', applyFilters);
+
+    $('[data-seo-filter]').on('click', function () {
+        const $card = $(this);
+        activeFilter = $card.data('seo-filter');
+
+        $('[data-seo-filter]').removeClass('active');
+        $card.addClass('active');
+        applyFilters();
+    });
+
+    $('[data-seo-filter="all"]').addClass('active');
+});

--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -1,0 +1,205 @@
+<?php
+// File: modules/seo/view.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
+
+$pagesFile = __DIR__ . '/../../data/pages.json';
+$pages = read_json_file($pagesFile);
+
+$report = [];
+$summary = [
+    'optimized' => 0,
+    'needs_attention' => 0,
+    'metadata_gaps' => 0,
+];
+
+foreach ($pages as $page) {
+    $title = $page['title'] ?? 'Untitled';
+    $slug = $page['slug'] ?? '';
+
+    $metaTitle = trim($page['meta_title'] ?? '');
+    $metaDescription = trim($page['meta_description'] ?? '');
+    $ogTitle = trim($page['og_title'] ?? '');
+    $ogDescription = trim($page['og_description'] ?? '');
+    $ogImage = trim($page['og_image'] ?? '');
+
+    $metaTitleLength = $metaTitle !== '' ? mb_strlen($metaTitle) : 0;
+    $metaDescriptionLength = $metaDescription !== '' ? mb_strlen($metaDescription) : 0;
+
+    $issues = [];
+    $metaTitleStatus = 'good';
+    $metaDescriptionStatus = 'good';
+
+    if ($metaTitle === '') {
+        $issues[] = 'Meta title missing';
+        $metaTitleStatus = 'critical';
+        $summary['metadata_gaps']++;
+    } elseif ($metaTitleLength < 30 || $metaTitleLength > 60) {
+        $issues[] = 'Meta title length outside 30-60 characters';
+        $metaTitleStatus = 'warning';
+    }
+
+    if ($metaDescription === '') {
+        $issues[] = 'Meta description missing';
+        $metaDescriptionStatus = 'critical';
+        $summary['metadata_gaps']++;
+    } elseif ($metaDescriptionLength < 50 || $metaDescriptionLength > 160) {
+        $issues[] = 'Meta description length outside 50-160 characters';
+        $metaDescriptionStatus = 'warning';
+    }
+
+    if ($slug === '' || !preg_match('/^[a-z0-9\-]+$/', $slug)) {
+        $issues[] = 'Slug should use lowercase letters, numbers, and dashes only';
+    }
+
+    $hasSocialPreview = $ogTitle !== '' && $ogDescription !== '' && $ogImage !== '';
+    if (!$hasSocialPreview) {
+        $issues[] = 'Social preview incomplete (requires OG title, description, and image)';
+    }
+
+    if (empty($issues)) {
+        $summary['optimized']++;
+    } else {
+        $summary['needs_attention']++;
+    }
+
+    $report[] = [
+        'title' => $title,
+        'slug' => $slug,
+        'meta_title' => $metaTitle,
+        'meta_title_length' => $metaTitleLength,
+        'meta_title_status' => $metaTitleStatus,
+        'meta_description' => $metaDescription,
+        'meta_description_length' => $metaDescriptionLength,
+        'meta_description_status' => $metaDescriptionStatus,
+        'has_social' => $hasSocialPreview,
+        'issues' => $issues,
+    ];
+}
+?>
+<div class="content-section" id="seo">
+    <div class="table-card">
+        <div class="table-header">
+            <div class="table-title">SEO Overview</div>
+            <div class="table-actions">
+                <input type="text" id="seoSearch" class="table-search" placeholder="Filter pages..." aria-label="Filter SEO rows">
+            </div>
+        </div>
+
+        <div class="stats-grid">
+            <div class="stat-card" data-seo-filter="all">
+                <div class="stat-header">
+                    <div class="stat-icon seo">🔎</div>
+                    <div class="stat-content">
+                        <div class="stat-label">Total Pages</div>
+                        <div class="stat-number"><?php echo count($report); ?></div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card" data-seo-filter="optimized">
+                <div class="stat-header">
+                    <div class="stat-icon seo">✅</div>
+                    <div class="stat-content">
+                        <div class="stat-label">Optimized</div>
+                        <div class="stat-number"><?php echo $summary['optimized']; ?></div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card" data-seo-filter="attention">
+                <div class="stat-header">
+                    <div class="stat-icon seo">⚠️</div>
+                    <div class="stat-content">
+                        <div class="stat-label">Needs Attention</div>
+                        <div class="stat-number"><?php echo $summary['needs_attention']; ?></div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card" data-seo-filter="metadata">
+                <div class="stat-header">
+                    <div class="stat-icon seo">📝</div>
+                    <div class="stat-content">
+                        <div class="stat-label">Metadata Gaps</div>
+                        <div class="stat-number"><?php echo $summary['metadata_gaps']; ?></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <table class="data-table" id="seoTable">
+            <thead>
+                <tr>
+                    <th>Page</th>
+                    <th>Meta Title</th>
+                    <th>Meta Description</th>
+                    <th>Slug</th>
+                    <th>Social Preview</th>
+                    <th>Issues</th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php foreach ($report as $entry): ?>
+                    <?php
+                        $statuses = [];
+                        if (empty($entry['issues'])) {
+                            $statuses[] = 'optimized';
+                        } else {
+                            $statuses[] = 'attention';
+                        }
+                        if ($entry['meta_title'] === '' || $entry['meta_description'] === '') {
+                            $statuses[] = 'metadata';
+                        }
+                        $rowStatus = implode(' ', $statuses);
+                    ?>
+                    <tr data-status="<?php echo htmlspecialchars($rowStatus); ?>">
+                        <td>
+                            <div class="cell-title"><?php echo htmlspecialchars($entry['title']); ?></div>
+                            <div class="cell-subtext">/<?php echo htmlspecialchars($entry['slug']); ?></div>
+                        </td>
+                        <td>
+                            <?php if ($entry['meta_title'] !== ''): ?>
+                                <div><?php echo htmlspecialchars($entry['meta_title']); ?></div>
+                                <span class="status-badge status-<?php echo htmlspecialchars($entry['meta_title_status']); ?>">
+                                    <?php echo $entry['meta_title_length']; ?> chars
+                                </span>
+                            <?php else: ?>
+                                <span class="status-badge status-critical">Missing</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php if ($entry['meta_description'] !== ''): ?>
+                                <div class="cell-muted"><?php echo htmlspecialchars($entry['meta_description']); ?></div>
+                                <span class="status-badge status-<?php echo htmlspecialchars($entry['meta_description_status']); ?>">
+                                    <?php echo $entry['meta_description_length']; ?> chars
+                                </span>
+                            <?php else: ?>
+                                <span class="status-badge status-critical">Missing</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <code>/<?php echo htmlspecialchars($entry['slug']); ?></code>
+                        </td>
+                        <td>
+                            <?php if ($entry['has_social']): ?>
+                                <span class="status-badge status-good">Complete</span>
+                            <?php else: ?>
+                                <span class="status-badge status-warning">Incomplete</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php if (!empty($entry['issues'])): ?>
+                                <ul class="issue-list">
+                                    <?php foreach ($entry['issues'] as $issue): ?>
+                                        <li><?php echo htmlspecialchars($issue); ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php else: ?>
+                                <span class="issue-none">No outstanding issues</span>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -288,6 +288,11 @@
             transform: translateY(-2px);
         }
 
+        .stat-card[data-seo-filter],
+        .stat-card[data-a11y-filter] {
+            cursor: pointer;
+        }
+
         .stat-header {
             display: flex;
             align-items: center;
@@ -319,6 +324,20 @@
         .stat-icon.media {
             background: linear-gradient(135deg, #ed8936, #dd6b20);
             color: white;
+        }
+
+        .stat-icon.seo {
+            background: linear-gradient(135deg, #38b2ac, #319795);
+            color: white;
+        }
+
+        .stat-icon.accessibility {
+            background: linear-gradient(135deg, #805ad5, #6b46c1);
+            color: white;
+        }
+
+        .stat-card.active {
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.35);
         }
 
         .stat-icon.views {
@@ -404,6 +423,20 @@
             gap: 10px;
         }
 
+        .table-search {
+            padding: 8px 12px;
+            border: 1px solid #cbd5e0;
+            border-radius: 8px;
+            font-size: 14px;
+            min-width: 200px;
+        }
+
+        .table-search:focus {
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.25);
+        }
+
         .btn {
             padding: 8px 16px;
             border: none;
@@ -476,12 +509,43 @@
             background: #f7fafc;
         }
 
+        .cell-title {
+            font-weight: 600;
+            color: #2d3748;
+        }
+
+        .cell-subtext {
+            font-size: 12px;
+            color: #718096;
+            margin-top: 4px;
+        }
+
+        .cell-muted {
+            color: #4a5568;
+            font-size: 13px;
+        }
+
         .status-badge {
             display: inline-block;
             padding: 4px 12px;
             border-radius: 20px;
             font-size: 12px;
             font-weight: 500;
+        }
+
+        .status-good {
+            background: #c6f6d5;
+            color: #22543d;
+        }
+
+        .status-warning {
+            background: #fefcbf;
+            color: #744210;
+        }
+
+        .status-critical {
+            background: #fed7d7;
+            color: #742a2a;
         }
 
         .status-published {
@@ -497,6 +561,21 @@
         .status-archived {
             background: #e2e8f0;
             color: #4a5568;
+        }
+
+        .issue-list {
+            margin: 0;
+            padding-left: 18px;
+            color: #4a5568;
+        }
+
+        .issue-list li + li {
+            margin-top: 4px;
+        }
+
+        .issue-none {
+            color: #2f855a;
+            font-weight: 500;
         }
 
         .home-badge {


### PR DESCRIPTION
## Summary
- add SEO dashboard module that audits page metadata, surfaces key counts, and supports quick filtering in the System menu
- introduce an accessibility insights module that reviews headings, alternative text, link clarity, and landmark usage for each page
- update admin styling to support the new dashboard cards, badges, and table search inputs

## Testing
- php -l CMS/modules/seo/view.php
- php -l CMS/modules/accessibility/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d5cc02d24c8331a0c5ec71af28c657