### PR TITLE
Enhance dashboard metrics with SEO and accessibility insights

### DIFF
--- a/CMS/modules/dashboard/dashboard.js
+++ b/CMS/modules/dashboard/dashboard.js
@@ -1,11 +1,68 @@
 // File: dashboard.js
 $(function(){
+    function formatNumber(value) {
+        if (typeof value === 'number') {
+            return value.toLocaleString();
+        }
+        const numeric = parseInt(value, 10);
+        if (Number.isNaN(numeric)) {
+            return '0';
+        }
+        return numeric.toLocaleString();
+    }
+
+    function formatPercent(value) {
+        if (typeof value !== 'number') {
+            value = parseFloat(value);
+        }
+        if (!Number.isFinite(value)) {
+            value = 0;
+        }
+        return `${Math.round(value)}%`;
+    }
+
+    function updateText(selector, value, formatter) {
+        const $el = $(selector);
+        if (!$el.length) {
+            return;
+        }
+        const output = typeof formatter === 'function' ? formatter(value) : formatNumber(value);
+        $el.text(output);
+    }
+
     function loadStats(){
         $.getJSON('modules/dashboard/dashboard_data.php', function(data){
-            $('#statPages').text(data.pages);
-            $('#statMedia').text(data.media);
-            $('#statUsers').text(data.users);
-            $('#statViews').text(data.views);
+            updateText('#statPages', data.pages);
+            updateText('#statMedia', data.media);
+            updateText('#statUsers', data.users);
+            updateText('#statViews', data.views);
+
+            updateText('#statSeoScore', data.seoScore, formatPercent);
+            updateText('#statSeoBreakdown', [data.seoOptimized, data.seoNeedsAttention], function(values){
+                const optimized = formatNumber(values[0]);
+                const attention = formatNumber(values[1]);
+                return `Optimized: ${optimized} • Needs attention: ${attention}`;
+            });
+            updateText('#statSeoMetadata', data.seoMetadataGaps, function(value){
+                return `Metadata gaps: ${formatNumber(value)}`;
+            });
+
+            updateText('#statAccessibilityScore', data.accessibilityScore, formatPercent);
+            updateText('#statAccessibilityBreakdown', [data.accessibilityCompliant, data.accessibilityNeedsReview], function(values){
+                const compliant = formatNumber(values[0]);
+                const review = formatNumber(values[1]);
+                return `Compliant: ${compliant} • Needs review: ${review}`;
+            });
+            updateText('#statAccessibilityAlt', data.accessibilityMissingAlt, function(value){
+                return `Alt text issues: ${formatNumber(value)}`;
+            });
+
+            updateText('#statAlerts', data.openAlerts);
+            updateText('#statAlertsBreakdown', [data.alertsSeo, data.alertsAccessibility], function(values){
+                const seo = formatNumber(values[0]);
+                const accessibility = formatNumber(values[1]);
+                return `SEO: ${seo} • Accessibility: ${accessibility}`;
+            });
         });
     }
     loadStats();

--- a/CMS/modules/dashboard/dashboard_data.php
+++ b/CMS/modules/dashboard/dashboard_data.php
@@ -7,21 +7,254 @@ require_login();
 $pagesFile = __DIR__ . '/../../data/pages.json';
 $mediaFile = __DIR__ . '/../../data/media.json';
 $usersFile = __DIR__ . '/../../data/users.json';
+$settingsFile = __DIR__ . '/../../data/settings.json';
+$menusFile = __DIR__ . '/../../data/menus.json';
 
 $pages = read_json_file($pagesFile);
 $media = read_json_file($mediaFile);
 $users = read_json_file($usersFile);
+$settings = read_json_file($settingsFile);
+$menus = read_json_file($menusFile);
+
+if (!is_array($pages)) {
+    $pages = [];
+}
+if (!is_array($media)) {
+    $media = [];
+}
+if (!is_array($users)) {
+    $users = [];
+}
+if (!is_array($settings)) {
+    $settings = [];
+}
+if (!is_array($menus)) {
+    $menus = [];
+}
 
 $views = 0;
 foreach ($pages as $p) {
     $views += $p['views'] ?? 0;
 }
 
+$seoSummary = [
+    'optimized' => 0,
+    'needs_attention' => 0,
+    'metadata_gaps' => 0,
+];
+
+$stringLength = function (string $value): int {
+    if (function_exists('mb_strlen')) {
+        return mb_strlen($value);
+    }
+    return strlen($value);
+};
+
+foreach ($pages as $page) {
+    $metaTitle = trim((string)($page['meta_title'] ?? ''));
+    $metaDescription = trim((string)($page['meta_description'] ?? ''));
+    $ogTitle = trim((string)($page['og_title'] ?? ''));
+    $ogDescription = trim((string)($page['og_description'] ?? ''));
+    $ogImage = trim((string)($page['og_image'] ?? ''));
+
+    $issues = [];
+
+    if ($metaTitle === '') {
+        $issues[] = 'meta_title_missing';
+        $seoSummary['metadata_gaps']++;
+    } else {
+        $length = $stringLength($metaTitle);
+        if ($length < 30 || $length > 60) {
+            $issues[] = 'meta_title_length';
+        }
+    }
+
+    if ($metaDescription === '') {
+        $issues[] = 'meta_description_missing';
+        $seoSummary['metadata_gaps']++;
+    } else {
+        $length = $stringLength($metaDescription);
+        if ($length < 50 || $length > 160) {
+            $issues[] = 'meta_description_length';
+        }
+    }
+
+    $slug = (string)($page['slug'] ?? '');
+    if ($slug === '' || !preg_match('/^[a-z0-9\-]+$/', $slug)) {
+        $issues[] = 'slug_format';
+    }
+
+    if ($ogTitle === '' || $ogDescription === '' || $ogImage === '') {
+        $issues[] = 'social_preview';
+    }
+
+    if (empty($issues)) {
+        $seoSummary['optimized']++;
+    } else {
+        $seoSummary['needs_attention']++;
+    }
+}
+
+$seoTotal = count($pages);
+$seoScore = $seoTotal > 0 ? round(($seoSummary['optimized'] / $seoTotal) * 100) : 0;
+
+$scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+if (substr($scriptBase, -4) === '/CMS') {
+    $scriptBase = substr($scriptBase, 0, -4);
+}
+$scriptBase = rtrim($scriptBase, '/');
+
+$templateDir = realpath(__DIR__ . '/../../../theme/templates/pages');
+
+function dashboard_capture_template_html(string $templateFile, array $settings, array $menus, string $scriptBase): string {
+    $page = ['content' => '{{CONTENT}}'];
+    $themeBase = $scriptBase . '/theme';
+    ob_start();
+    include $templateFile;
+    $html = ob_get_clean();
+    $html = preg_replace('/<div class="drop-area"><\/div>/', '{{CONTENT}}', $html, 1);
+    if (strpos($html, '{{CONTENT}}') === false) {
+        $html .= '{{CONTENT}}';
+    }
+    $html = preg_replace('#<templateSetting[^>]*>.*?</templateSetting>#si', '', $html);
+    $html = preg_replace('#<div class="block-controls"[^>]*>.*?</div>#si', '', $html);
+    $html = str_replace('draggable="true"', '', $html);
+    $html = preg_replace('#\sdata-ts="[^"]*"#i', '', $html);
+    $html = preg_replace('#\sdata-(?:blockid|template|original|active|custom_[A-Za-z0-9_-]+)="[^"]*"#i', '', $html);
+    return $html;
+}
+
+function dashboard_build_page_html(array $page, array $settings, array $menus, string $scriptBase, ?string $templateDir): string {
+    static $templateCache = [];
+
+    if (!$templateDir) {
+        return (string)($page['content'] ?? '');
+    }
+
+    $templateName = !empty($page['template']) ? basename((string)$page['template']) : 'page.php';
+    $templateFile = $templateDir . DIRECTORY_SEPARATOR . $templateName;
+    if (!is_file($templateFile)) {
+        return (string)($page['content'] ?? '');
+    }
+
+    if (!isset($templateCache[$templateFile])) {
+        $templateCache[$templateFile] = dashboard_capture_template_html($templateFile, $settings, $menus, $scriptBase);
+    }
+
+    $templateHtml = $templateCache[$templateFile];
+    $content = (string)($page['content'] ?? '');
+    return str_replace('{{CONTENT}}', $content, $templateHtml);
+}
+
+$libxmlPrevious = libxml_use_internal_errors(true);
+
+$accessibilitySummary = [
+    'accessible' => 0,
+    'needs_review' => 0,
+    'missing_alt' => 0,
+    'issues' => 0,
+];
+
+$genericLinkTerms = [
+    'click here',
+    'read more',
+    'learn more',
+    'here',
+    'more',
+    'this page',
+];
+
+foreach ($pages as $page) {
+    $pageHtml = dashboard_build_page_html($page, $settings, $menus, $scriptBase, $templateDir);
+
+    $doc = new DOMDocument();
+    $loaded = trim($pageHtml) !== '' && $doc->loadHTML('<?xml encoding="utf-8" ?>' . $pageHtml);
+
+    $missingAlt = 0;
+    $genericLinks = 0;
+    $landmarks = 0;
+    $h1Count = 0;
+
+    if ($loaded) {
+        $images = $doc->getElementsByTagName('img');
+        foreach ($images as $img) {
+            $alt = trim($img->getAttribute('alt'));
+            if ($alt === '') {
+                $missingAlt++;
+            }
+        }
+
+        $h1Count = $doc->getElementsByTagName('h1')->length;
+
+        $anchors = $doc->getElementsByTagName('a');
+        foreach ($anchors as $anchor) {
+            $text = strtolower(trim($anchor->textContent));
+            if ($text !== '') {
+                foreach ($genericLinkTerms as $term) {
+                    if ($text === $term) {
+                        $genericLinks++;
+                        break;
+                    }
+                }
+            }
+        }
+
+        $landmarkTags = ['main', 'nav', 'header', 'footer'];
+        foreach ($landmarkTags as $tag) {
+            $landmarks += $doc->getElementsByTagName($tag)->length;
+        }
+    }
+
+    $issues = [];
+
+    if ($missingAlt > 0) {
+        $issues[] = 'missing_alt';
+        $accessibilitySummary['missing_alt'] += $missingAlt;
+    }
+
+    if ($h1Count === 0 || $h1Count > 1) {
+        $issues[] = 'h1_count';
+    }
+
+    if ($genericLinks > 0) {
+        $issues[] = 'generic_links';
+    }
+
+    if ($landmarks === 0) {
+        $issues[] = 'landmarks';
+    }
+
+    if (empty($issues)) {
+        $accessibilitySummary['accessible']++;
+    } else {
+        $accessibilitySummary['needs_review']++;
+    }
+
+    $accessibilitySummary['issues'] += count($issues);
+}
+
+libxml_clear_errors();
+libxml_use_internal_errors($libxmlPrevious);
+
+$totalPages = count($pages);
+$accessibilityScore = $totalPages > 0 ? round(($accessibilitySummary['accessible'] / $totalPages) * 100) : 0;
+
 $data = [
-    'pages' => count($pages),
+    'pages' => $totalPages,
     'media' => count($media),
     'users' => count($users),
     'views' => $views,
+    'seoScore' => $seoScore,
+    'seoOptimized' => $seoSummary['optimized'],
+    'seoNeedsAttention' => $seoSummary['needs_attention'],
+    'seoMetadataGaps' => $seoSummary['metadata_gaps'],
+    'accessibilityScore' => $accessibilityScore,
+    'accessibilityCompliant' => $accessibilitySummary['accessible'],
+    'accessibilityNeedsReview' => $accessibilitySummary['needs_review'],
+    'accessibilityMissingAlt' => $accessibilitySummary['missing_alt'],
+    'openAlerts' => $seoSummary['needs_attention'] + $accessibilitySummary['needs_review'],
+    'alertsSeo' => $seoSummary['needs_attention'],
+    'alertsAccessibility' => $accessibilitySummary['needs_review'],
 ];
 
 header('Content-Type: application/json');

--- a/CMS/modules/dashboard/view.php
+++ b/CMS/modules/dashboard/view.php
@@ -37,6 +37,38 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon seo">🔎</div>
+                                <div class="stat-content">
+                                    <div class="stat-label">SEO Health</div>
+                                    <div class="stat-number" id="statSeoScore">0%</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statSeoBreakdown">Optimized: 0 • Needs attention: 0</div>
+                            <div class="stat-subtext" id="statSeoMetadata">Metadata gaps: 0</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon accessibility">♿</div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Accessibility</div>
+                                    <div class="stat-number" id="statAccessibilityScore">0%</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statAccessibilityBreakdown">Compliant: 0 • Needs review: 0</div>
+                            <div class="stat-subtext" id="statAccessibilityAlt">Alt text issues: 0</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon alerts">⚠️</div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Open Alerts</div>
+                                    <div class="stat-number" id="statAlerts">0</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statAlertsBreakdown">SEO: 0 • Accessibility: 0</div>
+                        </div>
                     </div>
                 </div>
 

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -336,6 +336,11 @@
             color: white;
         }
 
+        .stat-icon.alerts {
+            background: linear-gradient(135deg, #f6ad55, #dd6b20);
+            color: white;
+        }
+
         .stat-card.active {
             box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.35);
         }
@@ -359,6 +364,12 @@
             font-size: 14px;
             color: #718096;
             margin-bottom: 5px;
+        }
+
+        .stat-subtext {
+            font-size: 13px;
+            color: #a0aec0;
+            margin-top: 6px;
         }
 
         .stat-change {


### PR DESCRIPTION
## Summary
- add SEO, accessibility, and alert stat cards to the dashboard view
- compute SEO and accessibility aggregates for the dashboard data endpoint
- format dashboard stat updates for human-friendly numbers and percentages

## Testing
- php -l CMS/modules/dashboard/dashboard_data.php
- php -l CMS/modules/dashboard/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d6ae9871a08331ac602269cb4daac1