### PR TITLE
Remove maps module

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -74,10 +74,6 @@ $settings = get_cached_json($settingsFile);
                         <div class="nav-icon"><i class="fas fa-clipboard"></i></div>
                         <div class="nav-text">Forms</div>
                     </div>
-                    <div class="nav-item" data-section="maps">
-                        <div class="nav-icon"><i class="fas fa-map-marked-alt"></i></div>
-                        <div class="nav-text">Maps</div>
-                    </div>
                 </div>
 
                 <div class="nav-section">

--- a/CMS/modules/maps/_notes/dwsync.xml
+++ b/CMS/modules/maps/_notes/dwsync.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!-- File: dwsync.xml -->
-<dwsync>
-<file name="view.php" server="access-5016403829.webspace-host.com" local="133963212536585971" remote="133963213620000000" Dst="2" />
-</dwsync>

--- a/CMS/modules/maps/view.php
+++ b/CMS/modules/maps/view.php
@@ -1,6 +1,0 @@
-<!-- File: view.php -->
-                <div class="content-section" id="maps">
-                    <h2>Maps</h2>
-                    <p>Map settings will appear here.</p>
-                </div>
-


### PR DESCRIPTION
## Summary
- remove the Maps navigation entry from the admin sidebar
- delete the unused Maps module files

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6af5668f8833199fc489f07ff22a5