### PR TITLE
Remove Import/Export module

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -110,10 +110,6 @@ $settings = get_cached_json($settingsFile);
                         <div class="nav-icon"><i class="fas fa-save"></i></div>
                         <div class="nav-text">Backup</div>
                     </div>
-                    <div class="nav-item" data-section="import">
-                        <div class="nav-icon"><i class="fas fa-file-import"></i></div>
-                        <div class="nav-text">Import/Export</div>
-                    </div>
                     <div class="nav-item" data-section="accessibility">
                         <div class="nav-icon"><i class="fas fa-universal-access"></i></div>
                         <div class="nav-text">Accessibility</div>

--- a/CMS/modules/import_export/_notes/dwsync.xml
+++ b/CMS/modules/import_export/_notes/dwsync.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!-- File: dwsync.xml -->
-<dwsync>
-<file name=".gitkeep" server="access-5016403829.webspace-host.com" local="133963212536477749" remote="133963213610000000" Dst="2" />
-<file name="view.php" server="access-5016403829.webspace-host.com" local="133963212536507684" remote="133963213610000000" Dst="2" />
-</dwsync>

--- a/CMS/modules/import_export/view.php
+++ b/CMS/modules/import_export/view.php
@@ -1,5 +1,0 @@
-<!-- File: view.php -->
-                <div class="content-section" id="import">
-                    <h2>Import/Export</h2>
-                    <p>Import or export CMS data.</p>
-                </div>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Modules live in `CMS/modules` and provide specific functionality:
 - **blogs** – Blog post management
 - **dashboard** – Admin home page
 - **forms** – Contact forms
-- **import_export** – Data migration tools
 - **logs** – View system logs
 - **maps** – Embed maps
 - **media** – Upload and organize media files


### PR DESCRIPTION
## Summary
- remove the Import/Export module directory and its admin navigation entry
- update the README module list to reflect the removal

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6af6b9be883319441703a2a75ceb7