### PR TITLE
Add scan action and detail views to accessibility dashboard

### DIFF
--- a/CMS/modules/accessibility/accessibility.js
+++ b/CMS/modules/accessibility/accessibility.js
@@ -1,23 +1,44 @@
 $(function () {
-    const $rows = $('#accessibilityTable tbody tr');
+    const $summaryRows = $('#accessibilityTable tbody tr.a11y-summary-row');
     const $search = $('#a11ySearch');
-    let activeFilter = 'all';
     const $filters = $('[data-a11y-filter]');
+    const $scanBtn = $('#scanAllPagesBtn');
+    let activeFilter = 'all';
+
+    function hideDetail($button, $detailRow) {
+        $button.attr('aria-expanded', 'false').removeClass('is-active');
+        $button.closest('.a11y-summary-row').attr('data-expanded', 'false');
+        $detailRow.hide().attr('hidden', true);
+    }
+
+    function showDetail($button, $detailRow) {
+        $button.attr('aria-expanded', 'true').addClass('is-active');
+        $button.closest('.a11y-summary-row').attr('data-expanded', 'true');
+        $detailRow.show().attr('hidden', false);
+    }
 
     function applyFilters() {
-        const query = $search.val().toLowerCase();
+        const query = ($search.val() || '').toLowerCase();
 
-        $rows.each(function () {
+        $summaryRows.each(function () {
             const $row = $(this);
-            const matchesText = query === '' || $row.text().toLowerCase().indexOf(query) !== -1;
+            const $detailRow = $row.next('.a11y-detail-row');
+            const combinedText = ($row.text() + ' ' + $detailRow.text()).toLowerCase();
             const status = ($row.data('status') || '').toString();
-            const matchesFilter =
-                activeFilter === 'all' || status.split(' ').includes(activeFilter);
+            const matchesText = query === '' || combinedText.indexOf(query) !== -1;
+            const matchesFilter = activeFilter === 'all' || status.split(' ').includes(activeFilter);
+            const $detailButton = $row.find('.a11y-detail-btn');
 
             if (matchesText && matchesFilter) {
                 $row.show();
+                if ($row.attr('data-expanded') === 'true') {
+                    $detailRow.show().attr('hidden', false);
+                } else {
+                    $detailRow.hide().attr('hidden', true);
+                }
             } else {
                 $row.hide();
+                hideDetail($detailButton, $detailRow);
             }
         });
     }
@@ -25,9 +46,11 @@ $(function () {
     function setActiveFilter(filter) {
         activeFilter = filter;
         $filters.removeClass('active');
-        $filters.filter(function () {
-            return $(this).data('a11y-filter') === filter;
-        }).addClass('active');
+        $filters
+            .filter(function () {
+                return $(this).data('a11y-filter') === filter;
+            })
+            .addClass('active');
         applyFilters();
     }
 
@@ -37,6 +60,47 @@ $(function () {
         const filter = $(this).data('a11y-filter');
         setActiveFilter(filter);
     });
+
+    $summaryRows.find('.a11y-detail-btn').on('click', function () {
+        const $button = $(this);
+        const detailId = $button.attr('aria-controls');
+        const $detailRow = $('#' + detailId);
+        const isExpanded = $button.attr('aria-expanded') === 'true';
+
+        $summaryRows.find('.a11y-detail-btn[aria-expanded="true"]').each(function () {
+            const $openButton = $(this);
+            if ($openButton.is($button)) {
+                return;
+            }
+            const openDetailId = $openButton.attr('aria-controls');
+            hideDetail($openButton, $('#' + openDetailId));
+        });
+
+        if (isExpanded) {
+            hideDetail($button, $detailRow);
+        } else {
+            showDetail($button, $detailRow);
+        }
+    });
+
+    if ($scanBtn.length) {
+        $scanBtn.on('click', function () {
+            const $btn = $(this);
+
+            if ($btn.prop('disabled')) {
+                return;
+            }
+
+            $btn.prop('disabled', true).addClass('is-loading');
+            const $icon = $btn.find('.fa-solid');
+            $icon.removeClass('fa-arrows-rotate').addClass('fa-spinner fa-spin');
+            $btn.find('.a11y-scan-label').text('Scanning...');
+
+            setTimeout(function () {
+                window.location.reload();
+            }, 800);
+        });
+    }
 
     setActiveFilter('all');
 });

--- a/CMS/modules/accessibility/view.php
+++ b/CMS/modules/accessibility/view.php
@@ -184,7 +184,13 @@ libxml_clear_errors();
                 <h2 class="a11y-hero-title">Accessibility Dashboard</h2>
                 <p class="a11y-hero-subtitle">Monitor WCAG compliance and ensure every experience is inclusive.</p>
             </div>
-            <div class="a11y-hero-meta">Last scan: <?php echo htmlspecialchars($lastScan); ?></div>
+            <div class="a11y-hero-actions">
+                <button type="button" id="scanAllPagesBtn" class="a11y-scan-btn">
+                    <span class="a11y-scan-icon" aria-hidden="true"><i class="fa-solid fa-arrows-rotate"></i></span>
+                    <span class="a11y-scan-label">Scan All Pages</span>
+                </button>
+                <div class="a11y-hero-meta">Last scan: <?php echo htmlspecialchars($lastScan); ?></div>
+            </div>
         </div>
         <div class="a11y-hero-stats">
             <button class="a11y-stat-card active" data-a11y-filter="all">
@@ -263,10 +269,11 @@ libxml_clear_errors();
                     <th>Links</th>
                     <th>Landmarks</th>
                     <th>Issues</th>
+                    <th class="a11y-action-header">Actions</th>
                 </tr>
             </thead>
             <tbody>
-                <?php foreach ($report as $entry): ?>
+                <?php foreach ($report as $index => $entry): ?>
                     <?php
                         $statuses = [];
                         if (empty($entry['issues'])) {
@@ -278,8 +285,9 @@ libxml_clear_errors();
                             $statuses[] = 'alt';
                         }
                         $rowStatus = implode(' ', $statuses);
+                        $detailId = 'a11y-details-' . $index;
                     ?>
-                    <tr data-status="<?php echo htmlspecialchars($rowStatus); ?>">
+                    <tr class="a11y-summary-row" data-status="<?php echo htmlspecialchars($rowStatus); ?>" data-expanded="false">
                         <td>
                             <div class="cell-title"><?php echo htmlspecialchars($entry['title']); ?></div>
                             <div class="cell-subtext">/<?php echo htmlspecialchars($entry['slug']); ?></div>
@@ -320,6 +328,61 @@ libxml_clear_errors();
                             <?php else: ?>
                                 <span class="issue-none">No outstanding issues</span>
                             <?php endif; ?>
+                        </td>
+                        <td class="a11y-action-cell">
+                            <button type="button" class="a11y-detail-btn" aria-expanded="false" aria-controls="<?php echo htmlspecialchars($detailId); ?>">
+                                <span class="a11y-detail-icon" aria-hidden="true"><i class="fa-solid fa-chart-pie"></i></span>
+                                <span>View details</span>
+                            </button>
+                        </td>
+                    </tr>
+                    <tr id="<?php echo htmlspecialchars($detailId); ?>" class="a11y-detail-row" data-status="<?php echo htmlspecialchars($rowStatus); ?>" hidden>
+                        <td colspan="7">
+                            <div class="a11y-detail-card">
+                                <div class="a11y-detail-meta">
+                                    <div>
+                                        <span class="a11y-detail-label">Page URL</span>
+                                        <span class="a11y-detail-value">/<?php echo htmlspecialchars($entry['slug']); ?></span>
+                                    </div>
+                                    <div>
+                                        <span class="a11y-detail-label">Last scanned</span>
+                                        <span class="a11y-detail-value"><?php echo htmlspecialchars($lastScan); ?></span>
+                                    </div>
+                                    <div>
+                                        <span class="a11y-detail-label">Landmarks</span>
+                                        <span class="a11y-detail-value"><?php echo $entry['landmarks']; ?></span>
+                                    </div>
+                                </div>
+                                <div class="a11y-detail-grid">
+                                    <div class="a11y-detail-metric">
+                                        <span class="a11y-detail-label">Images</span>
+                                        <span class="a11y-detail-value"><?php echo $entry['image_count']; ?></span>
+                                        <span class="a11y-detail-hint"><?php echo $entry['missing_alt'] > 0 ? $entry['missing_alt'] . ' missing alt' : 'All images described'; ?></span>
+                                    </div>
+                                    <div class="a11y-detail-metric">
+                                        <span class="a11y-detail-label">Headings</span>
+                                        <span class="a11y-detail-value">H1: <?php echo $entry['headings']['h1']; ?> / H2: <?php echo $entry['headings']['h2']; ?></span>
+                                        <span class="a11y-detail-hint">Ensure a single descriptive H1</span>
+                                    </div>
+                                    <div class="a11y-detail-metric">
+                                        <span class="a11y-detail-label">Links</span>
+                                        <span class="a11y-detail-value"><?php echo $entry['generic_links']; ?> generic</span>
+                                        <span class="a11y-detail-hint"><?php echo $entry['generic_links'] > 0 ? 'Improve link text clarity' : 'All links descriptive'; ?></span>
+                                    </div>
+                                </div>
+                                <div class="a11y-detail-issues">
+                                    <h4>Issues detected</h4>
+                                    <?php if (!empty($entry['issues'])): ?>
+                                        <ul>
+                                            <?php foreach ($entry['issues'] as $issue): ?>
+                                                <li><?php echo htmlspecialchars($issue); ?></li>
+                                            <?php endforeach; ?>
+                                        </ul>
+                                    <?php else: ?>
+                                        <p class="a11y-detail-success">This page meets the current automated checks.</p>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
                         </td>
                     </tr>
                 <?php endforeach; ?>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -446,9 +446,15 @@
         .a11y-hero-header {
             display: flex;
             justify-content: space-between;
-            align-items: flex-start;
+            align-items: center;
             gap: 20px;
             margin-bottom: 28px;
+        }
+
+        .a11y-hero-actions {
+            display: flex;
+            align-items: center;
+            gap: 16px;
         }
 
         .a11y-hero-title {
@@ -471,6 +477,41 @@
             display: inline-flex;
             align-items: center;
             gap: 8px;
+        }
+
+        .a11y-scan-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 18px;
+            border-radius: 999px;
+            border: 1px solid rgba(255,255,255,0.45);
+            background: rgba(255,255,255,0.15);
+            color: white;
+            font-weight: 500;
+            font-size: 14px;
+            cursor: pointer;
+            transition: background 0.2s ease, transform 0.2s ease;
+            appearance: none;
+        }
+
+        .a11y-scan-btn:hover {
+            background: rgba(255,255,255,0.25);
+            transform: translateY(-1px);
+        }
+
+        .a11y-scan-btn.is-loading {
+            opacity: 0.8;
+            cursor: wait;
+        }
+
+        .a11y-scan-btn:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(255,255,255,0.45);
+        }
+
+        .a11y-scan-icon {
+            font-size: 16px;
         }
 
         .a11y-hero-stats {
@@ -724,6 +765,135 @@
             font-size: 12px;
             text-transform: uppercase;
             letter-spacing: 0.5px;
+        }
+
+        .a11y-action-header {
+            text-align: right;
+        }
+
+        .a11y-action-cell {
+            text-align: right;
+            width: 1%;
+            white-space: nowrap;
+        }
+
+        .a11y-detail-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 14px;
+            border-radius: 999px;
+            border: 1px solid #cbd5f5;
+            background: #eef2ff;
+            color: #3730a3;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            appearance: none;
+        }
+
+        .a11y-detail-btn:hover,
+        .a11y-detail-btn.is-active {
+            background: linear-gradient(135deg, #7f9cf5, #5a67d8);
+            color: white;
+            border-color: transparent;
+        }
+
+        .a11y-detail-btn:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.4);
+        }
+
+        .a11y-detail-icon {
+            font-size: 14px;
+        }
+
+        .a11y-detail-row {
+            background: #f8fafc;
+        }
+
+        .a11y-detail-row:hover {
+            background: #f8fafc;
+        }
+
+        .a11y-detail-row td {
+            padding-top: 0;
+            padding-bottom: 24px;
+        }
+
+        .a11y-detail-card {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 16px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            box-shadow: 0 12px 24px rgba(148, 163, 184, 0.2);
+        }
+
+        .a11y-detail-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 20px 32px;
+        }
+
+        .a11y-detail-meta > div {
+            min-width: 140px;
+        }
+
+        .a11y-detail-label {
+            display: block;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: #64748b;
+            margin-bottom: 6px;
+        }
+
+        .a11y-detail-value {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .a11y-detail-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 18px;
+        }
+
+        .a11y-detail-metric {
+            background: #f1f5f9;
+            border-radius: 12px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .a11y-detail-hint {
+            font-size: 12px;
+            color: #475569;
+        }
+
+        .a11y-detail-issues h4 {
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 10px;
+            color: #1e293b;
+        }
+
+        .a11y-detail-issues ul {
+            margin: 0;
+            padding-left: 20px;
+            color: #1f2937;
+        }
+
+        .a11y-detail-success {
+            margin: 0;
+            color: #2f855a;
+            font-weight: 500;
         }
 
         .data-table tr:hover {


### PR DESCRIPTION
## Summary
- add a "Scan All Pages" action to the accessibility dashboard hero and restyle supporting elements
- introduce expandable detail rows with a dedicated actions column for each page report
- enhance the dashboard script to manage detail toggles, scanning behavior, and filter/search interactions

## Testing
- php -l CMS/modules/accessibility/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d6b538a8c083319ba39b4e5e5448bf