### PR TITLE
Revamp accessibility dashboard and detail experience

### DIFF
--- a/CMS/modules/accessibility/accessibility.js
+++ b/CMS/modules/accessibility/accessibility.js
@@ -1,106 +1,477 @@
-$(function () {
-    const $summaryRows = $('#accessibilityTable tbody tr.a11y-summary-row');
-    const $search = $('#a11ySearch');
-    const $filters = $('[data-a11y-filter]');
-    const $scanBtn = $('#scanAllPagesBtn');
-    let activeFilter = 'all';
+(function ($) {
+    'use strict';
 
-    function hideDetail($button, $detailRow) {
-        $button.attr('aria-expanded', 'false').removeClass('is-active');
-        $button.closest('.a11y-summary-row').attr('data-expanded', 'false');
-        $detailRow.hide().attr('hidden', true);
-    }
-
-    function showDetail($button, $detailRow) {
-        $button.attr('aria-expanded', 'true').addClass('is-active');
-        $button.closest('.a11y-summary-row').attr('data-expanded', 'true');
-        $detailRow.show().attr('hidden', false);
-    }
-
-    function applyFilters() {
-        const query = ($search.val() || '').toLowerCase();
-
-        $summaryRows.each(function () {
-            const $row = $(this);
-            const $detailRow = $row.next('.a11y-detail-row');
-            const combinedText = ($row.text() + ' ' + $detailRow.text()).toLowerCase();
-            const status = ($row.data('status') || '').toString();
-            const matchesText = query === '' || combinedText.indexOf(query) !== -1;
-            const matchesFilter = activeFilter === 'all' || status.split(' ').includes(activeFilter);
-            const $detailButton = $row.find('.a11y-detail-btn');
-
-            if (matchesText && matchesFilter) {
-                $row.show();
-                if ($row.attr('data-expanded') === 'true') {
-                    $detailRow.show().attr('hidden', false);
-                } else {
-                    $detailRow.hide().attr('hidden', true);
-                }
-            } else {
-                $row.hide();
-                hideDetail($detailButton, $detailRow);
-            }
-        });
-    }
-
-    function setActiveFilter(filter) {
-        activeFilter = filter;
-        $filters.removeClass('active');
-        $filters
-            .filter(function () {
-                return $(this).data('a11y-filter') === filter;
-            })
-            .addClass('active');
-        applyFilters();
-    }
-
-    $search.on('input', applyFilters);
-
-    $filters.on('click', function () {
-        const filter = $(this).data('a11y-filter');
-        setActiveFilter(filter);
-    });
-
-    $summaryRows.find('.a11y-detail-btn').on('click', function () {
-        const $button = $(this);
-        const detailId = $button.attr('aria-controls');
-        const $detailRow = $('#' + detailId);
-        const isExpanded = $button.attr('aria-expanded') === 'true';
-
-        $summaryRows.find('.a11y-detail-btn[aria-expanded="true"]').each(function () {
-            const $openButton = $(this);
-            if ($openButton.is($button)) {
-                return;
-            }
-            const openDetailId = $openButton.attr('aria-controls');
-            hideDetail($openButton, $('#' + openDetailId));
-        });
-
-        if (isExpanded) {
-            hideDetail($button, $detailRow);
-        } else {
-            showDetail($button, $detailRow);
+    function loadAccessibilityModule(params) {
+        const $container = $('#contentContainer');
+        if (!$container.length || typeof $.fn.load !== 'function') {
+            return false;
         }
-    });
 
-    if ($scanBtn.length) {
-        $scanBtn.on('click', function () {
-            const $btn = $(this);
+        const query = params ? ('?' + params) : '';
+        $container.load('modules/accessibility/view.php' + query, function () {
+            $container.find('.content-section').addClass('active');
+            $.getScript('modules/accessibility/accessibility.js').fail(function () {
+                // no-op if the script could not be reloaded
+            });
+        });
+        return true;
+    }
 
-            if ($btn.prop('disabled')) {
-                return;
+    function getScoreClass(score) {
+        if (score >= 90) {
+            return 'a11y-score--aaa';
+        }
+        if (score >= 80) {
+            return 'a11y-score--aa';
+        }
+        if (score >= 60) {
+            return 'a11y-score--partial';
+        }
+        return 'a11y-score--failing';
+    }
+
+    function getLevelBadge(level) {
+        return 'level-' + String(level || '').toLowerCase();
+    }
+
+    function getImpactLabel(impact) {
+        switch (impact) {
+            case 'critical':
+                return 'Critical';
+            case 'serious':
+                return 'Serious';
+            case 'moderate':
+                return 'Moderate';
+            case 'minor':
+                return 'Minor';
+            default:
+                return 'Review';
+        }
+    }
+
+    function formatViolationsSummary(violations) {
+        if (!violations) {
+            return '';
+        }
+        const segments = [];
+        if (violations.critical) {
+            segments.push(violations.critical + ' critical');
+        }
+        if (violations.serious) {
+            segments.push(violations.serious + ' serious');
+        }
+        if (violations.moderate) {
+            segments.push(violations.moderate + ' moderate');
+        }
+        if (violations.minor) {
+            segments.push(violations.minor + ' minor');
+        }
+        if (!segments.length) {
+            return 'No outstanding issues';
+        }
+        return violations.total + ' total (' + segments.join(', ') + ')';
+    }
+
+    function renderMetricList(metrics) {
+        const items = [];
+        if (!metrics) {
+            return '';
+        }
+        const missingAlt = metrics.missingAlt || 0;
+        items.push('<li><span class="label">Images</span><span class="value">' + (metrics.images || 0) + '</span><span class="hint">' + (missingAlt > 0 ? missingAlt + ' missing alt text' : 'All images described') + '</span></li>');
+        items.push('<li><span class="label">Headings</span><span class="value">H1: ' + ((metrics.headings && metrics.headings.h1) || 0) + ' / H2: ' + ((metrics.headings && metrics.headings.h2) || 0) + '</span><span class="hint">Ensure a single descriptive H1</span></li>');
+        items.push('<li><span class="label">Generic links</span><span class="value">' + (metrics.genericLinks || 0) + '</span><span class="hint">' + ((metrics.genericLinks || 0) > 0 ? 'Improve link clarity' : 'All links descriptive') + '</span></li>');
+        items.push('<li><span class="label">Landmarks</span><span class="value">' + (metrics.landmarks || 0) + '</span><span class="hint">' + ((metrics.landmarks || 0) > 0 ? 'Landmarks detected' : 'Add semantic landmarks') + '</span></li>');
+        return items.join('');
+    }
+
+    function filterPages(data, filter, query) {
+        return data.filter(function (page) {
+            const matchesFilter = (function () {
+                switch (filter) {
+                    case 'failing':
+                        return (page.violations && (page.violations.critical > 0 || page.accessibilityScore < 60 || page.wcagLevel === 'Failing'));
+                    case 'partial':
+                        return page.wcagLevel === 'Partial';
+                    case 'compliant':
+                        return page.wcagLevel === 'AA' || page.wcagLevel === 'AAA';
+                    default:
+                        return true;
+                }
+            }());
+
+            if (!matchesFilter) {
+                return false;
             }
 
-            $btn.prop('disabled', true).addClass('is-loading');
-            const $icon = $btn.find('.fa-solid');
-            $icon.removeClass('fa-arrows-rotate').addClass('fa-spinner fa-spin');
-            $btn.find('.a11y-scan-label').text('Scanning...');
+            if (!query) {
+                return true;
+            }
 
-            setTimeout(function () {
-                window.location.reload();
-            }, 800);
+            const haystacks = [
+                page.title || '',
+                page.url || '',
+                page.path || '',
+                (page.pageType || ''),
+                (page.statusMessage || ''),
+            ];
+            if (page.issues && Array.isArray(page.issues.preview)) {
+                haystacks.push(page.issues.preview.join(' '));
+            }
+            return haystacks.join(' ').toLowerCase().indexOf(query) !== -1;
         });
     }
 
-    setActiveFilter('all');
-});
+    function updateFilterPills(data, $buttons) {
+        const counts = {
+            all: data.length,
+            failing: 0,
+            partial: 0,
+            compliant: 0,
+        };
+
+        data.forEach(function (page) {
+            if (page.wcagLevel === 'Partial') {
+                counts.partial += 1;
+            }
+            if (page.wcagLevel === 'AA' || page.wcagLevel === 'AAA') {
+                counts.compliant += 1;
+            }
+            if ((page.violations && page.violations.critical > 0) || page.wcagLevel === 'Failing' || page.accessibilityScore < 60) {
+                counts.failing += 1;
+            }
+        });
+
+        $buttons.each(function () {
+            const $btn = $(this);
+            const type = $btn.data('a11y-filter');
+            const $count = $btn.find('.a11y-filter-count');
+            if ($count.length && Object.prototype.hasOwnProperty.call(counts, type)) {
+                $count.text(counts[type]);
+            }
+        });
+    }
+
+    $(function () {
+        const data = Array.isArray(window.a11yDashboardData) ? window.a11yDashboardData : [];
+        const stats = window.a11yDashboardStats || {};
+        const dataMap = {};
+        data.forEach(function (page) {
+            dataMap[page.slug] = page;
+        });
+
+        const $grid = $('#a11yPagesGrid');
+        const $tableView = $('#a11yTableView');
+        const $tableBody = $('#a11yTableBody');
+        const $empty = $('#a11yEmptyState');
+        const $filterButtons = $('[data-a11y-filter]');
+        const $viewButtons = $('[data-a11y-view]');
+        const $searchInput = $('#a11ySearchInput');
+        const $modal = $('#a11yPageDetail');
+        const $modalClose = $('#a11yDetailClose');
+        const $modalMetrics = $('#a11yDetailMetrics');
+        const $modalIssues = $('#a11yDetailIssues');
+        const $modalScore = $('#a11yDetailScore');
+        const $modalLevel = $('#a11yDetailLevel');
+        const $modalViolations = $('#a11yDetailViolations');
+        const $modalTitle = $('#a11yDetailTitle');
+        const $modalUrl = $('#a11yDetailUrl');
+        const $modalDescription = $('#a11yDetailDescription');
+        const $fullAuditBtn = $modal.find('[data-a11y-action="full-audit"]');
+        const $scanAllBtn = $('#scanAllPagesBtn');
+        const $downloadReportBtn = $('#downloadWcagReport');
+
+        let currentFilter = 'all';
+        let currentView = 'grid';
+        let filteredPages = data.slice();
+        let activeSlug = null;
+
+        function closeModal() {
+            activeSlug = null;
+            $modal.attr('hidden', true).removeClass('is-visible');
+        }
+
+        function openModal(page) {
+            if (!page) {
+                return;
+            }
+            activeSlug = page.slug;
+            $modalTitle.text(page.title || 'Accessibility details');
+            $modalUrl.text(page.url || '');
+            $modalDescription.text(page.summaryLine || page.statusMessage || '');
+            $modalScore.text((page.accessibilityScore || 0) + '%');
+            $modalScore.removeClass('a11y-score--aaa a11y-score--aa a11y-score--partial a11y-score--failing').addClass(getScoreClass(page.accessibilityScore));
+            $modalLevel.text(page.wcagLevel || 'Unknown');
+            $modalLevel.removeClass('level-aaa level-aa level-partial level-failing level-').addClass(getLevelBadge(page.wcagLevel));
+            $modalViolations.text(formatViolationsSummary(page.violations));
+            $modalMetrics.html(renderMetricList(page.metrics));
+
+            if (page.issues && Array.isArray(page.issues.details) && page.issues.details.length) {
+                const issueItems = page.issues.details.map(function (issue) {
+                    const impact = getImpactLabel(issue.impact);
+                    return '<li><span class="issue">' + issue.description + '</span><span class="impact impact-' + issue.impact + '">' + impact + '</span><span class="tip">' + issue.recommendation + '</span></li>';
+                });
+                $modalIssues.html(issueItems.join(''));
+            } else {
+                $modalIssues.html('<li class="no-issues">No outstanding issues detected.</li>');
+            }
+
+            $modal.attr('hidden', false).addClass('is-visible');
+        }
+
+        function createIssueTags(page) {
+            if (!page.issues || !Array.isArray(page.issues.preview)) {
+                return '';
+            }
+            const severityClass = (page.violations && page.violations.critical > 0) ? 'critical' : ((page.violations && page.violations.serious > 0) ? 'serious' : '');
+            return page.issues.preview.map(function (issue) {
+                return '<span class="a11y-issue-tag ' + severityClass + '">' + issue + '</span>';
+            }).join('');
+        }
+
+        function createCard(page) {
+            const $card = $('<article>', {
+                class: 'a11y-page-card',
+                tabindex: 0,
+                role: 'listitem',
+                'data-slug': page.slug
+            });
+
+            const cardHtml = [
+                '<div class="a11y-page-card__header">',
+                '<div class="a11y-page-score ' + getScoreClass(page.accessibilityScore) + '">' + (page.accessibilityScore || 0) + '%</div>',
+                '<h3 class="a11y-page-title">' + (page.title || 'Untitled') + '</h3>',
+                '<p class="a11y-page-url">' + (page.url || '') + '</p>',
+                '</div>',
+                '<div class="a11y-page-card__metrics">',
+                '<div><span class="label">Violations</span><span class="value">' + ((page.violations && page.violations.total) || 0) + '</span></div>',
+                '<div><span class="label">Warnings</span><span class="value">' + (page.warnings || 0) + '</span></div>',
+                '<div><span class="label">WCAG</span><span class="value ' + getLevelBadge(page.wcagLevel) + '">' + (page.wcagLevel || '—') + '</span></div>',
+                '</div>',
+                '<div class="a11y-page-card__issues">',
+                '<div class="a11y-issue-tags">' + createIssueTags(page) + '</div>',
+                '</div>'
+            ].join('');
+
+            $card.html(cardHtml);
+            return $card;
+        }
+
+        function createTableRow(page) {
+            const $row = $('<div>', {
+                class: 'a11y-table-row',
+                role: 'row',
+                'data-slug': page.slug
+            });
+
+            const rowHtml = [
+                '<div class="a11y-table-cell">',
+                '<div class="title">' + (page.title || 'Untitled') + '</div>',
+                '<div class="subtitle">' + (page.url || '') + '</div>',
+                '</div>',
+                '<div class="a11y-table-cell score">',
+                '<span class="a11y-table-score ' + getScoreClass(page.accessibilityScore) + '">' + (page.accessibilityScore || 0) + '%</span>',
+                '</div>',
+                '<div class="a11y-table-cell level"><span class="' + getLevelBadge(page.wcagLevel) + '">' + (page.wcagLevel || '—') + '</span></div>',
+                '<div class="a11y-table-cell">' + formatViolationsSummary(page.violations) + '</div>',
+                '<div class="a11y-table-cell warnings">' + (page.warnings || 0) + '</div>',
+                '<div class="a11y-table-cell">' + (page.lastScanned || '') + '</div>',
+                '<div class="a11y-table-cell actions"><button type="button" class="a11y-btn a11y-btn--icon" data-a11y-action="open-detail" data-slug="' + page.slug + '"><i class="fas fa-universal-access" aria-hidden="true"></i><span class="sr-only">Open detail</span></button></div>'
+            ].join('');
+
+            $row.html(rowHtml);
+            return $row;
+        }
+
+        function render() {
+            if (!$grid.length) {
+                return;
+            }
+
+            if (!filteredPages.length) {
+                $grid.empty().attr('hidden', true);
+                $tableView.attr('hidden', true);
+                $empty.attr('hidden', false);
+                return;
+            }
+
+            $empty.attr('hidden', true);
+
+            if (currentView === 'grid') {
+                $grid.attr('hidden', false);
+                $tableView.attr('hidden', true);
+                $grid.empty();
+                filteredPages.forEach(function (page) {
+                    $grid.append(createCard(page));
+                });
+            } else {
+                $grid.attr('hidden', true).empty();
+                $tableView.attr('hidden', false);
+                $tableBody.empty();
+                filteredPages.forEach(function (page) {
+                    $tableBody.append(createTableRow(page));
+                });
+            }
+        }
+
+        function applyFilters() {
+            const query = ($searchInput.val() || '').toLowerCase();
+            filteredPages = filterPages(data, currentFilter, query);
+            render();
+        }
+
+        if ($grid.length) {
+            updateFilterPills(data, $filterButtons);
+            render();
+        }
+
+        $filterButtons.on('click', function () {
+            const $btn = $(this);
+            currentFilter = $btn.data('a11y-filter') || 'all';
+            $filterButtons.removeClass('active');
+            $btn.addClass('active');
+            applyFilters();
+        });
+
+        $viewButtons.on('click', function () {
+            const $btn = $(this);
+            currentView = $btn.data('a11y-view') || 'grid';
+            $viewButtons.removeClass('active');
+            $btn.addClass('active');
+            render();
+        });
+
+        $searchInput.on('input', function () {
+            applyFilters();
+        });
+
+        $grid.on('click', '.a11y-page-card', function () {
+            const slug = $(this).data('slug');
+            openModal(dataMap[slug]);
+        });
+
+        $grid.on('keydown', '.a11y-page-card', function (event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                const slug = $(this).data('slug');
+                openModal(dataMap[slug]);
+            }
+        });
+
+        $tableBody.on('click', '.a11y-table-row', function (event) {
+            const $target = $(event.target);
+            if ($target.closest('[data-a11y-action="open-detail"]').length) {
+                return;
+            }
+            const slug = $(this).data('slug');
+            openModal(dataMap[slug]);
+        });
+
+        $tableBody.on('click', '[data-a11y-action="open-detail"]', function (event) {
+            event.stopPropagation();
+            const slug = $(this).data('slug');
+            if (!loadAccessibilityModule('page=' + encodeURIComponent(slug))) {
+                if (stats.detailBaseUrl) {
+                    window.location.href = stats.detailBaseUrl + encodeURIComponent(slug);
+                }
+            }
+        });
+
+        if ($modal.length) {
+            $(document).off('keydown.a11yModal');
+            $modal.on('click', function (event) {
+                if (event.target === this) {
+                    closeModal();
+                }
+            });
+
+            $modalClose.on('click', function () {
+                closeModal();
+            });
+
+            $(document).on('keydown.a11yModal', function (event) {
+                if (event.key === 'Escape' && $modal.hasClass('is-visible')) {
+                    closeModal();
+                }
+            });
+
+            $fullAuditBtn.on('click', function () {
+                if (!activeSlug) {
+                    return;
+                }
+                if (!loadAccessibilityModule('page=' + encodeURIComponent(activeSlug))) {
+                    if (stats.detailBaseUrl) {
+                        window.location.href = stats.detailBaseUrl + encodeURIComponent(activeSlug);
+                    }
+                }
+            });
+        }
+
+        if ($scanAllBtn.length) {
+            $scanAllBtn.on('click', function () {
+                const $btn = $(this);
+                if ($btn.prop('disabled')) {
+                    return;
+                }
+                $btn.prop('disabled', true).addClass('is-loading');
+                const $icon = $btn.find('i');
+                const originalIcon = $icon.attr('class');
+                $icon.attr('class', 'fas fa-spinner fa-spin');
+                $btn.find('span').text('Scanning...');
+                setTimeout(function () {
+                    $btn.prop('disabled', false).removeClass('is-loading');
+                    $icon.attr('class', originalIcon);
+                    $btn.find('span').text('Scan All Pages');
+                    if (!loadAccessibilityModule('')) {
+                        window.location.reload();
+                    }
+                }, 900);
+            });
+        }
+
+        if ($downloadReportBtn.length) {
+            $downloadReportBtn.on('click', function () {
+                window.alert('Generating WCAG compliance report...\n\nThe report includes severity breakdowns, remediation recommendations, and scan history.');
+            });
+        }
+
+        const $detailPage = $('#a11yDetailPage');
+        if ($detailPage.length) {
+            const pageSlug = $detailPage.data('page-slug');
+            $('#a11yBackToDashboard').on('click', function (event) {
+                event.preventDefault();
+                if (!loadAccessibilityModule('')) {
+                    if (stats.moduleUrl) {
+                        window.location.href = stats.moduleUrl;
+                    }
+                }
+            });
+
+            $('[data-a11y-action="rescan-page"]').on('click', function () {
+                const $btn = $(this);
+                if ($btn.prop('disabled')) {
+                    return;
+                }
+                const $icon = $btn.find('i');
+                const originalClass = $icon.attr('class');
+                $btn.prop('disabled', true).addClass('is-loading');
+                $icon.attr('class', 'fas fa-spinner fa-spin');
+                setTimeout(function () {
+                    $btn.prop('disabled', false).removeClass('is-loading');
+                    $icon.attr('class', originalClass);
+                    if (!loadAccessibilityModule('page=' + encodeURIComponent(pageSlug))) {
+                        if (stats.detailBaseUrl) {
+                            window.location.href = stats.detailBaseUrl + encodeURIComponent(pageSlug);
+                        }
+                    }
+                }, 900);
+            });
+
+            $('[data-a11y-action="export-page-report"]').on('click', function () {
+                window.alert('Exporting detailed accessibility report for this page...\n\nThe export includes violation breakdowns, remediation steps, and testing history.');
+            });
+        }
+
+        applyFilters();
+    });
+})(jQuery);

--- a/CMS/modules/accessibility/view.php
+++ b/CMS/modules/accessibility/view.php
@@ -2,6 +2,7 @@
 // File: modules/accessibility/view.php
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
@@ -59,15 +60,81 @@ function build_page_html(array $page, array $settings, array $menus, string $scr
     return str_replace('{{CONTENT}}', $content, $templateHtml);
 }
 
+function describe_wcag_level(string $level): string {
+    switch ($level) {
+        case 'AAA':
+            return 'This page exceeds WCAG AA standards with no detected blocking issues.';
+        case 'AA':
+            return 'This page meets WCAG AA accessibility requirements but still has areas to refine.';
+        case 'Partial':
+            return 'This page has partial WCAG compliance and should be prioritized for remediation.';
+        default:
+            return 'This page has critical accessibility blockers that need immediate attention.';
+    }
+}
+
+function summarize_violations(array $violations): string {
+    $parts = [];
+    if (!empty($violations['critical'])) {
+        $parts[] = $violations['critical'] . ' critical';
+    }
+    if (!empty($violations['serious'])) {
+        $parts[] = $violations['serious'] . ' serious';
+    }
+    if (!empty($violations['moderate'])) {
+        $parts[] = $violations['moderate'] . ' moderate';
+    }
+    if (!empty($violations['minor'])) {
+        $parts[] = $violations['minor'] . ' minor';
+    }
+
+    if (empty($parts)) {
+        return 'No outstanding violations detected';
+    }
+
+    return implode(', ', $parts) . ' issue' . ($violations['total'] === 1 ? '' : 's');
+}
+
+function classify_issue_detail(string $issue): array {
+    $lower = strtolower($issue);
+
+    if (strpos($lower, 'alt') !== false) {
+        return [
+            'impact' => 'critical',
+            'recommendation' => 'Provide descriptive alternative text for all meaningful images to support screen reader users.'
+        ];
+    }
+
+    if (strpos($lower, 'h1') !== false) {
+        return [
+            'impact' => 'serious',
+            'recommendation' => 'Ensure each page uses a single, descriptive H1 heading to clarify document structure.'
+        ];
+    }
+
+    if (strpos($lower, 'link') !== false) {
+        return [
+            'impact' => 'moderate',
+            'recommendation' => 'Replace generic link labels with meaningful descriptions of the target destination.'
+        ];
+    }
+
+    if (strpos($lower, 'landmark') !== false) {
+        return [
+            'impact' => 'minor',
+            'recommendation' => 'Add structural landmarks such as <main>, <nav>, <header>, or <footer> for assistive navigation.'
+        ];
+    }
+
+    return [
+        'impact' => 'review',
+        'recommendation' => 'Review this issue to ensure it aligns with WCAG 2.1 AA expectations.'
+    ];
+}
+
 libxml_use_internal_errors(true);
 
 $report = [];
-$summary = [
-    'accessible' => 0,
-    'needs_review' => 0,
-    'missing_alt' => 0,
-];
-$issueCount = 0;
 
 $genericLinkTerms = [
     'click here',
@@ -132,8 +199,7 @@ foreach ($pages as $page) {
     $issues = [];
 
     if ($missingAlt > 0) {
-        $issues[] = sprintf('%d images missing alt text', $missingAlt);
-        $summary['missing_alt'] += $missingAlt;
+        $issues[] = sprintf('%d image%s missing alt text', $missingAlt, $missingAlt === 1 ? ' is' : 's are');
     }
 
     if ($headings['h1'] === 0) {
@@ -143,23 +209,17 @@ foreach ($pages as $page) {
     }
 
     if ($genericLinks > 0) {
-        $issues[] = sprintf('%d link(s) use generic text', $genericLinks);
+        $issues[] = sprintf('%d link%s use generic text', $genericLinks, $genericLinks === 1 ? '' : 's');
     }
 
     if ($landmarks === 0) {
-        $issues[] = 'Consider adding landmark elements (main, nav, header, footer)';
+        $issues[] = 'Add landmark elements (main, nav, header, footer)';
     }
 
-    if (empty($issues)) {
-        $summary['accessible']++;
-    } else {
-        $summary['needs_review']++;
-    }
-
-    $issueCount += count($issues);
     $report[] = [
         'title' => $title,
         'slug' => $slug,
+        'template' => $page['template'] ?? '',
         'image_count' => $imageCount,
         'missing_alt' => $missingAlt,
         'headings' => $headings,
@@ -170,223 +230,407 @@ foreach ($pages as $page) {
 }
 
 $totalPages = count($report);
-$avgCompliance = $totalPages > 0 ? round(($summary['accessible'] / $totalPages) * 100) : 0;
-$criticalIssues = $issueCount;
-$accessibleRate = $avgCompliance;
 $lastScan = date('M j, Y g:i A');
 
+$pageEntries = [];
+$pageEntryMap = [];
+$filterCounts = [
+    'all' => $totalPages,
+    'failing' => 0,
+    'partial' => 0,
+    'compliant' => 0,
+];
+$criticalIssues = 0;
+$aaCompliant = 0;
+$scoreSum = 0;
+
+foreach ($report as $entry) {
+    $slug = $entry['slug'];
+    $path = '/' . ltrim($slug, '/');
+
+    $critical = (int)$entry['missing_alt'];
+    $serious = ($entry['headings']['h1'] === 0 || $entry['headings']['h1'] > 1) ? 1 : 0;
+    $moderate = $entry['generic_links'] > 0 ? 1 : 0;
+    $minor = $entry['landmarks'] === 0 ? 1 : 0;
+    $violationsTotal = $critical + $serious + $moderate + $minor;
+
+    $warnings = ($entry['generic_links'] > 0 ? $entry['generic_links'] : 0) + ($entry['landmarks'] === 0 ? 1 : 0);
+
+    $score = 100;
+    $score -= $critical * 15;
+    $score -= $serious * 12;
+    $score -= $moderate * 8;
+    $score -= $minor * 5;
+    if ($violationsTotal === 0) {
+        $score = 98;
+    }
+    $score = max(0, min(100, $score));
+
+    if ($violationsTotal === 0) {
+        $wcagLevel = 'AAA';
+    } elseif ($critical === 0 && $serious <= 1 && $score >= 80) {
+        $wcagLevel = 'AA';
+    } elseif ($score >= 60) {
+        $wcagLevel = 'Partial';
+    } else {
+        $wcagLevel = 'Failing';
+    }
+
+    if (in_array($wcagLevel, ['AA', 'AAA'], true)) {
+        $aaCompliant++;
+    }
+
+    if ($wcagLevel === 'Partial') {
+        $filterCounts['partial']++;
+    }
+
+    if ($wcagLevel === 'Failing' || $critical > 0 || $score < 60) {
+        $filterCounts['failing']++;
+    }
+
+    if (in_array($wcagLevel, ['AA', 'AAA'], true)) {
+        $filterCounts['compliant']++;
+    }
+
+    $criticalIssues += $critical;
+    $scoreSum += $score;
+
+    $issueDetails = [];
+    foreach ($entry['issues'] as $issueText) {
+        $detail = classify_issue_detail($issueText);
+        $issueDetails[] = [
+            'description' => $issueText,
+            'impact' => $detail['impact'],
+            'recommendation' => $detail['recommendation'],
+        ];
+    }
+
+    $issuePreview = array_slice(array_map(static function ($detail) {
+        return $detail['description'];
+    }, $issueDetails), 0, 4);
+
+    if (empty($issuePreview)) {
+        $issuePreview = ['No outstanding issues'];
+    }
+
+    $violations = [
+        'critical' => $critical,
+        'serious' => $serious,
+        'moderate' => $moderate,
+        'minor' => $minor,
+        'total' => $violationsTotal,
+    ];
+
+    $pageData = [
+        'title' => $entry['title'],
+        'slug' => $slug,
+        'url' => $path,
+        'path' => $path,
+        'template' => $entry['template'],
+        'accessibilityScore' => $score,
+        'wcagLevel' => $wcagLevel,
+        'violations' => $violations,
+        'warnings' => $warnings,
+        'lastScanned' => $lastScan,
+        'pageType' => !empty($entry['template']) ? 'Template: ' . basename($entry['template']) : 'Standard Page',
+        'compliance' => $wcagLevel === 'Failing' ? 'Failing' : ($wcagLevel === 'Partial' ? 'Needs Work' : 'Compliant'),
+        'issues' => [
+            'preview' => $issuePreview,
+            'details' => $issueDetails,
+        ],
+        'metrics' => [
+            'images' => $entry['image_count'],
+            'missingAlt' => $entry['missing_alt'],
+            'headings' => $entry['headings'],
+            'genericLinks' => $entry['generic_links'],
+            'landmarks' => $entry['landmarks'],
+        ],
+    ];
+
+    $pageData['statusMessage'] = describe_wcag_level($wcagLevel);
+    $pageData['summaryLine'] = sprintf(
+        'Current accessibility score: %d%%. %s.',
+        $score,
+        summarize_violations($violations)
+    );
+
+    $pageEntries[] = $pageData;
+    $pageEntryMap[$slug] = $pageData;
+}
+
+$avgScore = $totalPages > 0 ? round($scoreSum / $totalPages) : 0;
+
+$moduleUrl = $_SERVER['PHP_SELF'] . '?module=accessibility';
+$detailSlug = isset($_GET['page']) ? sanitize_text($_GET['page']) : null;
+$detailSlug = $detailSlug !== null ? trim($detailSlug) : null;
+
+$selectedPage = null;
+if ($detailSlug !== null && $detailSlug !== '') {
+    $selectedPage = $pageEntryMap[$detailSlug] ?? null;
+}
+
 libxml_clear_errors();
+
+$dashboardStats = [
+    'totalPages' => $totalPages,
+    'avgScore' => $avgScore,
+    'criticalIssues' => $criticalIssues,
+    'aaCompliant' => $aaCompliant,
+    'filterCounts' => $filterCounts,
+    'moduleUrl' => $moduleUrl,
+    'detailBaseUrl' => $moduleUrl . '&page=',
+    'lastScan' => $lastScan,
+];
 ?>
 <div class="content-section" id="accessibility">
-    <div class="a11y-hero">
-        <div class="a11y-hero-header">
-            <div>
-                <h2 class="a11y-hero-title">Accessibility Dashboard</h2>
-                <p class="a11y-hero-subtitle">Monitor WCAG compliance and ensure every experience is inclusive.</p>
-            </div>
-            <div class="a11y-hero-actions">
-                <button type="button" id="scanAllPagesBtn" class="a11y-scan-btn">
-                    <span class="a11y-scan-icon" aria-hidden="true"><i class="fa-solid fa-arrows-rotate"></i></span>
-                    <span class="a11y-scan-label">Scan All Pages</span>
+<?php if ($selectedPage): ?>
+    <div class="a11y-detail-page" id="a11yDetailPage" data-page-slug="<?php echo htmlspecialchars($selectedPage['slug'], ENT_QUOTES); ?>">
+        <header class="a11y-detail-header">
+            <a href="<?php echo htmlspecialchars($moduleUrl, ENT_QUOTES); ?>" class="a11y-back-link" id="a11yBackToDashboard">
+                <i class="fas fa-arrow-left" aria-hidden="true"></i>
+                <span>Back to Dashboard</span>
+            </a>
+            <div class="a11y-detail-actions">
+                <button type="button" class="a11y-btn a11y-btn--ghost" data-a11y-action="rescan-page">
+                    <i class="fas fa-rotate" aria-hidden="true"></i>
+                    <span>Rescan Page</span>
                 </button>
-                <div class="a11y-hero-meta">Last scan: <?php echo htmlspecialchars($lastScan); ?></div>
+                <button type="button" class="a11y-btn a11y-btn--secondary" data-a11y-action="export-page-report">
+                    <i class="fas fa-file-export" aria-hidden="true"></i>
+                    <span>Export Report</span>
+                </button>
+            </div>
+        </header>
+
+        <section class="a11y-health-card">
+            <div class="a11y-health-score">
+                <div class="a11y-health-score__value"><?php echo (int)$selectedPage['accessibilityScore']; ?><span>%</span></div>
+                <div class="a11y-health-score__label">Accessibility Score</div>
+                <span class="a11y-health-score__badge level-<?php echo strtolower($selectedPage['wcagLevel']); ?>"><?php echo htmlspecialchars($selectedPage['wcagLevel']); ?></span>
+            </div>
+            <div class="a11y-health-summary">
+                <h1><?php echo htmlspecialchars($selectedPage['title']); ?></h1>
+                <p class="a11y-health-url"><?php echo htmlspecialchars($selectedPage['url']); ?></p>
+                <p><?php echo htmlspecialchars($selectedPage['statusMessage']); ?></p>
+                <p class="a11y-health-overview"><?php echo htmlspecialchars($selectedPage['summaryLine']); ?></p>
+                <div class="a11y-quick-stats">
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['images']; ?></div>
+                        <div class="a11y-quick-stat__label">Images</div>
+                    </div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['missingAlt']; ?></div>
+                        <div class="a11y-quick-stat__label">Missing Alt</div>
+                    </div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value">H1: <?php echo $selectedPage['metrics']['headings']['h1']; ?></div>
+                        <div class="a11y-quick-stat__label">Primary Headings</div>
+                    </div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['violations']['critical']; ?></div>
+                        <div class="a11y-quick-stat__label">Critical Issues</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="a11y-detail-grid">
+            <article class="a11y-detail-card">
+                <h2>Key accessibility checks</h2>
+                <div class="a11y-detail-metrics">
+                    <div>
+                        <span class="a11y-detail-metric__label">Images analysed</span>
+                        <span class="a11y-detail-metric__value"><?php echo $selectedPage['metrics']['images']; ?></span>
+                        <span class="a11y-detail-metric__hint"><?php echo $selectedPage['metrics']['missingAlt'] > 0 ? $selectedPage['metrics']['missingAlt'] . ' image(s) missing alt text' : 'All images include alt text'; ?></span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-metric__label">Headings</span>
+                        <span class="a11y-detail-metric__value">H1: <?php echo $selectedPage['metrics']['headings']['h1']; ?> / H2: <?php echo $selectedPage['metrics']['headings']['h2']; ?></span>
+                        <span class="a11y-detail-metric__hint">Ensure a single descriptive H1 per page.</span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-metric__label">Generic links</span>
+                        <span class="a11y-detail-metric__value"><?php echo $selectedPage['metrics']['genericLinks']; ?></span>
+                        <span class="a11y-detail-metric__hint"><?php echo $selectedPage['metrics']['genericLinks'] > 0 ? 'Replace generic link text with descriptive labels.' : 'All links descriptive'; ?></span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-metric__label">Landmarks</span>
+                        <span class="a11y-detail-metric__value"><?php echo $selectedPage['metrics']['landmarks']; ?></span>
+                        <span class="a11y-detail-metric__hint"><?php echo $selectedPage['metrics']['landmarks'] > 0 ? 'Structural landmarks detected' : 'Add semantic landmarks for easier navigation.'; ?></span>
+                    </div>
+                </div>
+            </article>
+            <article class="a11y-detail-card">
+                <h2>WCAG violation breakdown</h2>
+                <ul class="a11y-violation-list">
+                    <li><span>Critical</span><span><?php echo $selectedPage['violations']['critical']; ?></span></li>
+                    <li><span>Serious</span><span><?php echo $selectedPage['violations']['serious']; ?></span></li>
+                    <li><span>Moderate</span><span><?php echo $selectedPage['violations']['moderate']; ?></span></li>
+                    <li><span>Minor</span><span><?php echo $selectedPage['violations']['minor']; ?></span></li>
+                </ul>
+                <div class="a11y-detail-meta">
+                    <div>
+                        <span class="a11y-detail-meta__label">Last scanned</span>
+                        <span class="a11y-detail-meta__value"><?php echo htmlspecialchars($selectedPage['lastScanned']); ?></span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-meta__label">Page type</span>
+                        <span class="a11y-detail-meta__value"><?php echo htmlspecialchars($selectedPage['pageType']); ?></span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-meta__label">Warnings</span>
+                        <span class="a11y-detail-meta__value"><?php echo $selectedPage['warnings']; ?></span>
+                    </div>
+                </div>
+            </article>
+        </section>
+
+        <section class="a11y-detail-issues">
+            <div class="a11y-detail-issues__header">
+                <h2>Accessibility issues</h2>
+                <span><?php echo $selectedPage['violations']['total']; ?> total</span>
+            </div>
+            <?php if (!empty($selectedPage['issues']['details'])): ?>
+                <div class="a11y-issue-list">
+                    <?php foreach ($selectedPage['issues']['details'] as $issue): ?>
+                        <article class="a11y-issue-card impact-<?php echo htmlspecialchars($issue['impact']); ?>">
+                            <header>
+                                <h3><?php echo htmlspecialchars($issue['description']); ?></h3>
+                                <span class="a11y-impact-badge impact-<?php echo htmlspecialchars($issue['impact']); ?>"><?php echo ucfirst($issue['impact']); ?></span>
+                            </header>
+                            <p><?php echo htmlspecialchars($issue['recommendation']); ?></p>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            <?php else: ?>
+                <p class="a11y-detail-success">This page passed the automated checks with no remaining issues.</p>
+            <?php endif; ?>
+        </section>
+    </div>
+<?php else: ?>
+    <div class="a11y-dashboard" data-last-scan="<?php echo htmlspecialchars($lastScan, ENT_QUOTES); ?>">
+        <header class="a11y-hero">
+            <div class="a11y-hero-content">
+                <div>
+                    <h2 class="a11y-hero-title">Accessibility Dashboard</h2>
+                    <p class="a11y-hero-subtitle">Monitor WCAG compliance and keep your experience inclusive for every visitor.</p>
+                </div>
+                <div class="a11y-hero-actions">
+                    <button type="button" id="scanAllPagesBtn" class="a11y-btn a11y-btn--primary" data-a11y-action="scan-all">
+                        <i class="fas fa-universal-access" aria-hidden="true"></i>
+                        <span>Scan All Pages</span>
+                    </button>
+                    <span class="a11y-hero-meta">
+                        <i class="fas fa-clock" aria-hidden="true"></i>
+                        Last scan: <?php echo htmlspecialchars($lastScan); ?>
+                    </span>
+                </div>
+            </div>
+            <div class="a11y-overview-grid">
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="a11yStatTotalPages"><?php echo $totalPages; ?></div>
+                    <div class="a11y-overview-label">Total Pages</div>
+                </div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="a11yStatAvgScore"><?php echo $avgScore; ?>%</div>
+                    <div class="a11y-overview-label">Average Score</div>
+                </div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="a11yStatCritical"><?php echo $criticalIssues; ?></div>
+                    <div class="a11y-overview-label">Critical Issues</div>
+                </div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="a11yStatCompliant"><?php echo $aaCompliant; ?></div>
+                    <div class="a11y-overview-label">AA/AAA Compliant</div>
+                </div>
+            </div>
+        </header>
+
+        <div class="a11y-controls">
+            <label class="a11y-search" for="a11ySearchInput">
+                <i class="fas fa-search" aria-hidden="true"></i>
+                <input type="search" id="a11ySearchInput" placeholder="Search pages by title, URL, or issue" aria-label="Search accessibility results">
+            </label>
+            <div class="a11y-filter-group" role="group" aria-label="Accessibility filters">
+                <button type="button" class="a11y-filter-btn active" data-a11y-filter="all">All Pages <span class="a11y-filter-count" data-count="all"><?php echo $filterCounts['all']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-a11y-filter="failing">Critical Issues <span class="a11y-filter-count" data-count="failing"><?php echo $filterCounts['failing']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-a11y-filter="partial">Needs Work <span class="a11y-filter-count" data-count="partial"><?php echo $filterCounts['partial']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-a11y-filter="compliant">WCAG Compliant <span class="a11y-filter-count" data-count="compliant"><?php echo $filterCounts['compliant']; ?></span></button>
+            </div>
+            <div class="a11y-view-toggle" role="group" aria-label="Toggle layout">
+                <button type="button" class="a11y-view-btn active" data-a11y-view="grid" aria-label="Grid view">
+                    <i class="fas fa-th-large" aria-hidden="true"></i>
+                </button>
+                <button type="button" class="a11y-view-btn" data-a11y-view="table" aria-label="Table view">
+                    <i class="fas fa-list" aria-hidden="true"></i>
+                </button>
             </div>
         </div>
-        <div class="a11y-hero-stats">
-            <button class="a11y-stat-card active" data-a11y-filter="all">
-                <div class="a11y-stat-icon"><i class="fa-solid fa-universal-access" aria-hidden="true"></i></div>
-                <div>
-                    <div class="a11y-stat-value"><?php echo $totalPages; ?></div>
-                    <div class="a11y-stat-label">Total Pages</div>
-                </div>
-                <span class="a11y-stat-chip">View all</span>
-            </button>
-            <button class="a11y-stat-card" data-a11y-filter="accessible">
-                <div class="a11y-stat-icon success"><i class="fa-solid fa-circle-check" aria-hidden="true"></i></div>
-                <div>
-                    <div class="a11y-stat-value"><?php echo $summary['accessible']; ?></div>
-                    <div class="a11y-stat-label">AA Compliant</div>
-                </div>
-                <span class="a11y-stat-chip"><?php echo $accessibleRate; ?>% pass</span>
-            </button>
-            <button class="a11y-stat-card" data-a11y-filter="review">
-                <div class="a11y-stat-icon warning"><i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i></div>
-                <div>
-                    <div class="a11y-stat-value"><?php echo $summary['needs_review']; ?></div>
-                    <div class="a11y-stat-label">Needs Review</div>
-                </div>
-                <span class="a11y-stat-chip">Focus first</span>
-            </button>
-            <button class="a11y-stat-card" data-a11y-filter="alt">
-                <div class="a11y-stat-icon critical"><i class="fa-solid fa-image" aria-hidden="true"></i></div>
-                <div>
-                    <div class="a11y-stat-value"><?php echo $summary['missing_alt']; ?></div>
-                    <div class="a11y-stat-label">Alt Text Missing</div>
-                </div>
-                <span class="a11y-stat-chip">High impact</span>
-            </button>
+
+        <div class="a11y-action-bar">
+            <div class="a11y-bulk-actions">
+                <button type="button" class="a11y-btn a11y-btn--secondary" id="downloadWcagReport">
+                    <i class="fas fa-download" aria-hidden="true"></i>
+                    <span>Download WCAG Report</span>
+                </button>
+            </div>
         </div>
-        <div class="a11y-hero-overview">
-            <div class="a11y-overview-item">
-                <div class="a11y-overview-label">Average Compliance</div>
-                <div class="a11y-overview-value"><?php echo $avgCompliance; ?>%</div>
+
+        <div class="a11y-pages-grid" id="a11yPagesGrid" role="list"></div>
+
+        <div class="a11y-table-view" id="a11yTableView" hidden>
+            <div class="a11y-table-header">
+                <div>Page</div>
+                <div>Score</div>
+                <div>WCAG Level</div>
+                <div>Violations</div>
+                <div>Warnings</div>
+                <div>Last Scanned</div>
+                <div>Action</div>
             </div>
-            <div class="a11y-overview-item">
-                <div class="a11y-overview-label">Critical Issues Detected</div>
-                <div class="a11y-overview-value"><?php echo $criticalIssues; ?></div>
-            </div>
-            <div class="a11y-overview-item">
-                <div class="a11y-overview-label">Reports Generated</div>
-                <div class="a11y-overview-value"><?php echo $totalPages; ?></div>
-            </div>
+            <div id="a11yTableBody"></div>
+        </div>
+
+        <div class="a11y-empty-state" id="a11yEmptyState" hidden>
+            <i class="fas fa-universal-access" aria-hidden="true"></i>
+            <h3>No pages match your filters</h3>
+            <p>Try adjusting the search or changing the filter selection.</p>
         </div>
     </div>
 
-    <div class="table-card">
-        <div class="table-header">
-            <div>
-                <div class="table-title">Accessibility Insights</div>
-                <p class="table-subtitle">Filter pages and prioritize fixes to improve overall compliance.</p>
+    <div class="a11y-page-detail" id="a11yPageDetail" hidden role="dialog" aria-modal="true" aria-labelledby="a11yDetailTitle">
+        <div class="a11y-detail-content">
+            <button type="button" class="a11y-detail-close" id="a11yDetailClose" aria-label="Close accessibility details">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+            <header class="a11y-detail-modal-header">
+                <h2 id="a11yDetailTitle">Page Accessibility Details</h2>
+                <p id="a11yDetailUrl" class="a11y-detail-url"></p>
+                <p id="a11yDetailDescription" class="a11y-detail-description"></p>
+            </header>
+            <div class="a11y-detail-modal-body">
+                <div class="a11y-detail-badges">
+                    <span class="a11y-detail-score" id="a11yDetailScore"></span>
+                    <span class="a11y-detail-level" id="a11yDetailLevel"></span>
+                    <span class="a11y-detail-violations" id="a11yDetailViolations"></span>
+                </div>
+                <ul class="a11y-detail-metric-list" id="a11yDetailMetrics"></ul>
+                <div class="a11y-detail-issues-list">
+                    <h3>Key findings</h3>
+                    <ul id="a11yDetailIssues"></ul>
+                </div>
             </div>
-            <div class="table-actions">
-                <input type="text" id="a11ySearch" class="table-search" placeholder="Search by page, issue, or URL" aria-label="Filter accessibility rows">
-            </div>
+            <footer class="a11y-detail-modal-footer">
+                <button type="button" class="a11y-btn a11y-btn--primary" data-a11y-action="full-audit">
+                    <i class="fas fa-universal-access" aria-hidden="true"></i>
+                    <span>Full Accessibility Audit</span>
+                </button>
+            </footer>
         </div>
-
-        <div class="a11y-filter-bar">
-            <button class="a11y-filter-pill active" data-a11y-filter="all">All Pages <span><?php echo $totalPages; ?></span></button>
-            <button class="a11y-filter-pill" data-a11y-filter="review">Needs Review <span><?php echo $summary['needs_review']; ?></span></button>
-            <button class="a11y-filter-pill" data-a11y-filter="alt">Missing Alt Text <span><?php echo $summary['missing_alt']; ?></span></button>
-            <button class="a11y-filter-pill" data-a11y-filter="accessible">WCAG Compliant <span><?php echo $summary['accessible']; ?></span></button>
-        </div>
-
-        <table class="data-table" id="accessibilityTable">
-            <thead>
-                <tr>
-                    <th>Page</th>
-                    <th>Images</th>
-                    <th>Headings</th>
-                    <th>Links</th>
-                    <th>Landmarks</th>
-                    <th>Issues</th>
-                    <th class="a11y-action-header">Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($report as $index => $entry): ?>
-                    <?php
-                        $statuses = [];
-                        if (empty($entry['issues'])) {
-                            $statuses[] = 'accessible';
-                        } else {
-                            $statuses[] = 'review';
-                        }
-                        if ($entry['missing_alt'] > 0) {
-                            $statuses[] = 'alt';
-                        }
-                        $rowStatus = implode(' ', $statuses);
-                        $detailId = 'a11y-details-' . $index;
-                    ?>
-                    <tr class="a11y-summary-row" data-status="<?php echo htmlspecialchars($rowStatus); ?>" data-expanded="false">
-                        <td>
-                            <div class="cell-title"><?php echo htmlspecialchars($entry['title']); ?></div>
-                            <div class="cell-subtext">/<?php echo htmlspecialchars($entry['slug']); ?></div>
-                        </td>
-                        <td>
-                            <div><?php echo $entry['image_count']; ?> total</div>
-                            <?php if ($entry['missing_alt'] > 0): ?>
-                                <span class="status-badge status-critical"><?php echo $entry['missing_alt']; ?> missing alt</span>
-                            <?php else: ?>
-                                <span class="status-badge status-good">All described</span>
-                            <?php endif; ?>
-                        </td>
-                        <td>
-                            <div>H1: <?php echo $entry['headings']['h1']; ?></div>
-                            <div>H2: <?php echo $entry['headings']['h2']; ?></div>
-                        </td>
-                        <td>
-                            <?php if ($entry['generic_links'] > 0): ?>
-                                <span class="status-badge status-warning"><?php echo $entry['generic_links']; ?> generic</span>
-                            <?php else: ?>
-                                <span class="status-badge status-good">Descriptive</span>
-                            <?php endif; ?>
-                        </td>
-                        <td>
-                            <?php if ($entry['landmarks'] > 0): ?>
-                                <span class="status-badge status-good"><?php echo $entry['landmarks']; ?> landmark(s)</span>
-                            <?php else: ?>
-                                <span class="status-badge status-warning">None detected</span>
-                            <?php endif; ?>
-                        </td>
-                        <td>
-                            <?php if (!empty($entry['issues'])): ?>
-                                <ul class="issue-list">
-                                    <?php foreach ($entry['issues'] as $issue): ?>
-                                        <li><?php echo htmlspecialchars($issue); ?></li>
-                                    <?php endforeach; ?>
-                                </ul>
-                            <?php else: ?>
-                                <span class="issue-none">No outstanding issues</span>
-                            <?php endif; ?>
-                        </td>
-                        <td class="a11y-action-cell">
-                            <button type="button" class="a11y-detail-btn" aria-expanded="false" aria-controls="<?php echo htmlspecialchars($detailId); ?>">
-                                <span class="a11y-detail-icon" aria-hidden="true"><i class="fa-solid fa-chart-pie"></i></span>
-                                <span>View details</span>
-                            </button>
-                        </td>
-                    </tr>
-                    <tr id="<?php echo htmlspecialchars($detailId); ?>" class="a11y-detail-row" data-status="<?php echo htmlspecialchars($rowStatus); ?>" hidden>
-                        <td colspan="7">
-                            <div class="a11y-detail-card">
-                                <div class="a11y-detail-meta">
-                                    <div>
-                                        <span class="a11y-detail-label">Page URL</span>
-                                        <span class="a11y-detail-value">/<?php echo htmlspecialchars($entry['slug']); ?></span>
-                                    </div>
-                                    <div>
-                                        <span class="a11y-detail-label">Last scanned</span>
-                                        <span class="a11y-detail-value"><?php echo htmlspecialchars($lastScan); ?></span>
-                                    </div>
-                                    <div>
-                                        <span class="a11y-detail-label">Landmarks</span>
-                                        <span class="a11y-detail-value"><?php echo $entry['landmarks']; ?></span>
-                                    </div>
-                                </div>
-                                <div class="a11y-detail-grid">
-                                    <div class="a11y-detail-metric">
-                                        <span class="a11y-detail-label">Images</span>
-                                        <span class="a11y-detail-value"><?php echo $entry['image_count']; ?></span>
-                                        <span class="a11y-detail-hint"><?php echo $entry['missing_alt'] > 0 ? $entry['missing_alt'] . ' missing alt' : 'All images described'; ?></span>
-                                    </div>
-                                    <div class="a11y-detail-metric">
-                                        <span class="a11y-detail-label">Headings</span>
-                                        <span class="a11y-detail-value">H1: <?php echo $entry['headings']['h1']; ?> / H2: <?php echo $entry['headings']['h2']; ?></span>
-                                        <span class="a11y-detail-hint">Ensure a single descriptive H1</span>
-                                    </div>
-                                    <div class="a11y-detail-metric">
-                                        <span class="a11y-detail-label">Links</span>
-                                        <span class="a11y-detail-value"><?php echo $entry['generic_links']; ?> generic</span>
-                                        <span class="a11y-detail-hint"><?php echo $entry['generic_links'] > 0 ? 'Improve link text clarity' : 'All links descriptive'; ?></span>
-                                    </div>
-                                </div>
-                                <div class="a11y-detail-issues">
-                                    <h4>Issues detected</h4>
-                                    <?php if (!empty($entry['issues'])): ?>
-                                        <ul>
-                                            <?php foreach ($entry['issues'] as $issue): ?>
-                                                <li><?php echo htmlspecialchars($issue); ?></li>
-                                            <?php endforeach; ?>
-                                        </ul>
-                                    <?php else: ?>
-                                        <p class="a11y-detail-success">This page meets the current automated checks.</p>
-                                    <?php endif; ?>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
     </div>
+<?php endif; ?>
 </div>
+<script>
+window.a11yDashboardData = <?php echo json_encode($pageEntries, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+window.a11yDashboardStats = <?php echo json_encode($dashboardStats, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+</script>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -432,238 +432,908 @@
         #accessibility {
             display: flex;
             flex-direction: column;
-            gap: 25px;
+            gap: 24px;
+        }
+
+        .a11y-dashboard {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
         }
 
         .a11y-hero {
-            background: linear-gradient(135deg, #5a67d8 0%, #7f9cf5 50%, #4c51bf 100%);
-            color: white;
-            padding: 28px;
-            border-radius: 16px;
-            box-shadow: 0 20px 40px rgba(93, 100, 231, 0.35);
+            position: relative;
+            background: linear-gradient(135deg, #5b21b6, #2563eb);
+            color: #fff;
+            padding: 32px;
+            border-radius: 18px;
+            overflow: hidden;
+            box-shadow: 0 20px 48px rgba(37, 99, 235, 0.35);
         }
 
-        .a11y-hero-header {
+        .a11y-hero::before {
+            content: '';
+            position: absolute;
+            top: -80px;
+            right: -80px;
+            width: 240px;
+            height: 240px;
+            background: rgba(255,255,255,0.12);
+            border-radius: 50%;
+            filter: blur(0.5px);
+        }
+
+        .a11y-hero-content {
+            position: relative;
             display: flex;
             justify-content: space-between;
-            align-items: center;
-            gap: 20px;
-            margin-bottom: 28px;
+            gap: 24px;
+            flex-wrap: wrap;
+        }
+
+        .a11y-hero-title {
+            font-size: 30px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .a11y-hero-subtitle {
+            font-size: 15px;
+            max-width: 520px;
+            color: rgba(255,255,255,0.88);
         }
 
         .a11y-hero-actions {
             display: flex;
             align-items: center;
             gap: 16px;
-        }
-
-        .a11y-hero-title {
-            font-size: 28px;
-            font-weight: 600;
-            margin-bottom: 6px;
-        }
-
-        .a11y-hero-subtitle {
-            font-size: 15px;
-            color: rgba(255,255,255,0.85);
-            max-width: 480px;
+            flex-wrap: wrap;
         }
 
         .a11y-hero-meta {
-            background: rgba(255,255,255,0.12);
-            border-radius: 30px;
-            padding: 8px 18px;
-            font-size: 13px;
             display: inline-flex;
             align-items: center;
             gap: 8px;
+            padding: 8px 18px;
+            border-radius: 999px;
+            background: rgba(15,23,42,0.25);
+            font-size: 13px;
         }
 
-        .a11y-scan-btn {
+        .a11y-btn {
             display: inline-flex;
             align-items: center;
+            justify-content: center;
             gap: 10px;
             padding: 10px 18px;
             border-radius: 999px;
-            border: 1px solid rgba(255,255,255,0.45);
-            background: rgba(255,255,255,0.15);
-            color: white;
-            font-weight: 500;
+            border: none;
+            font-weight: 600;
             font-size: 14px;
             cursor: pointer;
-            transition: background 0.2s ease, transform 0.2s ease;
-            appearance: none;
+            transition: all 0.2s ease;
+            text-decoration: none;
+            background: rgba(255,255,255,0.16);
+            color: #fff;
         }
 
-        .a11y-scan-btn:hover {
-            background: rgba(255,255,255,0.25);
+        .a11y-btn:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(255,255,255,0.35);
+        }
+
+        .a11y-btn--primary {
+            background: linear-gradient(135deg, #7c3aed, #2563eb);
+            color: #fff;
+        }
+
+        .a11y-btn--primary:hover {
             transform: translateY(-1px);
+            box-shadow: 0 10px 24px rgba(59, 130, 246, 0.35);
         }
 
-        .a11y-scan-btn.is-loading {
-            opacity: 0.8;
+        .a11y-btn--secondary {
+            background: #f1f5f9;
+            color: #1f2937;
+        }
+
+        .a11y-btn--secondary:hover {
+            background: #e2e8f0;
+        }
+
+        .a11y-btn--ghost {
+            background: transparent;
+            color: #1f2937;
+            border: 1px solid #cbd5f5;
+        }
+
+        .a11y-btn--ghost:hover {
+            background: #e2e8f0;
+        }
+
+        .a11y-btn--icon {
+            padding: 6px 12px;
+            border-radius: 10px;
+            background: #eef2ff;
+            color: #4338ca;
+        }
+
+        .a11y-btn.is-loading {
+            opacity: 0.7;
             cursor: wait;
         }
 
-        .a11y-scan-btn:focus-visible {
-            outline: none;
-            box-shadow: 0 0 0 3px rgba(255,255,255,0.45);
-        }
-
-        .a11y-scan-icon {
-            font-size: 16px;
-        }
-
-        .a11y-hero-stats {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-            gap: 18px;
-            margin-bottom: 24px;
-        }
-
-        .a11y-stat-card {
-            background: rgba(255,255,255,0.14);
-            border: 1px solid transparent;
-            border-radius: 16px;
-            padding: 18px;
-            display: flex;
-            align-items: center;
-            gap: 16px;
-            cursor: pointer;
-            color: inherit;
-            transition: all 0.3s ease;
-            position: relative;
-            outline: none;
-            appearance: none;
-        }
-
-        .a11y-stat-card:hover,
-        .a11y-stat-card.active {
-            background: rgba(255,255,255,0.25);
-            border-color: rgba(255,255,255,0.45);
-            box-shadow: 0 12px 24px rgba(44, 82, 130, 0.25);
-        }
-
-        .a11y-stat-card:focus-visible {
-            box-shadow: 0 0 0 3px rgba(255,255,255,0.55);
-        }
-
-        .a11y-stat-card span,
-        .a11y-stat-card div {
-            pointer-events: none;
-        }
-
-        .a11y-stat-icon {
-            font-size: 28px;
-        }
-
-        .a11y-stat-icon.success { color: #c6f6d5; }
-        .a11y-stat-icon.warning { color: #fefcbf; }
-        .a11y-stat-icon.critical { color: #fed7d7; }
-
-        .a11y-stat-value {
-            font-size: 24px;
-            font-weight: 600;
-        }
-
-        .a11y-stat-label {
-            font-size: 13px;
-            opacity: 0.8;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-
-        .a11y-stat-chip {
-            position: absolute;
-            right: 18px;
-            bottom: 18px;
-            background: rgba(15, 23, 42, 0.25);
-            padding: 4px 10px;
-            border-radius: 12px;
-            font-size: 11px;
-            text-transform: uppercase;
-            letter-spacing: 0.6px;
-        }
-
-        .a11y-hero-overview {
+        .a11y-overview-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-            gap: 16px;
+            gap: 18px;
+            margin-top: 28px;
         }
 
-        .a11y-overview-item {
-            background: rgba(255,255,255,0.12);
-            border-radius: 14px;
-            padding: 16px 20px;
+        .a11y-overview-card {
+            background: rgba(255,255,255,0.14);
+            border-radius: 16px;
+            padding: 18px 20px;
+            backdrop-filter: blur(6px);
+        }
+
+        .a11y-overview-value {
+            font-size: 28px;
+            font-weight: 600;
         }
 
         .a11y-overview-label {
             font-size: 12px;
-            text-transform: uppercase;
             letter-spacing: 0.6px;
-            opacity: 0.75;
-            margin-bottom: 6px;
+            text-transform: uppercase;
+            opacity: 0.8;
         }
 
-        .a11y-overview-value {
-            font-size: 22px;
-            font-weight: 600;
+        .a11y-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            align-items: center;
         }
 
-        .table-subtitle {
-            color: #718096;
-            font-size: 13px;
-            margin-top: 4px;
+        .a11y-search {
+            position: relative;
+            flex: 1;
+            min-width: 240px;
+            max-width: 420px;
+            display: flex;
+            align-items: center;
+            background: #fff;
+            border: 1px solid #e2e8f0;
+            border-radius: 12px;
+            padding: 10px 14px;
+            gap: 10px;
+            color: #64748b;
         }
 
-        .a11y-filter-bar {
+        .a11y-search i {
+            font-size: 15px;
+        }
+
+        .a11y-search input {
+            border: none;
+            outline: none;
+            flex: 1;
+            font-size: 14px;
+            color: #1f2937;
+        }
+
+        .a11y-filter-group {
             display: flex;
             flex-wrap: wrap;
             gap: 10px;
-            padding: 16px 25px 12px;
-            border-bottom: 1px solid #e2e8f0;
         }
 
-        .a11y-filter-pill {
-            border: 1px solid #d6dffc;
-            background: #f7f9ff;
-            color: #2c5282;
+        .a11y-filter-btn {
+            border: 1px solid #d6dcff;
+            background: #f5f7ff;
+            color: #334155;
             padding: 8px 16px;
             border-radius: 999px;
             font-size: 13px;
-            font-weight: 500;
+            font-weight: 600;
             display: inline-flex;
             align-items: center;
             gap: 8px;
             cursor: pointer;
             transition: all 0.2s ease;
-            outline: none;
-            appearance: none;
         }
 
-        .a11y-filter-pill span {
-            background: #edf2ff;
-            padding: 2px 10px;
+        .a11y-filter-btn .a11y-filter-count {
+            background: #e0e7ff;
             border-radius: 999px;
+            padding: 2px 10px;
             font-size: 12px;
-            color: #4c51bf;
         }
 
-        .a11y-filter-pill:hover,
-        .a11y-filter-pill.active {
-            background: linear-gradient(135deg, #667eea, #764ba2);
-            color: white;
+        .a11y-filter-btn:hover,
+        .a11y-filter-btn.active {
+            background: linear-gradient(135deg, #4338ca, #2563eb);
+            color: #fff;
             border-color: transparent;
         }
 
-        .a11y-filter-pill:hover span,
-        .a11y-filter-pill.active span {
+        .a11y-filter-btn:hover .a11y-filter-count,
+        .a11y-filter-btn.active .a11y-filter-count {
             background: rgba(255,255,255,0.2);
-            color: white;
         }
 
-        .a11y-filter-pill:focus-visible {
-            box-shadow: 0 0 0 3px rgba(118, 75, 162, 0.4);
+        .a11y-view-toggle {
+            display: inline-flex;
+            border: 1px solid #e2e8f0;
+            border-radius: 10px;
+            overflow: hidden;
+        }
+
+        .a11y-view-btn {
+            background: #fff;
+            border: none;
+            padding: 8px 14px;
+            color: #64748b;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .a11y-view-btn.active {
+            background: #2563eb;
+            color: #fff;
+        }
+
+        .a11y-action-bar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .a11y-pages-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+            gap: 20px;
+        }
+
+        .a11y-page-card {
+            background: #fff;
+            border-radius: 16px;
+            padding: 22px;
+            box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+            border: 1px solid #e2e8f0;
+            cursor: pointer;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .a11y-page-card:hover,
+        .a11y-page-card:focus-visible {
+            transform: translateY(-3px);
+            box-shadow: 0 18px 32px rgba(37, 99, 235, 0.2);
+            outline: none;
+        }
+
+        .a11y-page-card__header {
+            position: relative;
+        }
+
+        .a11y-page-score {
+            position: absolute;
+            right: 0;
+            top: -10px;
+            width: 56px;
+            height: 56px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            color: #fff;
+            font-size: 18px;
+            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.15);
+        }
+
+        .a11y-score--aaa { background: linear-gradient(135deg, #059669, #047857); }
+        .a11y-score--aa { background: linear-gradient(135deg, #3b82f6, #2563eb); }
+        .a11y-score--partial { background: linear-gradient(135deg, #f59e0b, #d97706); }
+        .a11y-score--failing { background: linear-gradient(135deg, #ef4444, #dc2626); }
+
+        .a11y-page-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: #1e293b;
+            margin-bottom: 6px;
+            padding-right: 70px;
+        }
+
+        .a11y-page-url {
+            font-family: monospace;
+            font-size: 13px;
+            color: #64748b;
+        }
+
+        .a11y-page-card__metrics {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .a11y-page-card__metrics .label {
+            display: block;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: #94a3b8;
+        }
+
+        .a11y-page-card__metrics .value {
+            font-size: 16px;
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .a11y-issue-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .a11y-issue-tag {
+            display: inline-flex;
+            align-items: center;
+            padding: 4px 10px;
+            background: #f1f5f9;
+            border-radius: 8px;
+            font-size: 11px;
+            font-weight: 600;
+            color: #475569;
+        }
+
+        .a11y-issue-tag.critical {
+            background: #fee2e2;
+            color: #b91c1c;
+        }
+
+        .a11y-issue-tag.serious {
+            background: #fef3c7;
+            color: #92400e;
+        }
+
+        .a11y-table-view {
+            background: #fff;
+            border-radius: 16px;
+            box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+            border: 1px solid #e2e8f0;
+            overflow: hidden;
+        }
+
+        .a11y-table-header {
+            display: grid;
+            grid-template-columns: 2fr 120px 130px 160px 110px 140px 90px;
+            gap: 16px;
+            padding: 18px 24px;
+            background: #f8fafc;
+            font-size: 12px;
+            font-weight: 600;
+            color: #475569;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+        }
+
+        .a11y-table-row {
+            display: grid;
+            grid-template-columns: 2fr 120px 130px 160px 110px 140px 90px;
+            gap: 16px;
+            padding: 18px 24px;
+            border-top: 1px solid #f1f5f9;
+            align-items: center;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .a11y-table-row:hover {
+            background: #f8fafc;
+        }
+
+        .a11y-table-cell .title {
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        .a11y-table-cell .subtitle {
+            font-family: monospace;
+            font-size: 12px;
+            color: #64748b;
+        }
+
+        .a11y-table-score {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 54px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-weight: 600;
+            color: #fff;
+        }
+
+        .level-aaa { background: #dcfce7; color: #047857; }
+        .level-aa { background: #dbeafe; color: #1d4ed8; }
+        .level-partial { background: #fef3c7; color: #92400e; }
+        .level-failing { background: #fee2e2; color: #b91c1c; }
+
+        .a11y-empty-state {
+            background: #fff;
+            border-radius: 16px;
+            border: 1px dashed #cbd5f5;
+            padding: 60px 20px;
+            text-align: center;
+            color: #475569;
+        }
+
+        .a11y-empty-state i {
+            font-size: 36px;
+            margin-bottom: 12px;
+            color: #4338ca;
+        }
+
+        .a11y-page-detail {
+            position: fixed;
+            inset: 0;
+            background: rgba(15, 23, 42, 0.55);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+            z-index: 1000;
+        }
+
+        .a11y-page-detail.is-visible {
+            display: flex;
+        }
+
+        .a11y-detail-content {
+            background: #fff;
+            border-radius: 18px;
+            width: 100%;
+            max-width: 720px;
+            max-height: 90vh;
+            overflow-y: auto;
+            position: relative;
+            padding: 30px;
+        }
+
+        .a11y-detail-close {
+            position: absolute;
+            top: 18px;
+            right: 18px;
+            background: none;
+            border: none;
+            color: #64748b;
+            font-size: 22px;
+            cursor: pointer;
+            border-radius: 50%;
+            width: 36px;
+            height: 36px;
+        }
+
+        .a11y-detail-close:hover {
+            background: #f1f5f9;
+        }
+
+        .a11y-detail-modal-header {
+            margin-bottom: 18px;
+        }
+
+        .a11y-detail-modal-header h2 {
+            margin: 0 0 8px;
+            color: #1e293b;
+        }
+
+        .a11y-detail-url {
+            font-family: monospace;
+            font-size: 13px;
+            color: #475569;
+            margin-bottom: 8px;
+        }
+
+        .a11y-detail-badges {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-bottom: 18px;
+        }
+
+        .a11y-detail-badges span {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-weight: 600;
+        }
+
+        .a11y-detail-score {
+            background: #2563eb;
+            color: #fff;
+        }
+
+        .a11y-detail-level {
+            background: #e0f2fe;
+            color: #0369a1;
+        }
+
+        .a11y-detail-violations {
+            background: #fef3c7;
+            color: #92400e;
+        }
+
+        .a11y-detail-metric-list {
+            list-style: none;
+            padding: 0;
+            margin: 0 0 20px;
+            display: grid;
+            gap: 12px;
+        }
+
+        .a11y-detail-metric-list li {
+            display: grid;
+            grid-template-columns: 140px 1fr;
+            align-items: baseline;
+            gap: 12px;
+            padding: 12px;
+            border-radius: 12px;
+            background: #f8fafc;
+        }
+
+        .a11y-detail-metric-list .label {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            color: #64748b;
+        }
+
+        .a11y-detail-metric-list .value {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .a11y-detail-metric-list .hint {
+            grid-column: 2 / span 1;
+            font-size: 12px;
+            color: #475569;
+        }
+
+        .a11y-detail-issues-list h3 {
+            margin: 0 0 12px;
+            font-size: 16px;
+            color: #1e293b;
+        }
+
+        .a11y-detail-issues-list ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: 10px;
+        }
+
+        .a11y-detail-issues-list li {
+            display: grid;
+            gap: 6px;
+            padding: 12px;
+            border-radius: 12px;
+            background: #f8fafc;
+        }
+
+        .a11y-detail-issues-list .issue {
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        .a11y-detail-issues-list .impact {
+            display: inline-flex;
+            padding: 4px 8px;
+            border-radius: 999px;
+            font-size: 11px;
+            font-weight: 600;
+            width: fit-content;
+        }
+
+        .a11y-detail-issues-list .tip {
+            font-size: 12px;
+            color: #475569;
+        }
+
+        .a11y-detail-issues-list .impact-critical { background: #fee2e2; color: #b91c1c; }
+        .a11y-detail-issues-list .impact-serious { background: #fef3c7; color: #92400e; }
+        .a11y-detail-issues-list .impact-moderate { background: #e0f2fe; color: #0369a1; }
+        .a11y-detail-issues-list .impact-minor { background: #ede9fe; color: #5b21b6; }
+        .a11y-detail-issues-list .impact-review { background: #f1f5f9; color: #475569; }
+
+        .a11y-detail-issues-list .no-issues {
+            color: #047857;
+            font-weight: 600;
+        }
+
+        .a11y-detail-modal-footer {
+            margin-top: 24px;
+            display: flex;
+            justify-content: flex-end;
+        }
+
+        .a11y-detail-page {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .a11y-detail-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 16px;
+        }
+
+        .a11y-back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            text-decoration: none;
+            color: #2563eb;
+            font-weight: 600;
+        }
+
+        .a11y-health-card {
+            display: grid;
+            grid-template-columns: minmax(220px, 260px) 1fr;
+            gap: 24px;
+            background: linear-gradient(135deg, #4c1d95, #2563eb);
+            color: #fff;
+            padding: 32px;
+            border-radius: 18px;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .a11y-health-card::before {
+            content: '';
+            position: absolute;
+            bottom: -60px;
+            left: -40px;
+            width: 220px;
+            height: 220px;
+            background: rgba(255,255,255,0.14);
+            border-radius: 50%;
+        }
+
+        .a11y-health-score {
+            position: relative;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .a11y-health-score__value {
+            font-size: 64px;
+            font-weight: 700;
+            line-height: 1;
+        }
+
+        .a11y-health-score__value span {
+            font-size: 24px;
+        }
+
+        .a11y-health-score__label {
+            font-size: 14px;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+            opacity: 0.9;
+        }
+
+        .a11y-health-score__badge {
+            padding: 6px 14px;
+            border-radius: 999px;
+            background: rgba(255,255,255,0.2);
+            font-weight: 600;
+        }
+
+        .a11y-health-summary {
+            position: relative;
+            z-index: 2;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .a11y-health-summary h1 {
+            font-size: 26px;
+            margin: 0;
+        }
+
+        .a11y-health-url {
+            font-family: monospace;
+            font-size: 13px;
+            opacity: 0.85;
+        }
+
+        .a11y-quick-stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+            gap: 16px;
+            margin-top: 12px;
+        }
+
+        .a11y-quick-stat {
+            text-align: center;
+        }
+
+        .a11y-quick-stat__value {
+            font-size: 22px;
+            font-weight: 600;
+        }
+
+        .a11y-quick-stat__label {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+        }
+
+        .a11y-detail-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 20px;
+        }
+
+        .a11y-detail-card {
+            background: #fff;
+            border-radius: 16px;
+            padding: 22px;
+            box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+            border: 1px solid #e2e8f0;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .a11y-detail-card h2 {
+            font-size: 18px;
+            margin: 0;
+            color: #1e293b;
+        }
+
+        .a11y-detail-metrics div {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .a11y-detail-metric__label {
+            font-size: 12px;
+            text-transform: uppercase;
+            color: #64748b;
+            letter-spacing: 0.5px;
+        }
+
+        .a11y-detail-metric__value {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .a11y-detail-metric__hint {
+            font-size: 12px;
+            color: #475569;
+        }
+
+        .a11y-violation-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: 10px;
+        }
+
+        .a11y-violation-list li {
+            display: flex;
+            justify-content: space-between;
+            background: #f8fafc;
+            padding: 10px 14px;
+            border-radius: 12px;
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        .a11y-detail-meta {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 12px;
+        }
+
+        .a11y-detail-meta__label {
+            font-size: 11px;
+            text-transform: uppercase;
+            color: #94a3b8;
+        }
+
+        .a11y-detail-meta__value {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .a11y-detail-issues {
+            background: #fff;
+            border-radius: 16px;
+            padding: 24px;
+            box-shadow: 0 8px 20px rgba(15, 23, 42, 0.06);
+            border: 1px solid #e2e8f0;
+        }
+
+        .a11y-detail-issues__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 16px;
+            color: #1f2937;
+        }
+
+        .a11y-issue-list {
+            display: grid;
+            gap: 14px;
+        }
+
+        .a11y-issue-card {
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid #e2e8f0;
+            background: #f9fafc;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .a11y-issue-card header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .a11y-issue-card h3 {
+            margin: 0;
+            font-size: 16px;
+            color: #1e293b;
+        }
+
+        .a11y-impact-badge {
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+
+        .impact-critical { background: #fee2e2; color: #b91c1c; }
+        .impact-serious { background: #fef3c7; color: #92400e; }
+        .impact-moderate { background: #e0f2fe; color: #0369a1; }
+        .impact-minor { background: #ede9fe; color: #5b21b6; }
+
+        .a11y-detail-success {
+            margin: 0;
+            color: #047857;
+            font-weight: 600;
+        }
+
+        .table-card {
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+            overflow: hidden;
         }
 
         .table-header {


### PR DESCRIPTION
## Summary
- rebuild the accessibility module view to compute page metrics, expose dashboard data, and render the new dashboard/detail markup
- replace the client script to power search, filtering, view toggles, modal details, and navigation into the full audit view
- refresh the module styling for the new layout, controls, cards, and modal presentation

## Testing
- php -l CMS/modules/accessibility/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d6b8278998833190f7ee75f2ef03b3