### PR TITLE
Remove accessibility export report button

### DIFF
--- a/CMS/modules/accessibility/accessibility.js
+++ b/CMS/modules/accessibility/accessibility.js
@@ -467,9 +467,6 @@
                 }, 900);
             });
 
-            $('[data-a11y-action="export-page-report"]').on('click', function () {
-                window.alert('Exporting detailed accessibility report for this page...\n\nThe export includes violation breakdowns, remediation steps, and testing history.');
-            });
         }
 
         applyFilters();

--- a/CMS/modules/accessibility/view.php
+++ b/CMS/modules/accessibility/view.php
@@ -395,10 +395,6 @@ $dashboardStats = [
                     <i class="fas fa-rotate" aria-hidden="true"></i>
                     <span>Rescan Page</span>
                 </button>
-                <button type="button" class="a11y-btn a11y-btn--secondary" data-a11y-action="export-page-report">
-                    <i class="fas fa-file-export" aria-hidden="true"></i>
-                    <span>Export Report</span>
-                </button>
             </div>
         </header>
 


### PR DESCRIPTION
## Summary
- remove the Export Report button from the accessibility detail view
- drop the unused JavaScript handler tied to the removed button

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d71e73f08c8331809e181712f7374f