### PR TITLE
Enhance analytics dashboard with richer insights

### DIFF
--- a/CMS/modules/analytics/analytics_data.php
+++ b/CMS/modules/analytics/analytics_data.php
@@ -16,5 +16,9 @@ foreach ($pages as $p) {
     ];
 }
 
+usort($data, function ($a, $b) {
+    return ($b['views'] ?? 0) <=> ($a['views'] ?? 0);
+});
+
 header('Content-Type: application/json');
 echo json_encode($data);

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -10,6 +10,23 @@ $totalViews = 0;
 foreach ($pages as $p) {
     $totalViews += $p['views'] ?? 0;
 }
+
+$totalPages = count($pages);
+$averageViews = $totalPages > 0 ? $totalViews / $totalPages : 0;
+
+$sortedPages = $pages;
+usort($sortedPages, function ($a, $b) {
+    return ($b['views'] ?? 0) <=> ($a['views'] ?? 0);
+});
+
+$topPages = array_slice($sortedPages, 0, 3);
+$topPage = $topPages[0] ?? null;
+
+$zeroViewPages = array_values(array_filter($pages, function ($page) {
+    return ($page['views'] ?? 0) === 0;
+}));
+$zeroViewCount = count($zeroViewPages);
+$zeroViewExamples = array_slice($zeroViewPages, 0, 3);
 ?>
 <div class="content-section" id="analytics">
     <div class="table-card">
@@ -22,9 +39,95 @@ foreach ($pages as $p) {
                     <div class="stat-icon views"><i class="fa-solid fa-chart-line" aria-hidden="true"></i></div>
                     <div class="stat-content">
                         <div class="stat-label">Total Views</div>
-                        <div class="stat-number"><?php echo $totalViews; ?></div>
+                        <div class="stat-number"><?php echo number_format($totalViews); ?></div>
+                        <?php if ($topPage): ?>
+                        <div class="stat-subtext">Top page: <?php echo htmlspecialchars($topPage['title']); ?> (<?php echo number_format($topPage['views'] ?? 0); ?>)</div>
+                        <?php else: ?>
+                        <div class="stat-subtext">No traffic recorded yet</div>
+                        <?php endif; ?>
                     </div>
                 </div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-header">
+                    <div class="stat-icon average"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i></div>
+                    <div class="stat-content">
+                        <div class="stat-label">Avg. Views / Page</div>
+                        <div class="stat-number"><?php echo number_format($averageViews, 1); ?></div>
+                        <div class="stat-subtext">Based on <?php echo $totalPages; ?> published pages</div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-header">
+                    <div class="stat-icon pages"><i class="fa-regular fa-file-lines" aria-hidden="true"></i></div>
+                    <div class="stat-content">
+                        <div class="stat-label">Published Pages</div>
+                        <div class="stat-number"><?php echo number_format($totalPages); ?></div>
+                        <div class="stat-subtext">Includes static and dynamic content</div>
+                    </div>
+                </div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-header">
+                    <div class="stat-icon low-views"><i class="fa-solid fa-arrow-trend-down" aria-hidden="true"></i></div>
+                    <div class="stat-content">
+                        <div class="stat-label">Unviewed Pages</div>
+                        <div class="stat-number"><?php echo number_format($zeroViewCount); ?></div>
+                        <div class="stat-subtext"><?php echo $zeroViewCount > 0 ? 'Great candidates for promotion' : 'Every page has traffic'; ?></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="insights-grid">
+            <div class="insights-card">
+                <div class="insights-header">
+                    <div class="insights-icon highlight"><i class="fa-solid fa-ranking-star" aria-hidden="true"></i></div>
+                    <div>
+                        <div class="insights-title">Top Performing Pages</div>
+                        <div class="insights-subtitle">Most viewed content this period</div>
+                    </div>
+                </div>
+                <?php if (!empty($topPages)): ?>
+                <ul class="insights-list">
+                    <?php foreach ($topPages as $page): ?>
+                        <li>
+                            <div>
+                                <div class="insight-title"><?php echo htmlspecialchars($page['title']); ?></div>
+                                <div class="insight-subtitle"><?php echo htmlspecialchars($page['slug']); ?></div>
+                            </div>
+                            <div class="insight-metric"><?php echo number_format($page['views'] ?? 0); ?> views</div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+                <?php else: ?>
+                <div class="insight-empty">Traffic insights will appear once pages start receiving views.</div>
+                <?php endif; ?>
+            </div>
+            <div class="insights-card opportunities">
+                <div class="insights-header">
+                    <div class="insights-icon opportunities"><i class="fa-solid fa-lightbulb" aria-hidden="true"></i></div>
+                    <div>
+                        <div class="insights-title">Opportunities</div>
+                        <div class="insights-subtitle">Pages that need more attention</div>
+                    </div>
+                </div>
+                <?php if ($zeroViewCount > 0): ?>
+                <div class="insight-summary">You have <?php echo number_format($zeroViewCount); ?> page<?php echo $zeroViewCount === 1 ? '' : 's'; ?> without any views.</div>
+                <ul class="insights-list">
+                    <?php foreach ($zeroViewExamples as $page): ?>
+                        <li>
+                            <div>
+                                <div class="insight-title"><?php echo htmlspecialchars($page['title']); ?></div>
+                                <div class="insight-subtitle"><?php echo htmlspecialchars($page['slug']); ?></div>
+                            </div>
+                            <div class="insight-metric">0 views</div>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+                <?php else: ?>
+                <div class="insight-empty">Great job! Every published page has at least one view.</div>
+                <?php endif; ?>
             </div>
         </div>
         <table class="data-table" id="analyticsTable">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -363,6 +363,16 @@
             color: white;
         }
 
+        .stat-icon.average {
+            background: linear-gradient(135deg, #3182ce, #2b6cb0);
+            color: white;
+        }
+
+        .stat-icon.low-views {
+            background: linear-gradient(135deg, #f6ad55, #dd6b20);
+            color: white;
+        }
+
         .stat-content {
             flex: 1;
         }
@@ -396,6 +406,113 @@
 
         .stat-change.negative {
             color: #e53e3e;
+        }
+
+        .insights-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+
+        .insights-card {
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .insights-card.opportunities {
+            border: 1px solid rgba(246, 173, 85, 0.35);
+        }
+
+        .insights-header {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .insights-icon {
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 20px;
+        }
+
+        .insights-icon.highlight {
+            background: linear-gradient(135deg, #805ad5, #6b46c1);
+        }
+
+        .insights-icon.opportunities {
+            background: linear-gradient(135deg, #ecc94b, #d69e2e);
+        }
+
+        .insights-title {
+            font-weight: 600;
+            font-size: 16px;
+            color: #2d3748;
+        }
+
+        .insights-subtitle {
+            font-size: 13px;
+            color: #718096;
+        }
+
+        .insight-summary {
+            font-size: 14px;
+            color: #2d3748;
+            font-weight: 500;
+        }
+
+        .insights-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .insights-list li {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 20px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid #edf2f7;
+        }
+
+        .insights-list li:last-child {
+            padding-bottom: 0;
+            border-bottom: none;
+        }
+
+        .insight-title {
+            font-weight: 600;
+            color: #2d3748;
+        }
+
+        .insight-subtitle {
+            font-size: 12px;
+            color: #a0aec0;
+        }
+
+        .insight-metric {
+            font-weight: 600;
+            color: #4a5568;
+            white-space: nowrap;
+        }
+
+        .insight-empty {
+            font-size: 14px;
+            color: #a0aec0;
         }
 
         /* Charts */


### PR DESCRIPTION
## Summary
- expand the analytics module with additional rollups and insight cards
- add styling for the new analytics summaries and icons
- sort analytics data by view count before rendering the table

## Testing
- php -l CMS/modules/analytics/view.php
- php -l CMS/modules/analytics/analytics_data.php

------
https://chatgpt.com/codex/tasks/task_e_68d71f2a0d608331a551cc2a0bd9a345