### PR TITLE
Add performance speed dashboard module

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -102,6 +102,10 @@ $settings = get_cached_json($settingsFile);
                         <div class="nav-icon"><i class="fas fa-clipboard-list"></i></div>
                         <div class="nav-text">Logs</div>
                     </div>
+                    <div class="nav-item" data-section="speed">
+                        <div class="nav-icon"><i class="fas fa-gauge-high"></i></div>
+                        <div class="nav-text">Performance</div>
+                    </div>
                     <div class="nav-item" data-section="accessibility">
                         <div class="nav-icon"><i class="fas fa-universal-access"></i></div>
                         <div class="nav-text">Accessibility</div>

--- a/CMS/modules/speed/speed.js
+++ b/CMS/modules/speed/speed.js
@@ -1,0 +1,513 @@
+(function ($) {
+    'use strict';
+
+    function loadSpeedModule(params) {
+        const $container = $('#contentContainer');
+        if (!$container.length || typeof $.fn.load !== 'function') {
+            return false;
+        }
+
+        const query = params ? ('?' + params) : '';
+        $container.load('modules/speed/view.php' + query, function () {
+            $container.find('.content-section').addClass('active');
+            $.getScript('modules/speed/speed.js').fail(function () {
+                // no-op if the script fails to reload
+            });
+        });
+        return true;
+    }
+
+    function getScoreClass(score) {
+        if (score >= 90) {
+            return 'speed-score--a';
+        }
+        if (score >= 80) {
+            return 'speed-score--b';
+        }
+        if (score >= 70) {
+            return 'speed-score--c';
+        }
+        return 'speed-score--d';
+    }
+
+    function getGradeBadge(grade) {
+        switch ((grade || '').toUpperCase()) {
+            case 'A':
+                return 'grade-a';
+            case 'B':
+                return 'grade-b';
+            case 'C':
+                return 'grade-c';
+            default:
+                return 'grade-d';
+        }
+    }
+
+    function getImpactLabel(impact) {
+        switch (impact) {
+            case 'critical':
+                return 'Critical';
+            case 'serious':
+                return 'Major';
+            case 'moderate':
+                return 'Moderate';
+            case 'minor':
+                return 'Minor';
+            default:
+                return 'Review';
+        }
+    }
+
+    function formatAlertSummary(alerts) {
+        if (!alerts) {
+            return '';
+        }
+        const segments = [];
+        if (alerts.critical) {
+            segments.push(alerts.critical + ' critical');
+        }
+        if (alerts.serious) {
+            segments.push(alerts.serious + ' major');
+        }
+        if (alerts.moderate) {
+            segments.push(alerts.moderate + ' moderate');
+        }
+        if (alerts.minor) {
+            segments.push(alerts.minor + ' minor');
+        }
+        if (!segments.length) {
+            return 'No outstanding alerts';
+        }
+        return (alerts.total || segments.length) + ' total (' + segments.join(', ') + ')';
+    }
+
+    function renderMetricList(metrics) {
+        if (!metrics) {
+            return '';
+        }
+        const weight = metrics.weightKb || 0;
+        const images = metrics.imageCount || 0;
+        const scripts = metrics.scriptCount || 0;
+        const stylesheets = (metrics.stylesheetCount || 0) + (metrics.inlineStyles || 0);
+        const domNodes = metrics.domNodes || 0;
+        const iframeCount = metrics.iframeCount || 0;
+        const avgImageWeight = metrics.avgImageWeight || 0;
+        return [
+            '<li><span class="label">Estimated weight</span><span class="value">' + weight + ' KB</span><span class="hint">Aim for under 500 KB for primary content.</span></li>',
+            '<li><span class="label">Images</span><span class="value">' + images + '</span><span class="hint">' + (images > 10 ? 'Consider lazy loading and compression.' : 'Image usage looks healthy.') + '</span></li>',
+            '<li><span class="label">Average image weight</span><span class="value">' + avgImageWeight + ' KB</span><span class="hint">Smaller than 50 KB keeps pages snappy.</span></li>',
+            '<li><span class="label">Scripts</span><span class="value">' + scripts + '</span><span class="hint">' + (scripts > 5 ? 'Bundle and defer non-critical code.' : 'Script budget within limits.') + '</span></li>',
+            '<li><span class="label">Stylesheets</span><span class="value">' + stylesheets + '</span><span class="hint">Deliver only the CSS needed for first paint.</span></li>',
+            '<li><span class="label">DOM nodes</span><span class="value">' + domNodes + '</span><span class="hint">Keep below 1,500 for smooth rendering.</span></li>',
+            '<li><span class="label">Embeds</span><span class="value">' + iframeCount + '</span><span class="hint">Lazy-load video or map embeds to avoid jank.</span></li>'
+        ].join('');
+    }
+
+    function filterPages(data, filter, query) {
+        return data.filter(function (page) {
+            let matchesFilter = true;
+            switch (filter) {
+                case 'slow':
+                    matchesFilter = page.performanceCategory === 'slow';
+                    break;
+                case 'monitor':
+                    matchesFilter = page.performanceCategory === 'monitor';
+                    break;
+                case 'fast':
+                    matchesFilter = page.performanceCategory === 'fast';
+                    break;
+                default:
+                    matchesFilter = true;
+            }
+
+            if (!matchesFilter) {
+                return false;
+            }
+
+            if (!query) {
+                return true;
+            }
+
+            const haystacks = [
+                page.title || '',
+                page.url || '',
+                page.path || '',
+                page.summaryLine || '',
+                page.statusMessage || '',
+                page.grade || '',
+                page.performanceCategory || ''
+            ];
+            if (page.issues && Array.isArray(page.issues.preview)) {
+                haystacks.push(page.issues.preview.join(' '));
+            }
+            return haystacks.join(' ').toLowerCase().indexOf(query) !== -1;
+        });
+    }
+
+    function updateFilterPills(data, $buttons) {
+        const counts = {
+            all: data.length,
+            slow: 0,
+            monitor: 0,
+            fast: 0
+        };
+
+        data.forEach(function (page) {
+            if (page.performanceCategory === 'slow') {
+                counts.slow += 1;
+            } else if (page.performanceCategory === 'monitor') {
+                counts.monitor += 1;
+            } else if (page.performanceCategory === 'fast') {
+                counts.fast += 1;
+            }
+        });
+
+        $buttons.each(function () {
+            const $btn = $(this);
+            const type = $btn.data('speed-filter');
+            const $count = $btn.find('.a11y-filter-count');
+            if ($count.length && Object.prototype.hasOwnProperty.call(counts, type)) {
+                $count.text(counts[type]);
+            }
+        });
+    }
+
+    function createIssueTags(page) {
+        if (!page.issues || !Array.isArray(page.issues.preview)) {
+            return '';
+        }
+        let severityClass = '';
+        if (page.alerts && page.alerts.critical > 0) {
+            severityClass = 'critical';
+        } else if (page.alerts && page.alerts.serious > 0) {
+            severityClass = 'serious';
+        }
+        return page.issues.preview.map(function (issue) {
+            return '<span class="a11y-issue-tag ' + severityClass + '">' + issue + '</span>';
+        }).join('');
+    }
+
+    function createCard(page) {
+        const $card = $('<article>', {
+            class: 'a11y-page-card',
+            tabindex: 0,
+            role: 'listitem',
+            'data-slug': page.slug
+        });
+
+        const weight = page.metrics && page.metrics.weightKb ? page.metrics.weightKb + ' KB' : '—';
+        const alertsTotal = page.alerts && typeof page.alerts.total !== 'undefined' ? page.alerts.total : (page.warnings || 0);
+
+        const cardHtml = [
+            '<div class="a11y-page-card__header">',
+            '<div class="a11y-page-score ' + getScoreClass(page.performanceScore) + '">' + (page.performanceScore || 0) + '%</div>',
+            '<h3 class="a11y-page-title">' + (page.title || 'Untitled') + '</h3>',
+            '<p class="a11y-page-url">' + (page.url || '') + '</p>',
+            '</div>',
+            '<div class="a11y-page-card__metrics">',
+            '<div><span class="label">Grade</span><span class="value ' + getGradeBadge(page.grade) + '">' + (page.grade || '—') + '</span></div>',
+            '<div><span class="label">Alerts</span><span class="value">' + alertsTotal + '</span></div>',
+            '<div><span class="label">Weight</span><span class="value">' + weight + '</span></div>',
+            '</div>',
+            '<div class="a11y-page-card__issues">',
+            '<div class="a11y-issue-tags">' + createIssueTags(page) + '</div>',
+            '</div>'
+        ].join('');
+
+        $card.html(cardHtml);
+        return $card;
+    }
+
+    function createTableRow(page) {
+        const $row = $('<div>', {
+            class: 'a11y-table-row',
+            role: 'row',
+            'data-slug': page.slug
+        });
+
+        const alertsSummary = formatAlertSummary(page.alerts);
+        const weight = page.metrics && page.metrics.weightKb ? page.metrics.weightKb + ' KB' : '—';
+
+        const rowHtml = [
+            '<div class="a11y-table-cell">',
+            '<div class="title">' + (page.title || 'Untitled') + '</div>',
+            '<div class="subtitle">' + (page.url || '') + '</div>',
+            '</div>',
+            '<div class="a11y-table-cell score">',
+            '<span class="a11y-table-score ' + getScoreClass(page.performanceScore) + '">' + (page.performanceScore || 0) + '%</span>',
+            '</div>',
+            '<div class="a11y-table-cell level"><span class="' + getGradeBadge(page.grade) + '">' + (page.grade || '—') + '</span></div>',
+            '<div class="a11y-table-cell">' + alertsSummary + '</div>',
+            '<div class="a11y-table-cell">' + weight + '</div>',
+            '<div class="a11y-table-cell">' + (page.lastScanned || '') + '</div>',
+            '<div class="a11y-table-cell actions"><button type="button" class="a11y-btn a11y-btn--icon" data-speed-action="open-detail" data-slug="' + page.slug + '"><i class="fas fa-gauge-high" aria-hidden="true"></i><span class="sr-only">Open detail</span></button></div>'
+        ].join('');
+
+        $row.html(rowHtml);
+        return $row;
+    }
+
+    $(function () {
+        const data = Array.isArray(window.speedDashboardData) ? window.speedDashboardData : [];
+        const stats = window.speedDashboardStats || {};
+        const dataMap = {};
+        data.forEach(function (page) {
+            dataMap[page.slug] = page;
+        });
+
+        const $grid = $('#speedPagesGrid');
+        const $tableView = $('#speedTableView');
+        const $tableBody = $('#speedTableBody');
+        const $empty = $('#speedEmptyState');
+        const $filterButtons = $('[data-speed-filter]');
+        const $viewButtons = $('[data-speed-view]');
+        const $searchInput = $('#speedSearchInput');
+        const $modal = $('#speedPageDetail');
+        const $modalClose = $('#speedDetailClose');
+        const $modalMetrics = $('#speedDetailMetrics');
+        const $modalIssues = $('#speedDetailIssues');
+        const $modalScore = $('#speedDetailScore');
+        const $modalGrade = $('#speedDetailGrade');
+        const $modalAlerts = $('#speedDetailAlerts');
+        const $modalTitle = $('#speedDetailTitle');
+        const $modalUrl = $('#speedDetailUrl');
+        const $modalDescription = $('#speedDetailDescription');
+        const $fullAuditBtn = $modal.find('[data-speed-action="full-diagnose"]');
+        const $scanAllBtn = $('#speedScanAllBtn');
+        const $downloadReportBtn = $('#speedDownloadReport');
+        const $heroHeaviest = $('[data-speed-action="view-heaviest"]');
+
+        let currentFilter = 'all';
+        let currentView = 'grid';
+        let filteredPages = data.slice();
+        let activeSlug = null;
+
+        function closeModal() {
+            activeSlug = null;
+            $modal.attr('hidden', true).removeClass('is-visible');
+        }
+
+        function openModal(page) {
+            if (!page) {
+                return;
+            }
+            activeSlug = page.slug;
+            $modalTitle.text(page.title || 'Performance details');
+            $modalUrl.text(page.url || '');
+            $modalDescription.text(page.summaryLine || page.statusMessage || '');
+            $modalScore.text((page.performanceScore || 0) + '%');
+            $modalScore.removeClass('speed-score--a speed-score--b speed-score--c speed-score--d').addClass(getScoreClass(page.performanceScore));
+            $modalGrade.text(page.grade || '—');
+            $modalGrade.removeClass('grade-a grade-b grade-c grade-d').addClass(getGradeBadge(page.grade));
+            $modalAlerts.text(formatAlertSummary(page.alerts));
+            $modalMetrics.html(renderMetricList(page.metrics));
+
+            if (page.issues && Array.isArray(page.issues.details) && page.issues.details.length) {
+                const issueItems = page.issues.details.map(function (issue) {
+                    const impact = getImpactLabel(issue.impact);
+                    return '<li><span class="issue">' + issue.description + '</span><span class="impact impact-' + issue.impact + '">' + impact + '</span><span class="tip">' + issue.recommendation + '</span></li>';
+                });
+                $modalIssues.html(issueItems.join(''));
+            } else {
+                $modalIssues.html('<li class="no-issues">No outstanding alerts detected.</li>');
+            }
+
+            $modal.attr('hidden', false).addClass('is-visible');
+        }
+
+        function render() {
+            if (!$grid.length) {
+                return;
+            }
+
+            if (!filteredPages.length) {
+                $grid.empty().attr('hidden', true);
+                $tableView.attr('hidden', true);
+                $empty.attr('hidden', false);
+                return;
+            }
+
+            $empty.attr('hidden', true);
+
+            if (currentView === 'grid') {
+                $grid.attr('hidden', false);
+                $tableView.attr('hidden', true);
+                $grid.empty();
+                filteredPages.forEach(function (page) {
+                    $grid.append(createCard(page));
+                });
+            } else {
+                $grid.attr('hidden', true).empty();
+                $tableView.attr('hidden', false);
+                $tableBody.empty();
+                filteredPages.forEach(function (page) {
+                    $tableBody.append(createTableRow(page));
+                });
+            }
+        }
+
+        function applyFilters() {
+            const query = ($searchInput.val() || '').toLowerCase();
+            filteredPages = filterPages(data, currentFilter, query);
+            render();
+        }
+
+        if ($grid.length) {
+            updateFilterPills(data, $filterButtons);
+            render();
+        }
+
+        $filterButtons.on('click', function () {
+            const $btn = $(this);
+            currentFilter = $btn.data('speed-filter') || 'all';
+            $filterButtons.removeClass('active');
+            $btn.addClass('active');
+            applyFilters();
+        });
+
+        $viewButtons.on('click', function () {
+            const $btn = $(this);
+            currentView = $btn.data('speed-view') || 'grid';
+            $viewButtons.removeClass('active');
+            $btn.addClass('active');
+            render();
+        });
+
+        $searchInput.on('input', function () {
+            applyFilters();
+        });
+
+        $grid.on('click', '.a11y-page-card', function () {
+            const slug = $(this).data('slug');
+            openModal(dataMap[slug]);
+        });
+
+        $grid.on('keydown', '.a11y-page-card', function (event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                const slug = $(this).data('slug');
+                openModal(dataMap[slug]);
+            }
+        });
+
+        $tableBody.on('click', '.a11y-table-row', function (event) {
+            const $target = $(event.target);
+            if ($target.closest('[data-speed-action="open-detail"]').length) {
+                return;
+            }
+            const slug = $(this).data('slug');
+            openModal(dataMap[slug]);
+        });
+
+        $tableBody.on('click', '[data-speed-action="open-detail"]', function (event) {
+            event.stopPropagation();
+            const slug = $(this).data('slug');
+            if (!loadSpeedModule('page=' + encodeURIComponent(slug))) {
+                if (stats.detailBaseUrl) {
+                    window.location.href = stats.detailBaseUrl + encodeURIComponent(slug);
+                }
+            }
+        });
+
+        if ($modal.length) {
+            $(document).off('keydown.speedModal');
+            $modal.on('click', function (event) {
+                if (event.target === this) {
+                    closeModal();
+                }
+            });
+
+            $modalClose.on('click', function () {
+                closeModal();
+            });
+
+            $(document).on('keydown.speedModal', function (event) {
+                if (event.key === 'Escape' && $modal.hasClass('is-visible')) {
+                    closeModal();
+                }
+            });
+
+            $fullAuditBtn.on('click', function () {
+                if (!activeSlug) {
+                    return;
+                }
+                if (!loadSpeedModule('page=' + encodeURIComponent(activeSlug))) {
+                    if (stats.detailBaseUrl) {
+                        window.location.href = stats.detailBaseUrl + encodeURIComponent(activeSlug);
+                    }
+                }
+            });
+        }
+
+        if ($scanAllBtn.length) {
+            $scanAllBtn.on('click', function () {
+                const $btn = $(this);
+                if ($btn.prop('disabled')) {
+                    return;
+                }
+                $btn.prop('disabled', true).addClass('is-loading');
+                const $icon = $btn.find('i');
+                const originalIcon = $icon.attr('class');
+                $icon.attr('class', 'fas fa-spinner fa-spin');
+                $btn.find('span').text('Scanning...');
+                window.setTimeout(function () {
+                    $icon.attr('class', originalIcon);
+                    $btn.find('span').text('Run Speed Scan');
+                    $btn.prop('disabled', false).removeClass('is-loading');
+                    window.alert('Speed scan complete!\n\nIn production this would trigger Lighthouse or WebPageTest runs for every page and refresh the dashboard with updated metrics.');
+                }, 1600);
+            });
+        }
+
+        if ($downloadReportBtn.length) {
+            $downloadReportBtn.on('click', function () {
+                window.alert('Preparing performance export...\n\nThe report will include asset weight, script budgets, lazy-loading recommendations, and before/after comparisons.');
+            });
+        }
+
+        if ($heroHeaviest.length) {
+            $heroHeaviest.on('click', function () {
+                const slug = $(this).data('speed-slug');
+                if (!slug) {
+                    return;
+                }
+                if (!loadSpeedModule('page=' + encodeURIComponent(slug))) {
+                    if (stats.detailBaseUrl) {
+                        window.location.href = stats.detailBaseUrl + encodeURIComponent(slug);
+                    }
+                }
+            });
+        }
+
+        const $detailPage = $('#speedDetailPage');
+        if ($detailPage.length) {
+            const pageSlug = $detailPage.data('page-slug');
+            const pageData = dataMap[pageSlug];
+            const $rescanBtn = $detailPage.find('[data-speed-action="rescan-page"]');
+            const $exportBtn = $detailPage.find('[data-speed-action="export-page-report"]');
+
+            if ($rescanBtn.length) {
+                $rescanBtn.on('click', function () {
+                    window.alert('Re-running speed diagnostics for this page...\n\nThis would trigger a fresh performance audit capturing Core Web Vitals, asset payloads, and blocking resources.');
+                });
+            }
+
+            if ($exportBtn.length) {
+                $exportBtn.on('click', function () {
+                    window.alert('Exporting detailed speed report...\n\nThe export would include filmstrips, resource waterfalls, and suggested optimizations for this specific page.');
+                });
+            }
+
+            if (pageData) {
+                const $detailMetrics = $detailPage.find('.a11y-detail-metrics');
+                const $detailIssuesList = $detailPage.find('.a11y-issue-list');
+                if ($detailMetrics.length) {
+                    $detailMetrics.attr('data-score', pageData.performanceScore);
+                }
+                if ($detailIssuesList.length && (!pageData.issues || !pageData.issues.details || !pageData.issues.details.length)) {
+                    $detailIssuesList.replaceWith('<p class="a11y-detail-success">This page passed the automated checks with no remaining alerts.</p>');
+                }
+            }
+        }
+    });
+}(jQuery));

--- a/CMS/modules/speed/view.php
+++ b/CMS/modules/speed/view.php
@@ -1,0 +1,670 @@
+<?php
+// File: modules/speed/view.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
+require_login();
+
+$pagesFile = __DIR__ . '/../../data/pages.json';
+$pages = read_json_file($pagesFile);
+$settingsFile = __DIR__ . '/../../data/settings.json';
+$settings = read_json_file($settingsFile);
+$menusFile = __DIR__ . '/../../data/menus.json';
+$menus = read_json_file($menusFile);
+
+$scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+if (substr($scriptBase, -4) === '/CMS') {
+    $scriptBase = substr($scriptBase, 0, -4);
+}
+$scriptBase = rtrim($scriptBase, '/');
+
+$templateDir = realpath(__DIR__ . '/../../../theme/templates/pages');
+
+function capture_template_html(string $templateFile, array $settings, array $menus, string $scriptBase): string {
+    $page = ['content' => '{{CONTENT}}'];
+    $themeBase = $scriptBase . '/theme';
+    ob_start();
+    include $templateFile;
+    $html = ob_get_clean();
+    $html = preg_replace('/<div class="drop-area"><\/div>/', '{{CONTENT}}', $html, 1);
+    if (strpos($html, '{{CONTENT}}') === false) {
+        $html .= '{{CONTENT}}';
+    }
+    $html = preg_replace('#<templateSetting[^>]*>.*?</templateSetting>#si', '', $html);
+    $html = preg_replace('#<div class="block-controls"[^>]*>.*?</div>#si', '', $html);
+    $html = str_replace('draggable="true"', '', $html);
+    $html = preg_replace('#\sdata-ts="[^"]*"#i', '', $html);
+    $html = preg_replace('#\sdata-(?:blockid|template|original|active|custom_[A-Za-z0-9_-]+)="[^"]*"#i', '', $html);
+    return $html;
+}
+
+function build_page_html(array $page, array $settings, array $menus, string $scriptBase, ?string $templateDir): string {
+    static $templateCache = [];
+
+    if (!$templateDir) {
+        return (string)($page['content'] ?? '');
+    }
+
+    $templateName = !empty($page['template']) ? basename($page['template']) : 'page.php';
+    $templateFile = $templateDir . DIRECTORY_SEPARATOR . $templateName;
+    if (!is_file($templateFile)) {
+        return (string)($page['content'] ?? '');
+    }
+
+    if (!isset($templateCache[$templateFile])) {
+        $templateCache[$templateFile] = capture_template_html($templateFile, $settings, $menus, $scriptBase);
+    }
+
+    $templateHtml = $templateCache[$templateFile];
+    $content = (string)($page['content'] ?? '');
+    return str_replace('{{CONTENT}}', $content, $templateHtml);
+}
+
+function describe_performance_grade(string $grade): string {
+    switch ($grade) {
+        case 'A':
+            return 'This page is highly optimized and should feel fast for most visitors.';
+        case 'B':
+            return 'Overall performance is strong with a few opportunities for speed gains.';
+        case 'C':
+            return 'This page needs optimization to avoid noticeable slowdowns during peak traffic.';
+        default:
+            return 'Heavy assets or blocking scripts are likely to cause a slow experience. Prioritize fixes soon.';
+    }
+}
+
+function summarize_alerts(array $alerts): string {
+    $parts = [];
+    if (!empty($alerts['critical'])) {
+        $parts[] = $alerts['critical'] . ' critical';
+    }
+    if (!empty($alerts['serious'])) {
+        $parts[] = $alerts['serious'] . ' major';
+    }
+    if (!empty($alerts['moderate'])) {
+        $parts[] = $alerts['moderate'] . ' moderate';
+    }
+    if (!empty($alerts['minor'])) {
+        $parts[] = $alerts['minor'] . ' minor';
+    }
+
+    if (empty($parts)) {
+        return 'No outstanding alerts detected';
+    }
+
+    $total = $alerts['total'] ?? array_sum($alerts);
+    return $total . ' total (' . implode(', ', $parts) . ')';
+}
+
+function grade_to_score_class(string $grade): string {
+    switch ($grade) {
+        case 'A':
+            return 'speed-score--a';
+        case 'B':
+            return 'speed-score--b';
+        case 'C':
+            return 'speed-score--c';
+        default:
+            return 'speed-score--d';
+    }
+}
+
+function grade_to_badge_class(string $grade): string {
+    switch ($grade) {
+        case 'A':
+            return 'grade-a';
+        case 'B':
+            return 'grade-b';
+        case 'C':
+            return 'grade-c';
+        default:
+            return 'grade-d';
+    }
+}
+
+libxml_use_internal_errors(true);
+
+$report = [];
+$totalPages = 0;
+$scoreSum = 0;
+$criticalAlertsTotal = 0;
+$fastPages = 0;
+$slowPages = 0;
+$pageEntryMap = [];
+$filterCounts = [
+    'all' => 0,
+    'slow' => 0,
+    'monitor' => 0,
+    'fast' => 0,
+];
+$heaviestPage = null;
+$scanTimestamp = date('M j, Y g:i A');
+
+foreach ($pages as $page) {
+    $title = $page['title'] ?? 'Untitled';
+    $slug = $page['slug'] ?? '';
+    $path = '/' . ltrim($slug, '/');
+    $pageHtml = build_page_html($page, $settings, $menus, $scriptBase, $templateDir);
+
+    $doc = new DOMDocument();
+    $loaded = trim($pageHtml) !== '' && $doc->loadHTML('<?xml encoding="utf-8" ?>' . $pageHtml);
+
+    $htmlBytes = strlen($pageHtml);
+    $htmlSizeKb = round($htmlBytes / 1024, 1);
+    $wordCount = str_word_count(strip_tags($pageHtml));
+
+    $imageCount = 0;
+    $scriptCount = 0;
+    $inlineScriptCount = 0;
+    $stylesheetCount = 0;
+    $inlineStyleBlocks = 0;
+    $iframeCount = 0;
+    $domNodes = 0;
+
+    if ($loaded) {
+        $domNodes = $doc->getElementsByTagName('*')->length;
+        $images = $doc->getElementsByTagName('img');
+        $imageCount = $images->length;
+
+        $scripts = $doc->getElementsByTagName('script');
+        foreach ($scripts as $script) {
+            $scriptCount++;
+            if (!$script->hasAttribute('src')) {
+                $inlineScriptCount++;
+            }
+        }
+
+        $links = $doc->getElementsByTagName('link');
+        foreach ($links as $link) {
+            if (strtolower($link->getAttribute('rel')) === 'stylesheet') {
+                $stylesheetCount++;
+            }
+        }
+
+        $styles = $doc->getElementsByTagName('style');
+        $inlineStyleBlocks = $styles->length;
+
+        $iframes = $doc->getElementsByTagName('iframe');
+        $iframeCount = $iframes->length;
+    } else {
+        $domNodes = max(0, substr_count($pageHtml, '<'));
+        $imageCount = substr_count(strtolower($pageHtml), '<img');
+        $scriptCount = substr_count(strtolower($pageHtml), '<script');
+        $stylesheetCount = substr_count(strtolower($pageHtml), 'rel="stylesheet"');
+        $inlineScriptCount = max(0, $scriptCount - substr_count(strtolower($pageHtml), 'src='));
+        $inlineStyleBlocks = substr_count(strtolower($pageHtml), '<style');
+        $iframeCount = substr_count(strtolower($pageHtml), '<iframe');
+    }
+
+    $estimatedWeightKb = round($htmlSizeKb + ($imageCount * 45) + ($scriptCount * 12) + ($stylesheetCount * 8), 1);
+    $avgImageWeight = $imageCount > 0 ? round($estimatedWeightKb / $imageCount, 1) : 0;
+
+    $issues = [];
+    $addIssue = static function (array &$issues, string $impact, string $description, string $recommendation): void {
+        $issues[] = [
+            'impact' => $impact,
+            'description' => $description,
+            'recommendation' => $recommendation,
+        ];
+    };
+
+    if ($estimatedWeightKb > 900) {
+        $addIssue($issues, 'critical', 'Estimated page weight exceeds 900 KB', 'Compress large assets, enable caching, and consider splitting content across lighter templates.');
+    } elseif ($estimatedWeightKb > 600) {
+        $addIssue($issues, 'serious', 'Estimated page weight above 600 KB', 'Minify HTML, compress imagery, and lazy-load non-critical resources.');
+    } elseif ($estimatedWeightKb > 400) {
+        $addIssue($issues, 'moderate', 'Estimated page weight above 400 KB', 'Audit media assets and remove unused scripts or styles to reduce payload.');
+    }
+
+    if ($imageCount > 15) {
+        $addIssue($issues, 'serious', $imageCount . ' images detected', 'Use responsive image sizes, next-gen formats, and defer offscreen assets.');
+    } elseif ($imageCount > 9) {
+        $addIssue($issues, 'moderate', $imageCount . ' images detected', 'Review gallery content and apply lazy loading for below-the-fold imagery.');
+    }
+
+    if ($scriptCount > 7) {
+        $addIssue($issues, 'serious', $scriptCount . ' scripts included', 'Bundle and defer non-critical JavaScript to shorten the main thread.');
+    } elseif ($scriptCount > 4) {
+        $addIssue($issues, 'moderate', $scriptCount . ' scripts included', 'Audit third-party embeds and remove unused libraries to improve speed.');
+    }
+
+    if ($stylesheetCount + $inlineStyleBlocks > 6) {
+        $addIssue($issues, 'minor', 'Multiple blocking stylesheets detected', 'Combine styles where possible and inline only the critical CSS.');
+    }
+
+    if ($inlineScriptCount > 0) {
+        $addIssue($issues, 'minor', $inlineScriptCount . ' inline script block(s)', 'Move inline logic into external files to improve caching and diagnostics.');
+    }
+
+    if ($domNodes > 1500) {
+        $addIssue($issues, 'moderate', 'Large DOM tree with ' . $domNodes . ' nodes', 'Simplify nested layouts and remove unnecessary wrappers to speed up rendering.');
+    } elseif ($domNodes > 1000) {
+        $addIssue($issues, 'minor', 'DOM tree approaching heavy threshold (' . $domNodes . ' nodes)', 'Consider breaking long pages into sections and trimming unused markup.');
+    }
+
+    if ($iframeCount > 0) {
+        $addIssue($issues, 'minor', $iframeCount . ' embedded frame(s)', 'Lazy-load embedded media or replace with preview placeholders to reduce startup cost.');
+    }
+
+    $critical = 0;
+    $serious = 0;
+    $moderate = 0;
+    $minor = 0;
+    foreach ($issues as $issue) {
+        switch ($issue['impact']) {
+            case 'critical':
+                $critical++;
+                break;
+            case 'serious':
+                $serious++;
+                break;
+            case 'moderate':
+                $moderate++;
+                break;
+            default:
+                $minor++;
+                break;
+        }
+    }
+
+    $alerts = [
+        'critical' => $critical,
+        'serious' => $serious,
+        'moderate' => $moderate,
+        'minor' => $minor,
+    ];
+    $alerts['total'] = array_sum($alerts);
+
+    $score = 100;
+    $score -= max(0, $estimatedWeightKb - 300) * 0.08;
+    $score -= max(0, $imageCount - 8) * 1.5;
+    $score -= max(0, $scriptCount - 5) * 2.5;
+    $score -= max(0, ($stylesheetCount + $inlineStyleBlocks) - 4) * 1.2;
+    $score -= max(0, $domNodes - 900) * 0.02;
+    $score -= $inlineScriptCount * 0.5;
+    $score = max(0, min(100, (int)round($score)));
+
+    if ($alerts['total'] === 0 && $score > 96) {
+        $score = 98;
+    }
+
+    if ($score >= 90) {
+        $grade = 'A';
+    } elseif ($score >= 80) {
+        $grade = 'B';
+    } elseif ($score >= 70) {
+        $grade = 'C';
+    } else {
+        $grade = 'D';
+    }
+
+    $performanceCategory = 'fast';
+    if ($alerts['critical'] > 0 || $score < 70) {
+        $performanceCategory = 'slow';
+    } elseif ($score < 90 || $alerts['serious'] > 0 || $grade === 'C') {
+        $performanceCategory = 'monitor';
+    }
+
+    switch ($performanceCategory) {
+        case 'fast':
+            $filterCounts['fast']++;
+            $fastPages++;
+            break;
+        case 'monitor':
+            $filterCounts['monitor']++;
+            break;
+        case 'slow':
+            $filterCounts['slow']++;
+            $slowPages++;
+            break;
+    }
+
+    $filterCounts['all']++;
+    $totalPages++;
+    $scoreSum += $score;
+    $criticalAlertsTotal += $alerts['critical'];
+
+    if ($heaviestPage === null || $estimatedWeightKb > $heaviestPage['weight']) {
+        $heaviestPage = [
+            'title' => $title,
+            'slug' => $slug,
+            'weight' => $estimatedWeightKb,
+            'url' => $path,
+        ];
+    }
+
+    $issuePreview = array_slice(array_map(static function ($detail) {
+        return $detail['description'];
+    }, $issues), 0, 4);
+    if (empty($issuePreview)) {
+        $issuePreview = ['No outstanding alerts'];
+    }
+
+    $pageData = [
+        'title' => $title,
+        'slug' => $slug,
+        'url' => $path,
+        'path' => $path,
+        'template' => $page['template'] ?? '',
+        'performanceScore' => $score,
+        'grade' => $grade,
+        'gradeClass' => grade_to_badge_class($grade),
+        'scoreClass' => grade_to_score_class($grade),
+        'alerts' => $alerts,
+        'warnings' => $alerts['serious'] + $alerts['moderate'] + $alerts['minor'],
+        'lastScanned' => $scanTimestamp,
+        'pageType' => !empty($page['template']) ? 'Template: ' . basename($page['template']) : 'Standard Page',
+        'performanceCategory' => $performanceCategory,
+        'issues' => [
+            'preview' => $issuePreview,
+            'details' => $issues,
+        ],
+        'metrics' => [
+            'weightKb' => $estimatedWeightKb,
+            'htmlSizeKb' => $htmlSizeKb,
+            'imageCount' => $imageCount,
+            'scriptCount' => $scriptCount,
+            'stylesheetCount' => $stylesheetCount,
+            'inlineScripts' => $inlineScriptCount,
+            'inlineStyles' => $inlineStyleBlocks,
+            'domNodes' => $domNodes,
+            'wordCount' => $wordCount,
+            'avgImageWeight' => $avgImageWeight,
+            'iframeCount' => $iframeCount,
+        ],
+    ];
+
+    $pageData['statusMessage'] = describe_performance_grade($grade);
+    $pageData['summaryLine'] = sprintf(
+        'Performance score %d%%. %s.',
+        $score,
+        summarize_alerts($alerts)
+    );
+
+    $report[] = $pageData;
+    $pageEntryMap[$slug] = $pageData;
+}
+
+$avgScore = $totalPages > 0 ? (int)round($scoreSum / $totalPages) : 0;
+$lastScan = $scanTimestamp;
+
+$moduleUrl = $_SERVER['PHP_SELF'] . '?module=speed';
+$detailSlug = isset($_GET['page']) ? sanitize_text($_GET['page']) : null;
+$detailSlug = $detailSlug !== null ? trim($detailSlug) : null;
+
+$selectedPage = null;
+if ($detailSlug !== null && $detailSlug !== '') {
+    $selectedPage = $pageEntryMap[$detailSlug] ?? null;
+}
+
+libxml_clear_errors();
+
+$dashboardStats = [
+    'totalPages' => $totalPages,
+    'avgScore' => $avgScore,
+    'criticalAlerts' => $criticalAlertsTotal,
+    'fastPages' => $fastPages,
+    'slowPages' => $slowPages,
+    'filterCounts' => $filterCounts,
+    'moduleUrl' => $moduleUrl,
+    'detailBaseUrl' => $moduleUrl . '&page=',
+    'lastScan' => $lastScan,
+    'heaviestPage' => $heaviestPage,
+];
+?>
+<div class="content-section" id="performance">
+<?php if ($selectedPage): ?>
+    <div class="a11y-detail-page" id="speedDetailPage" data-page-slug="<?php echo htmlspecialchars($selectedPage['slug'], ENT_QUOTES); ?>">
+        <header class="a11y-detail-header">
+            <a href="<?php echo htmlspecialchars($moduleUrl, ENT_QUOTES); ?>" class="a11y-back-link" id="speedBackToDashboard">
+                <i class="fas fa-arrow-left" aria-hidden="true"></i>
+                <span>Back to Performance Dashboard</span>
+            </a>
+            <div class="a11y-detail-actions">
+                <button type="button" class="a11y-btn a11y-btn--ghost" data-speed-action="rescan-page">
+                    <i class="fas fa-rotate" aria-hidden="true"></i>
+                    <span>Rescan Page</span>
+                </button>
+                <button type="button" class="a11y-btn a11y-btn--secondary" data-speed-action="export-page-report">
+                    <i class="fas fa-file-export" aria-hidden="true"></i>
+                    <span>Export Speed Report</span>
+                </button>
+            </div>
+        </header>
+
+        <section class="a11y-health-card">
+            <div class="a11y-health-score">
+                <div class="a11y-health-score__value"><?php echo (int)$selectedPage['performanceScore']; ?><span>%</span></div>
+                <div class="a11y-health-score__label">Performance Score</div>
+                <span class="a11y-health-score__badge <?php echo htmlspecialchars($selectedPage['gradeClass']); ?>"><?php echo htmlspecialchars($selectedPage['grade']); ?></span>
+            </div>
+            <div class="a11y-health-summary">
+                <h1><?php echo htmlspecialchars($selectedPage['title']); ?></h1>
+                <p class="a11y-health-url"><?php echo htmlspecialchars($selectedPage['url']); ?></p>
+                <p><?php echo htmlspecialchars($selectedPage['statusMessage']); ?></p>
+                <p class="a11y-health-overview"><?php echo htmlspecialchars($selectedPage['summaryLine']); ?></p>
+                <div class="a11y-quick-stats">
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['weightKb']; ?> KB</div>
+                        <div class="a11y-quick-stat__label">Estimated Weight</div>
+                    </div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['imageCount']; ?></div>
+                        <div class="a11y-quick-stat__label">Images</div>
+                    </div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['scriptCount']; ?></div>
+                        <div class="a11y-quick-stat__label">Scripts</div>
+                    </div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['alerts']['critical']; ?></div>
+                        <div class="a11y-quick-stat__label">Critical Alerts</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="a11y-detail-grid">
+            <article class="a11y-detail-card">
+                <h2>Performance checkpoints</h2>
+                <div class="a11y-detail-metrics">
+                    <div>
+                        <span class="a11y-detail-metric__label">HTML payload</span>
+                        <span class="a11y-detail-metric__value"><?php echo $selectedPage['metrics']['htmlSizeKb']; ?> KB</span>
+                        <span class="a11y-detail-metric__hint">Keep markup lean and remove unused sections.</span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-metric__label">Scripts</span>
+                        <span class="a11y-detail-metric__value"><?php echo $selectedPage['metrics']['scriptCount']; ?> total (<?php echo $selectedPage['metrics']['inlineScripts']; ?> inline)</span>
+                        <span class="a11y-detail-metric__hint">Defer non-critical logic and audit third-party tags.</span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-metric__label">Stylesheets</span>
+                        <span class="a11y-detail-metric__value"><?php echo $selectedPage['metrics']['stylesheetCount']; ?> linked, <?php echo $selectedPage['metrics']['inlineStyles']; ?> inline</span>
+                        <span class="a11y-detail-metric__hint">Inline only critical CSS, load the rest asynchronously.</span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-metric__label">DOM nodes</span>
+                        <span class="a11y-detail-metric__value"><?php echo $selectedPage['metrics']['domNodes']; ?></span>
+                        <span class="a11y-detail-metric__hint">Keep below 1,500 for optimal rendering.</span>
+                    </div>
+                </div>
+            </article>
+            <article class="a11y-detail-card">
+                <h2>Alert breakdown</h2>
+                <ul class="a11y-violation-list">
+                    <li><span>Critical</span><span><?php echo $selectedPage['alerts']['critical']; ?></span></li>
+                    <li><span>Major</span><span><?php echo $selectedPage['alerts']['serious']; ?></span></li>
+                    <li><span>Moderate</span><span><?php echo $selectedPage['alerts']['moderate']; ?></span></li>
+                    <li><span>Minor</span><span><?php echo $selectedPage['alerts']['minor']; ?></span></li>
+                </ul>
+                <div class="a11y-detail-meta">
+                    <div>
+                        <span class="a11y-detail-meta__label">Last scanned</span>
+                        <span class="a11y-detail-meta__value"><?php echo htmlspecialchars($dashboardStats['lastScan']); ?></span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-meta__label">Page type</span>
+                        <span class="a11y-detail-meta__value"><?php echo htmlspecialchars($selectedPage['pageType']); ?></span>
+                    </div>
+                    <div>
+                        <span class="a11y-detail-meta__label">Warnings</span>
+                        <span class="a11y-detail-meta__value"><?php echo $selectedPage['warnings']; ?></span>
+                    </div>
+                </div>
+            </article>
+        </section>
+
+        <section class="a11y-detail-issues">
+            <div class="a11y-detail-issues__header">
+                <h2>Optimization opportunities</h2>
+                <span><?php echo $selectedPage['alerts']['total']; ?> total</span>
+            </div>
+            <?php if (!empty($selectedPage['issues']['details'])): ?>
+                <div class="a11y-issue-list">
+                    <?php foreach ($selectedPage['issues']['details'] as $issue): ?>
+                        <article class="a11y-issue-card impact-<?php echo htmlspecialchars($issue['impact']); ?>">
+                            <header>
+                                <h3><?php echo htmlspecialchars($issue['description']); ?></h3>
+                                <span class="a11y-impact-badge impact-<?php echo htmlspecialchars($issue['impact']); ?>"><?php echo ucfirst($issue['impact']); ?></span>
+                            </header>
+                            <p><?php echo htmlspecialchars($issue['recommendation']); ?></p>
+                        </article>
+                    <?php endforeach; ?>
+                </div>
+            <?php else: ?>
+                <p class="a11y-detail-success">This page passed the automated checks with no remaining alerts.</p>
+            <?php endif; ?>
+        </section>
+    </div>
+<?php else: ?>
+    <div class="a11y-dashboard" data-last-scan="<?php echo htmlspecialchars($dashboardStats['lastScan'], ENT_QUOTES); ?>">
+        <header class="a11y-hero">
+            <div class="a11y-hero-content">
+                <div>
+                    <h2 class="a11y-hero-title">Performance &amp; Speed Dashboard</h2>
+                    <p class="a11y-hero-subtitle">Track asset weight, script usage, and rendering health across every published page.</p>
+                </div>
+                <div class="a11y-hero-actions">
+                    <button type="button" id="speedScanAllBtn" class="a11y-btn a11y-btn--primary" data-speed-action="scan-all">
+                        <i class="fas fa-gauge-high" aria-hidden="true"></i>
+                        <span>Run Speed Scan</span>
+                    </button>
+                    <?php if (!empty($heaviestPage)): ?>
+                    <button type="button" class="a11y-btn a11y-btn--ghost" data-speed-action="view-heaviest" data-speed-slug="<?php echo htmlspecialchars($heaviestPage['slug'] ?? '', ENT_QUOTES); ?>" title="Estimated weight: <?php echo isset($heaviestPage['weight']) ? htmlspecialchars(number_format((float)$heaviestPage['weight'], 1), ENT_QUOTES) . ' KB' : ''; ?>">
+                        <i class="fas fa-weight-hanging" aria-hidden="true"></i>
+                        <span>Heaviest page: <?php echo htmlspecialchars($heaviestPage['title'] ?? ''); ?></span>
+                    </button>
+                    <?php endif; ?>
+                    <span class="a11y-hero-meta">
+                        <i class="fas fa-clock" aria-hidden="true"></i>
+                        Last scan: <?php echo htmlspecialchars($dashboardStats['lastScan']); ?>
+                    </span>
+                    <span class="a11y-hero-meta">
+                        <i class="fas fa-bolt" aria-hidden="true"></i>
+                        High-performing pages: <?php echo $dashboardStats['fastPages']; ?>
+                    </span>
+                </div>
+            </div>
+        </header>
+        <div class="a11y-overview-grid">
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="speedStatTotalPages"><?php echo $dashboardStats['totalPages']; ?></div>
+                <div class="a11y-overview-label">Total Pages</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="speedStatAvgScore"><?php echo $dashboardStats['avgScore']; ?>%</div>
+                <div class="a11y-overview-label">Average Score</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="speedStatCritical"><?php echo $dashboardStats['criticalAlerts']; ?></div>
+                <div class="a11y-overview-label">Critical Alerts</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="speedStatSlow"><?php echo $dashboardStats['slowPages']; ?></div>
+                <div class="a11y-overview-label">Pages needing attention</div>
+            </div>
+        </div>
+        <div class="a11y-controls">
+            <label class="a11y-search" for="speedSearchInput">
+                <i class="fas fa-search" aria-hidden="true"></i>
+                <input type="search" id="speedSearchInput" placeholder="Search pages by title, URL, or alert" aria-label="Search performance results">
+            </label>
+            <div class="a11y-filter-group" role="group" aria-label="Performance filters">
+                <button type="button" class="a11y-filter-btn active" data-speed-filter="all">All Pages <span class="a11y-filter-count" data-count="all"><?php echo $filterCounts['all']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-speed-filter="slow">Slow pages <span class="a11y-filter-count" data-count="slow"><?php echo $filterCounts['slow']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-speed-filter="monitor">Needs attention <span class="a11y-filter-count" data-count="monitor"><?php echo $filterCounts['monitor']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-speed-filter="fast">Performing well <span class="a11y-filter-count" data-count="fast"><?php echo $filterCounts['fast']; ?></span></button>
+            </div>
+            <div class="a11y-view-toggle" role="group" aria-label="Toggle layout">
+                <button type="button" class="a11y-view-btn active" data-speed-view="grid" aria-label="Grid view">
+                    <i class="fas fa-th-large" aria-hidden="true"></i>
+                </button>
+                <button type="button" class="a11y-view-btn" data-speed-view="table" aria-label="Table view">
+                    <i class="fas fa-list" aria-hidden="true"></i>
+                </button>
+            </div>
+        </div>
+        <div class="a11y-action-bar">
+            <div class="a11y-bulk-actions">
+                <button type="button" class="a11y-btn a11y-btn--secondary" id="speedDownloadReport">
+                    <i class="fas fa-download" aria-hidden="true"></i>
+                    <span>Download Speed Report</span>
+                </button>
+            </div>
+        </div>
+        <div class="a11y-pages-grid" id="speedPagesGrid" role="list"></div>
+        <div class="a11y-table-view" id="speedTableView" hidden>
+            <div class="a11y-table-header">
+                <div>Page</div>
+                <div>Score</div>
+                <div>Grade</div>
+                <div>Alerts</div>
+                <div>Est. Weight</div>
+                <div>Last Scanned</div>
+                <div>Action</div>
+            </div>
+            <div id="speedTableBody"></div>
+        </div>
+        <div class="a11y-empty-state" id="speedEmptyState" hidden>
+            <i class="fas fa-gauge-high" aria-hidden="true"></i>
+            <h3>No pages match your filters</h3>
+            <p>Try adjusting the search or choosing a different performance segment.</p>
+        </div>
+    </div>
+    <div class="a11y-page-detail" id="speedPageDetail" hidden role="dialog" aria-modal="true" aria-labelledby="speedDetailTitle">
+        <div class="a11y-detail-content">
+            <button type="button" class="a11y-detail-close" id="speedDetailClose" aria-label="Close performance details">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+            <header class="a11y-detail-modal-header">
+                <h2 id="speedDetailTitle">Page performance details</h2>
+                <p id="speedDetailUrl" class="a11y-detail-url"></p>
+                <p id="speedDetailDescription" class="a11y-detail-description"></p>
+            </header>
+            <div class="a11y-detail-modal-body">
+                <div class="a11y-detail-badges">
+                    <span class="a11y-detail-score" id="speedDetailScore"></span>
+                    <span class="a11y-detail-level" id="speedDetailGrade"></span>
+                    <span class="a11y-detail-violations" id="speedDetailAlerts"></span>
+                </div>
+                <ul class="a11y-detail-metric-list" id="speedDetailMetrics"></ul>
+                <div class="a11y-detail-issues-list">
+                    <h3>Key findings</h3>
+                    <ul id="speedDetailIssues"></ul>
+                </div>
+            </div>
+            <footer class="a11y-detail-modal-footer">
+                <button type="button" class="a11y-btn a11y-btn--primary" data-speed-action="full-diagnose">
+                    <i class="fas fa-gauge-simple-high" aria-hidden="true"></i>
+                    <span>Launch detailed audit</span>
+                </button>
+            </footer>
+        </div>
+    </div>
+<?php endif; ?>
+</div>
+<script>
+window.speedDashboardData = <?php echo json_encode($report, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+window.speedDashboardStats = <?php echo json_encode($dashboardStats, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+</script>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -740,6 +740,10 @@
         .a11y-score--aa { background: linear-gradient(135deg, #3b82f6, #2563eb); }
         .a11y-score--partial { background: linear-gradient(135deg, #f59e0b, #d97706); }
         .a11y-score--failing { background: linear-gradient(135deg, #ef4444, #dc2626); }
+        .speed-score--a { background: linear-gradient(135deg, #10b981, #059669); }
+        .speed-score--b { background: linear-gradient(135deg, #38bdf8, #0ea5e9); }
+        .speed-score--c { background: linear-gradient(135deg, #fbbf24, #f59e0b); }
+        .speed-score--d { background: linear-gradient(135deg, #f97316, #dc2626); }
 
         .a11y-page-title {
             font-size: 18px;
@@ -864,6 +868,10 @@
         .level-aa { background: #dbeafe; color: #1d4ed8; }
         .level-partial { background: #fef3c7; color: #92400e; }
         .level-failing { background: #fee2e2; color: #b91c1c; }
+        .grade-a { background: #dcfce7; color: #047857; }
+        .grade-b { background: #dbeafe; color: #1d4ed8; }
+        .grade-c { background: #fef3c7; color: #92400e; }
+        .grade-d { background: #fee2e2; color: #b91c1c; }
 
         .a11y-empty-state {
             background: #fff;


### PR DESCRIPTION
## Summary
- add a new System > Performance module that estimates per-page weight and categorizes alerts
- implement dashboard and detail views for performance data alongside modal interactions
- extend admin navigation and styling for new performance score and grade badges

## Testing
- php -l CMS/modules/speed/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d71e5d4d748331acbe34ed06b0e705