### PR TITLE
Expand dashboard to aggregate module metrics

### DIFF
--- a/CMS/modules/dashboard/dashboard.js
+++ b/CMS/modules/dashboard/dashboard.js
@@ -33,9 +33,24 @@ $(function(){
     function loadStats(){
         $.getJSON('modules/dashboard/dashboard_data.php', function(data){
             updateText('#statPages', data.pages);
+            updateText('#statPagesBreakdown', [data.pagesPublished, data.pagesDrafts, data.pagesScheduled], function(values){
+                const published = formatNumber(values[0]);
+                const drafts = formatNumber(values[1]);
+                const scheduled = formatNumber(values[2]);
+                return `Published: ${published} • Drafts: ${drafts} • Scheduled: ${scheduled}`;
+            });
             updateText('#statMedia', data.media);
             updateText('#statUsers', data.users);
+            updateText('#statUsersBreakdown', [data.usersAdmins, data.usersEditors, data.usersInactive], function(values){
+                const admins = formatNumber(values[0]);
+                const editors = formatNumber(values[1]);
+                const inactive = formatNumber(values[2]);
+                return `Admins: ${admins} • Editors: ${editors} • Inactive: ${inactive}`;
+            });
             updateText('#statViews', data.views);
+            updateText('#statViewsAverage', data.averageViews, function(value){
+                return `Average per page: ${formatNumber(value)}`;
+            });
 
             updateText('#statSeoScore', data.seoScore, formatPercent);
             updateText('#statSeoBreakdown', [data.seoOptimized, data.seoNeedsAttention], function(values){
@@ -63,6 +78,67 @@ $(function(){
                 const accessibility = formatNumber(values[1]);
                 return `SEO: ${seo} • Accessibility: ${accessibility}`;
             });
+
+            updateText('#statBlogPosts', data.blogsTotal);
+            updateText('#statBlogBreakdown', [data.blogsPublished, data.blogsDrafts, data.blogsScheduled], function(values){
+                const published = formatNumber(values[0]);
+                const drafts = formatNumber(values[1]);
+                const scheduled = formatNumber(values[2]);
+                return `Published: ${published} • Drafts: ${drafts} • Scheduled: ${scheduled}`;
+            });
+
+            updateText('#statForms', data.formsTotal);
+            updateText('#statFormsBreakdown', [data.formsFields, data.formsRequiredFields], function(values){
+                const fields = formatNumber(values[0]);
+                const required = formatNumber(values[1]);
+                return `Fields: ${fields} • Required: ${required}`;
+            });
+
+            updateText('#statMenus', data.menusTotal);
+            updateText('#statMenusBreakdown', [data.menusItems, data.menusNestedGroups], function(values){
+                const items = formatNumber(values[0]);
+                const nested = formatNumber(values[1]);
+                return `Items: ${items} • Nested groups: ${nested}`;
+            });
+
+            updateText('#statSettings', data.settingsCount);
+            updateText('#statSettingsBreakdown', data.settingsSocialProfiles, function(value){
+                return `Social profiles: ${formatNumber(value)}`;
+            });
+
+            updateText('#statSitemap', data.sitemapUrls);
+            updateText('#statSitemapBreakdown', data.sitemapLastGenerated, function(value){
+                if (!value) {
+                    return 'Last generated: Not yet generated';
+                }
+                return `Last generated: ${value}`;
+            });
+
+            updateText('#statLogs', data.logsEntries);
+            updateText('#statLogsBreakdown', data.logsLastActivity, function(value){
+                if (!value) {
+                    return 'Last activity: No history recorded';
+                }
+                return `Last activity: ${value}`;
+            });
+
+            const $topPages = $('#statTopPages');
+            if ($topPages.length) {
+                $topPages.empty();
+                if (Array.isArray(data.topPages) && data.topPages.length) {
+                    data.topPages.forEach(function(page){
+                        const title = page.title || 'Untitled Page';
+                        const views = formatNumber(page.views || 0);
+                        const status = page.published ? 'Published' : 'Draft';
+                        const $item = $('<li/>');
+                        $('<span/>').addClass('stat-list-title').text(title).appendTo($item);
+                        $('<span/>').addClass('stat-list-meta').text(`${views} views • ${status}`).appendTo($item);
+                        $topPages.append($item);
+                    });
+                } else {
+                    $topPages.append($('<li/>').addClass('stat-list-empty').text('No page analytics available yet.'));
+                }
+            }
         });
     }
     loadStats();

--- a/CMS/modules/dashboard/view.php
+++ b/CMS/modules/dashboard/view.php
@@ -9,6 +9,7 @@
                                     <div class="stat-number" id="statPages">0</div>
                                 </div>
                             </div>
+                            <div class="stat-subtext" id="statPagesBreakdown">Published: 0 • Drafts: 0 • Scheduled: 0</div>
                         </div>
                         <div class="stat-card">
                             <div class="stat-header">
@@ -27,6 +28,7 @@
                                     <div class="stat-number" id="statUsers">0</div>
                                 </div>
                             </div>
+                            <div class="stat-subtext" id="statUsersBreakdown">Admins: 0 • Editors: 0 • Inactive: 0</div>
                         </div>
                         <div class="stat-card">
                             <div class="stat-header">
@@ -36,6 +38,7 @@
                                     <div class="stat-number" id="statViews">0</div>
                                 </div>
                             </div>
+                            <div class="stat-subtext" id="statViewsAverage">Average per page: 0</div>
                         </div>
                         <div class="stat-card">
                             <div class="stat-header">
@@ -68,6 +71,78 @@
                                 </div>
                             </div>
                             <div class="stat-subtext" id="statAlertsBreakdown">SEO: 0 • Accessibility: 0</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon blogs"><i class="fa-solid fa-rss" aria-hidden="true"></i></div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Blog Posts</div>
+                                    <div class="stat-number" id="statBlogPosts">0</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statBlogBreakdown">Published: 0 • Drafts: 0 • Scheduled: 0</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon forms"><i class="fa-solid fa-wpforms" aria-hidden="true"></i></div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Forms</div>
+                                    <div class="stat-number" id="statForms">0</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statFormsBreakdown">Fields: 0 • Required: 0</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon menus"><i class="fa-solid fa-bars" aria-hidden="true"></i></div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Menus</div>
+                                    <div class="stat-number" id="statMenus">0</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statMenusBreakdown">Items: 0 • Nested groups: 0</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon settings"><i class="fa-solid fa-sliders" aria-hidden="true"></i></div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Site Settings</div>
+                                    <div class="stat-number" id="statSettings">0</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statSettingsBreakdown">Social profiles: 0</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon sitemap"><i class="fa-solid fa-sitemap" aria-hidden="true"></i></div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Sitemap URLs</div>
+                                    <div class="stat-number" id="statSitemap">0</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statSitemapBreakdown">Last generated: Not yet generated</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon logs"><i class="fa-solid fa-clock-rotate-left" aria-hidden="true"></i></div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Change Log</div>
+                                    <div class="stat-number" id="statLogs">0</div>
+                                </div>
+                            </div>
+                            <div class="stat-subtext" id="statLogsBreakdown">Last activity: No history recorded</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-header">
+                                <div class="stat-icon analytics"><i class="fa-solid fa-chart-column" aria-hidden="true"></i></div>
+                                <div class="stat-content">
+                                    <div class="stat-label">Top Pages</div>
+                                    <div class="stat-number">Top 5</div>
+                                </div>
+                            </div>
+                            <ul class="stat-list" id="statTopPages">
+                                <li class="stat-list-empty">Loading…</li>
+                            </ul>
                         </div>
                     </div>
                 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -363,6 +363,41 @@
             color: white;
         }
 
+        .stat-icon.blogs {
+            background: linear-gradient(135deg, #f97316, #ea580c);
+            color: white;
+        }
+
+        .stat-icon.forms {
+            background: linear-gradient(135deg, #4299e1, #3182ce);
+            color: white;
+        }
+
+        .stat-icon.menus {
+            background: linear-gradient(135deg, #4fd1c5, #38b2ac);
+            color: white;
+        }
+
+        .stat-icon.settings {
+            background: linear-gradient(135deg, #a855f7, #7c3aed);
+            color: white;
+        }
+
+        .stat-icon.sitemap {
+            background: linear-gradient(135deg, #2b6cb0, #2c5282);
+            color: white;
+        }
+
+        .stat-icon.logs {
+            background: linear-gradient(135deg, #f59e0b, #d97706);
+            color: white;
+        }
+
+        .stat-icon.analytics {
+            background: linear-gradient(135deg, #0ea5e9, #0284c7);
+            color: white;
+        }
+
         .stat-content {
             flex: 1;
         }
@@ -383,6 +418,42 @@
             font-size: 13px;
             color: #a0aec0;
             margin-top: 6px;
+        }
+
+        .stat-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .stat-list li {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 6px 0;
+            border-bottom: 1px solid #edf2f7;
+            font-size: 13px;
+            color: #4a5568;
+        }
+
+        .stat-list li:last-child {
+            border-bottom: none;
+        }
+
+        .stat-list-title {
+            font-weight: 600;
+            color: #2d3748;
+        }
+
+        .stat-list-meta {
+            color: #718096;
+            font-size: 12px;
+        }
+
+        .stat-list-empty {
+            text-align: center;
+            color: #a0aec0;
+            padding: 8px 0;
         }
 
         .stat-change {


### PR DESCRIPTION
## Summary
- broaden the dashboard data source to aggregate stats from pages, media, users, blogs, forms, menus, logs, and sitemap modules
- expand the dashboard UI and JavaScript to surface the new module metrics and top page analytics
- add styling for the new stat cards and list presentation

## Testing
- php -l CMS/modules/dashboard/dashboard_data.php

------
https://chatgpt.com/codex/tasks/task_e_68d71ebe31708331ad3cf874b0aee097