### PR TITLE
Revamp logs module dashboard

### DIFF
--- a/CMS/modules/logs/list_logs.php
+++ b/CMS/modules/logs/list_logs.php
@@ -15,13 +15,27 @@ $historyFile = __DIR__ . '/../../data/page_history.json';
 $historyData = read_json_file($historyFile);
 
 $logs = [];
+
+function normalize_action_label(?string $action): string {
+    $label = trim((string)($action ?? ''));
+    return $label !== '' ? $label : 'Updated content';
+}
+
+function slugify_action_label(string $label): string {
+    $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $label));
+    $slug = trim($slug ?? '', '-');
+    return $slug !== '' ? $slug : 'unknown';
+}
+
 foreach ($historyData as $pid => $entries) {
     foreach ($entries as $entry) {
+        $actionLabel = normalize_action_label($entry['action'] ?? '');
         $logs[] = [
-            'time' => $entry['time'] ?? 0,
+            'time' => (int)($entry['time'] ?? 0),
             'user' => $entry['user'] ?? '',
             'page_title' => $pageLookup[$pid] ?? 'Unknown',
-            'action' => $entry['action'] ?? ''
+            'action' => $actionLabel,
+            'action_slug' => slugify_action_label($actionLabel),
         ];
     }
 }

--- a/CMS/modules/logs/logs.js
+++ b/CMS/modules/logs/logs.js
@@ -1,19 +1,349 @@
 // File: logs.js
 $(function(){
-    function escapeHtml(str){ return $('<div>').text(str).html(); }
-    function loadLogs(){
-        $.getJSON('modules/logs/list_logs.php', function(data){
-            const tbody = $('#logsTable tbody').empty();
-            (data || []).forEach(log => {
-                const date = new Date(log.time * 1000).toLocaleString();
-                tbody.append('<tr>'+
-                    '<td class="time">'+date+'</td>'+
-                    '<td class="user">'+escapeHtml(log.user)+'</td>'+
-                    '<td class="page">'+escapeHtml(log.page_title)+'</td>'+
-                    '<td class="action">'+escapeHtml(log.action)+'</td>'+
-                '</tr>');
+    const dashboard = $('.logs-dashboard');
+    if (!dashboard.length) {
+        return;
+    }
+
+    const timeline = $('#logsTimeline');
+    const matchCountEl = $('#logsMatchCount');
+    const searchInput = $('#logsSearch');
+    const filterContainer = $('#logsFilters');
+    const refreshBtn = $('#logsRefreshBtn');
+    const endpoint = dashboard.data('endpoint');
+
+    const statsEls = {
+        total: $('#logsTotalCount'),
+        last7: $('#logsLast7Days'),
+        users: $('#logsUserCount'),
+        pages: $('#logsPageCount'),
+        topActionLabel: $('#logsTopActionLabel'),
+        topActionCount: $('#logsTopActionCount'),
+        lastActivity: $('#logsLastActivity'),
+        past24h: $('#logsPast24h')
+    };
+
+    let currentAction = 'all';
+    let allLogs = [];
+
+    function escapeHtml(str) {
+        return $('<div>').text(str).html();
+    }
+
+    function getActionLabel(log) {
+        const raw = log && typeof log.action !== 'undefined' ? String(log.action) : '';
+        const label = raw.trim();
+        return label !== '' ? label : 'Updated content';
+    }
+
+    function slugifyAction(label) {
+        return label.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'unknown';
+    }
+
+    function formatAbsolute(timestamp) {
+        if (!timestamp) {
+            return 'No recent activity';
+        }
+        const date = new Date(timestamp * 1000);
+        return date.toLocaleString();
+    }
+
+    function heroTime(timestamp) {
+        if (!timestamp) {
+            return 'No activity yet';
+        }
+        const now = Date.now();
+        const diff = now - timestamp * 1000;
+        if (diff < 0) {
+            return 'Scheduled update';
+        }
+        const seconds = Math.floor(diff / 1000);
+        if (seconds < 60) {
+            return 'Just now';
+        }
+        if (seconds < 3600) {
+            const minutes = Math.floor(seconds / 60);
+            return minutes + ' min' + (minutes === 1 ? '' : 's') + ' ago';
+        }
+        if (seconds < 86400) {
+            const hours = Math.floor(seconds / 3600);
+            return hours + ' hour' + (hours === 1 ? '' : 's') + ' ago';
+        }
+        if (seconds < 604800) {
+            const days = Math.floor(seconds / 86400);
+            return days + ' day' + (days === 1 ? '' : 's') + ' ago';
+        }
+        return formatAbsolute(timestamp);
+    }
+
+    function relativeTime(timestamp) {
+        if (!timestamp) {
+            return 'Unknown time';
+        }
+        const now = Date.now();
+        const diff = now - timestamp * 1000;
+        if (diff < 0) {
+            return 'Scheduled update';
+        }
+        const seconds = Math.floor(diff / 1000);
+        if (seconds < 60) {
+            return 'Just now';
+        }
+        if (seconds < 3600) {
+            const minutes = Math.floor(seconds / 60);
+            return minutes + ' min' + (minutes === 1 ? '' : 's');
+        }
+        if (seconds < 86400) {
+            const hours = Math.floor(seconds / 3600);
+            return hours + ' hr' + (hours === 1 ? '' : 's');
+        }
+        if (seconds < 604800) {
+            const days = Math.floor(seconds / 86400);
+            return days + ' day' + (days === 1 ? '' : 's');
+        }
+        return formatAbsolute(timestamp);
+    }
+
+    function normalizeLogs(logs) {
+        if (typeof logs === 'string') {
+            try {
+                logs = JSON.parse(logs);
+            } catch (err) {
+                logs = [];
+            }
+        }
+        if (!Array.isArray(logs)) {
+            return [];
+        }
+        return logs.map(function(item){
+            const label = getActionLabel(item);
+            const slug = item && item.action_slug ? String(item.action_slug) : slugifyAction(label);
+            return {
+                time: parseInt(item.time, 10) || 0,
+                user: item && item.user ? String(item.user) : '',
+                page_title: item && item.page_title ? String(item.page_title) : 'Unknown',
+                action: label,
+                action_slug: slug
+            };
+        }).sort(function(a, b){
+            return b.time - a.time;
+        });
+    }
+
+    function summarizeActions(logs) {
+        const summary = {};
+        logs.forEach(function(log){
+            const label = getActionLabel(log);
+            const slug = log.action_slug || slugifyAction(label);
+            if (!summary[slug]) {
+                summary[slug] = { slug: slug, label: label, count: 0 };
+            }
+            summary[slug].count += 1;
+        });
+        return Object.values(summary).sort(function(a, b){
+            return b.count - a.count;
+        });
+    }
+
+    function renderFilters(logs) {
+        const actions = summarizeActions(logs);
+        if (currentAction !== 'all' && !actions.some(function(action){ return action.slug === currentAction; })) {
+            currentAction = 'all';
+        }
+
+        filterContainer.empty();
+
+        const allBtn = $('<button type="button" class="logs-filter-btn"></button>')
+            .attr('data-filter', 'all')
+            .toggleClass('active', currentAction === 'all')
+            .append($('<span>').text('All activity'))
+            .append($('<span class="logs-filter-count" id="logsAllCount"></span>').text(logs.length));
+
+        filterContainer.append(allBtn);
+
+        actions.slice(0, 4).forEach(function(action){
+            const btn = $('<button type="button" class="logs-filter-btn"></button>')
+                .attr('data-filter', action.slug)
+                .toggleClass('active', currentAction === action.slug)
+                .append($('<span>').text(action.label))
+                .append($('<span class="logs-filter-count"></span>').attr('data-filter-count', action.slug).text(action.count));
+            filterContainer.append(btn);
+        });
+    }
+
+    function buildCard(log) {
+        const label = getActionLabel(log);
+        const slug = log.action_slug || slugifyAction(label);
+        const timestamp = log.time || 0;
+        const exact = timestamp ? new Date(timestamp * 1000).toISOString() : '';
+        const absolute = formatAbsolute(timestamp);
+        const relative = relativeTime(timestamp);
+        const pageTitle = log.page_title || 'Unknown';
+        const user = log.user && log.user !== '' ? log.user : 'System';
+        const searchText = (user + ' ' + pageTitle + ' ' + label).toLowerCase();
+
+        return (
+            '<article class="logs-activity-card" data-search="' + escapeHtml(searchText) + '" data-action="' + escapeHtml(slug) + '">' +
+                '<header class="logs-activity-card__header">' +
+                    '<span class="logs-activity-badge">' + escapeHtml(label) + '</span>' +
+                    '<time datetime="' + exact + '" class="logs-activity-time" title="' + escapeHtml(absolute) + '">' +
+                        escapeHtml(relative) +
+                    '</time>' +
+                '</header>' +
+                '<h4 class="logs-activity-page">' + escapeHtml(pageTitle) + '</h4>' +
+                '<p class="logs-activity-description">' +
+                    '<span class="logs-activity-user">' + escapeHtml(user) + '</span>' +
+                    '<span class="logs-activity-divider" aria-hidden="true">•</span>' +
+                    '<span class="logs-activity-action">' + escapeHtml(label) + '</span>' +
+                '</p>' +
+            '</article>'
+        );
+    }
+
+    function updateTimeline(logs) {
+        if (!logs.length) {
+            timeline.html('<div class="logs-empty"><i class="fas fa-clipboard-list" aria-hidden="true"></i><p>No activity recorded yet.</p><p class="logs-empty-hint">Updates will appear here as your team edits content.</p></div>');
+            return;
+        }
+        const html = logs.map(buildCard).join('');
+        timeline.html(html);
+    }
+
+    function updateMatchCount(count) {
+        if (!matchCountEl.length) {
+            return;
+        }
+        if (count === 0) {
+            matchCountEl.text('No entries to display');
+        } else if (count === 1) {
+            matchCountEl.text('1 entry');
+        } else {
+            matchCountEl.text(count + ' entries');
+        }
+    }
+
+    function updateStats(logs) {
+        const total = logs.length;
+        const now = Date.now();
+        const past24h = logs.filter(function(log){
+            return log.time && (now - log.time * 1000) <= 86400000;
+        }).length;
+        const last7 = logs.filter(function(log){
+            return log.time && (now - log.time * 1000) <= 604800000;
+        }).length;
+
+        const uniqueUsers = new Set();
+        const uniquePages = new Set();
+        logs.forEach(function(log){
+            if (log.user) {
+                uniqueUsers.add(log.user.toLowerCase());
+            }
+            if (log.page_title) {
+                uniquePages.add(log.page_title.toLowerCase());
+            }
+        });
+
+        const heroTimestamp = logs.length ? logs[0].time : 0;
+        const heroLabel = heroTime(heroTimestamp);
+        const heroTitle = heroTimestamp ? formatAbsolute(heroTimestamp) : 'No recent activity';
+
+        if (statsEls.total.length) {
+            statsEls.total.text(total);
+        }
+        if (statsEls.last7.length) {
+            statsEls.last7.text(last7);
+        }
+        if (statsEls.users.length) {
+            statsEls.users.text(uniqueUsers.size);
+        }
+        if (statsEls.pages.length) {
+            statsEls.pages.text(uniquePages.size);
+        }
+        if (statsEls.past24h.length) {
+            statsEls.past24h.text(past24h);
+        }
+        if (statsEls.lastActivity.length) {
+            statsEls.lastActivity.text(heroLabel).attr('title', heroTitle);
+        }
+        const allCountEl = $('#logsAllCount');
+        if (allCountEl.length) {
+            allCountEl.text(total);
+        }
+
+        const actions = summarizeActions(logs);
+        if (statsEls.topActionLabel.length && statsEls.topActionCount.length) {
+            if (actions.length) {
+                statsEls.topActionLabel.text(actions[0].label);
+                statsEls.topActionCount.text(actions[0].count + (actions[0].count === 1 ? ' entry' : ' entries'));
+            } else {
+                statsEls.topActionLabel.text('—');
+                statsEls.topActionCount.text('No recorded actions yet');
+            }
+        }
+    }
+
+    function applyFilters() {
+        const query = searchInput.val() ? searchInput.val().toLowerCase().trim() : '';
+        const filtered = allLogs.filter(function(log){
+            const slug = log.action_slug || slugifyAction(getActionLabel(log));
+            const matchesAction = currentAction === 'all' || slug === currentAction;
+            if (!matchesAction) {
+                return false;
+            }
+            if (!query) {
+                return true;
+            }
+            const haystack = (log.user + ' ' + log.page_title + ' ' + getActionLabel(log)).toLowerCase();
+            return haystack.indexOf(query) !== -1;
+        });
+
+        updateTimeline(filtered);
+        updateMatchCount(filtered.length);
+    }
+
+    function setLogs(logs) {
+        allLogs = normalizeLogs(logs);
+        renderFilters(allLogs);
+        updateStats(allLogs);
+        applyFilters();
+    }
+
+    filterContainer.on('click', 'button', function(){
+        const filter = $(this).data('filter') || 'all';
+        if (currentAction === filter) {
+            return;
+        }
+        currentAction = filter;
+        filterContainer.find('button').removeClass('active');
+        $(this).addClass('active');
+        applyFilters();
+    });
+
+    searchInput.on('input', function(){
+        applyFilters();
+    });
+
+    if (refreshBtn.length) {
+        refreshBtn.on('click', function(){
+            if (!endpoint) {
+                return;
+            }
+            refreshBtn.prop('disabled', true).addClass('is-loading');
+            $.getJSON(endpoint).done(function(data){
+                setLogs(data || []);
+            }).fail(function(){
+                const alert = $('<div class="logs-inline-alert" role="status">Unable to refresh activity right now.</div>');
+                timeline.prepend(alert);
+                setTimeout(function(){
+                    alert.fadeOut(250, function(){
+                        $(this).remove();
+                    });
+                }, 4000);
+            }).always(function(){
+                refreshBtn.prop('disabled', false).removeClass('is-loading');
             });
         });
     }
-    loadLogs();
+
+    setLogs(dashboard.data('logs'));
 });

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -196,8 +196,406 @@
             transition: background 0.3s ease;
         }
 
-        .notification-btn:hover {
+.notification-btn:hover {
             background: #f7fafc;
+        }
+
+        /* Logs module */
+        .logs-dashboard {
+            display: flex;
+            flex-direction: column;
+            gap: 32px;
+        }
+
+        .logs-hero {
+            position: relative;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 32px;
+            padding: 32px;
+            border-radius: 24px;
+            color: #fff;
+            overflow: hidden;
+            background: linear-gradient(135deg, #312e81, #4c1d95);
+            box-shadow: 0 30px 60px -40px rgba(76, 29, 149, 0.6);
+        }
+
+        .logs-hero::before {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(147, 197, 253, 0.15));
+            pointer-events: none;
+        }
+
+        .logs-hero-copy {
+            position: relative;
+            z-index: 1;
+            max-width: 640px;
+        }
+
+        .logs-hero-title {
+            font-size: 32px;
+            font-weight: 700;
+            margin-bottom: 8px;
+        }
+
+        .logs-hero-subtitle {
+            font-size: 16px;
+            line-height: 1.6;
+            opacity: 0.9;
+        }
+
+        .logs-hero-meta {
+            display: flex;
+            gap: 28px;
+            margin-top: 24px;
+            flex-wrap: wrap;
+        }
+
+        .logs-hero-meta > div {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .logs-hero-meta__label {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 1.2px;
+            opacity: 0.65;
+        }
+
+        .logs-hero-meta__value {
+            font-size: 18px;
+            font-weight: 600;
+        }
+
+        .logs-hero-actions {
+            position: relative;
+            z-index: 1;
+        }
+
+        .logs-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            border-radius: 999px;
+            border: none;
+            padding: 12px 24px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.25s ease;
+            font-size: 14px;
+        }
+
+        .logs-btn i {
+            font-size: 16px;
+        }
+
+        .logs-btn--ghost {
+            background: rgba(255, 255, 255, 0.12);
+            color: #fff;
+        }
+
+        .logs-btn--ghost:hover,
+        .logs-btn--ghost:focus-visible {
+            background: rgba(255, 255, 255, 0.2);
+            outline: none;
+        }
+
+        .logs-btn.is-loading {
+            opacity: 0.65;
+            cursor: progress;
+        }
+
+        .logs-btn.is-loading i {
+            animation: logs-spin 0.9s linear infinite;
+        }
+
+        @keyframes logs-spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+
+        .logs-stats-grid {
+            display: grid;
+            gap: 20px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .logs-stat-card {
+            background: #fff;
+            border-radius: 20px;
+            padding: 24px;
+            box-shadow: 0 20px 40px -35px rgba(76, 29, 149, 0.35);
+            border: 1px solid rgba(99, 102, 241, 0.08);
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .logs-stat-label {
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            color: #64748b;
+            font-weight: 600;
+        }
+
+        .logs-stat-value {
+            font-size: 32px;
+            font-weight: 700;
+            color: #1e1b4b;
+        }
+
+        .logs-stat-hint {
+            font-size: 14px;
+            color: #6b7280;
+        }
+
+        .logs-activity {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .logs-activity-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        .logs-activity-header h3 {
+            font-size: 22px;
+            font-weight: 600;
+            color: #1e1b4b;
+        }
+
+        .logs-activity-header p {
+            margin-top: 6px;
+            color: #64748b;
+            font-size: 14px;
+        }
+
+        .logs-controls {
+            margin-left: auto;
+        }
+
+        .logs-search {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            background: #fff;
+            border-radius: 999px;
+            padding: 8px 16px;
+            box-shadow: 0 10px 30px -20px rgba(76, 29, 149, 0.4);
+        }
+
+        .logs-search i {
+            color: #6366f1;
+            font-size: 16px;
+            margin-right: 10px;
+        }
+
+        .logs-search input {
+            border: none;
+            background: transparent;
+            font-size: 14px;
+            min-width: 220px;
+            color: #1f2937;
+        }
+
+        .logs-search input:focus {
+            outline: none;
+        }
+
+        .logs-filters {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .logs-filter-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 18px;
+            border-radius: 999px;
+            border: 1px solid rgba(99, 102, 241, 0.15);
+            background: #f8fafc;
+            color: #1f2937;
+            font-weight: 500;
+            font-size: 13px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .logs-filter-btn:hover,
+        .logs-filter-btn:focus-visible {
+            border-color: rgba(99, 102, 241, 0.45);
+            background: #eef2ff;
+            outline: none;
+        }
+
+        .logs-filter-btn.active {
+            background: linear-gradient(135deg, #4f46e5, #7c3aed);
+            color: #fff;
+            border-color: transparent;
+            box-shadow: 0 16px 30px -24px rgba(79, 70, 229, 0.6);
+        }
+
+        .logs-filter-count {
+            background: rgba(15, 23, 42, 0.08);
+            padding: 2px 10px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .logs-filter-btn.active .logs-filter-count {
+            background: rgba(255, 255, 255, 0.22);
+            color: #fff;
+        }
+
+        .logs-activity-list {
+            display: grid;
+            gap: 18px;
+        }
+
+        .logs-activity-card {
+            background: #fff;
+            border-radius: 18px;
+            padding: 20px 24px;
+            border: 1px solid rgba(226, 232, 240, 0.8);
+            box-shadow: 0 18px 40px -35px rgba(30, 64, 175, 0.5);
+            transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+        }
+
+        .logs-activity-card:hover,
+        .logs-activity-card:focus-within {
+            transform: translateY(-2px);
+            border-color: rgba(129, 140, 248, 0.6);
+            box-shadow: 0 22px 40px -28px rgba(99, 102, 241, 0.55);
+        }
+
+        .logs-activity-card__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 12px;
+            gap: 12px;
+        }
+
+        .logs-activity-badge {
+            display: inline-flex;
+            align-items: center;
+            padding: 6px 14px;
+            border-radius: 999px;
+            background: rgba(79, 70, 229, 0.1);
+            color: #4338ca;
+            font-size: 13px;
+            font-weight: 600;
+        }
+
+        .logs-activity-time {
+            font-size: 13px;
+            color: #64748b;
+        }
+
+        .logs-activity-page {
+            font-size: 18px;
+            font-weight: 600;
+            color: #1f2937;
+            margin-bottom: 8px;
+        }
+
+        .logs-activity-description {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            color: #475569;
+            font-size: 14px;
+        }
+
+        .logs-activity-user {
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        .logs-activity-divider {
+            opacity: 0.4;
+        }
+
+        .logs-empty {
+            background: #fff;
+            border-radius: 18px;
+            padding: 48px 24px;
+            text-align: center;
+            color: #64748b;
+            border: 1px dashed rgba(148, 163, 184, 0.4);
+        }
+
+        .logs-empty i {
+            font-size: 40px;
+            color: rgba(79, 70, 229, 0.4);
+            margin-bottom: 12px;
+        }
+
+        .logs-empty-hint {
+            font-size: 13px;
+            margin-top: 6px;
+            color: #94a3b8;
+        }
+
+        .logs-inline-alert {
+            background: #fee2e2;
+            border: 1px solid #fecaca;
+            color: #b91c1c;
+            border-radius: 12px;
+            padding: 12px 16px;
+            font-size: 14px;
+            margin-bottom: 16px;
+            box-shadow: 0 10px 30px -25px rgba(248, 113, 113, 0.5);
+        }
+
+        @media (max-width: 900px) {
+            .logs-hero {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .logs-hero-actions {
+                width: 100%;
+            }
+
+            .logs-hero-actions .logs-btn {
+                width: 100%;
+                justify-content: center;
+            }
+
+            .logs-search input {
+                min-width: 160px;
+            }
+        }
+
+        @media (max-width: 600px) {
+            .logs-activity-card {
+                padding: 18px;
+            }
+
+            .logs-activity-description {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 4px;
+            }
+
+            .logs-hero-title {
+                font-size: 28px;
+            }
         }
 
         .notification-badge {


### PR DESCRIPTION
## Summary
- redesign the logs module view with a hero summary, stat cards, and timeline cards for a friendlier activity experience
- enhance the logs JavaScript to support live filtering, searching, refreshing, and stat updates based on fetched data
- update API normalization and add dedicated styles for the refreshed logs layout to match the design system

## Testing
- php -l CMS/modules/logs/view.php
- php -l CMS/modules/logs/list_logs.php

------
https://chatgpt.com/codex/tasks/task_e_68d71efbe4588331ab8f2c537e890c99