### PR TITLE
Revamp users module dashboard

### DIFF
--- a/CMS/modules/users/users.js
+++ b/CMS/modules/users/users.js
@@ -1,65 +1,399 @@
 // File: users.js
-$(function(){
-    function loadUsers(){
-        $.getJSON('modules/users/list_users.php', function(data){
-            const tbody = $('#usersTable tbody').empty();
-            data.forEach(u => {
-                tbody.append(
-                    '<tr data-id="'+u.id+'" data-username="'+u.username+'" data-role="'+u.role+'" data-status="'+u.status+'">'+
-                    '<td class="username">'+u.username+'</td>'+
-                    '<td class="role">'+u.role+'</td>'+
-                    '<td class="status">'+u.status+'</td>'+
-                    '<td><button class="btn btn-secondary editUser">Edit</button> '+
-                    '<button class="btn btn-danger deleteUser">Delete</button></td>'+
-                    '</tr>'
-                );
-            });
+$(function () {
+    const state = {
+        users: [],
+        filtered: [],
+        filter: 'all',
+        view: 'grid',
+        search: ''
+    };
+
+    const $grid = $('#usersGrid');
+    const $tableView = $('#usersTableView');
+    const $tableBody = $('#usersTableBody');
+    const $emptyState = $('#usersEmptyState');
+    const $filterButtons = $('[data-users-filter]');
+    const $viewButtons = $('[data-users-view]');
+    const $searchInput = $('#usersSearchInput');
+    const $newBtn = $('#usersNewBtn');
+    const $refreshBtn = $('#usersRefreshBtn');
+    const $lastSync = $('#usersLastSync');
+
+    const $drawer = $('#usersDrawer');
+    const $form = $('#userForm');
+    const $formTitle = $('#userFormTitle');
+    const $formSubtitle = $('#userFormSubtitle');
+    const $formClose = $('#userFormClose');
+    const $formCancel = $('#userFormCancel');
+    const $deleteBtn = $('#userDeleteBtn');
+    const $userId = $('#userId');
+    const $username = $('#username');
+    const $password = $('#password');
+    const $role = $('#role');
+    const $status = $('#status');
+
+    const $statTotal = $('#usersStatTotal');
+    const $statActive = $('#usersStatActive');
+    const $statAdmins = $('#usersStatAdmins');
+    const $statRecent = $('#usersStatRecent');
+
+    function escapeHtml(value) {
+        return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    function nowLabel() {
+        const now = new Date();
+        return now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+
+    function formatRelative(timestamp) {
+        if (!timestamp || Number(timestamp) <= 0) {
+            return 'No activity';
+        }
+        const ms = Number(timestamp) * 1000;
+        const diff = Date.now() - ms;
+        if (diff < 0) {
+            return 'Scheduled';
+        }
+        const minutes = Math.floor(diff / 60000);
+        if (minutes < 1) {
+            return 'Just now';
+        }
+        if (minutes < 60) {
+            return minutes + ' minute' + (minutes === 1 ? '' : 's') + ' ago';
+        }
+        const hours = Math.floor(minutes / 60);
+        if (hours < 24) {
+            return hours + ' hour' + (hours === 1 ? '' : 's') + ' ago';
+        }
+        const days = Math.floor(hours / 24);
+        if (days < 30) {
+            return days + ' day' + (days === 1 ? '' : 's') + ' ago';
+        }
+        const months = Math.floor(days / 30);
+        if (months < 12) {
+            return months + ' month' + (months === 1 ? '' : 's') + ' ago';
+        }
+        const years = Math.floor(months / 12);
+        return years + ' year' + (years === 1 ? '' : 's') + ' ago';
+    }
+
+    function roleLabel(role) {
+        switch (role) {
+            case 'admin':
+                return 'Administrator';
+            case 'editor':
+                return 'Editor';
+            default:
+                return role ? (role.charAt(0).toUpperCase() + role.slice(1)) : 'Editor';
+        }
+    }
+
+    function statusLabel(status) {
+        return status === 'inactive' ? 'Inactive' : 'Active';
+    }
+
+    function statusClass(status) {
+        return status === 'inactive' ? 'user-status--inactive' : 'user-status--active';
+    }
+
+    function roleClass(role) {
+        return role === 'admin' ? 'user-role--admin' : 'user-role--editor';
+    }
+
+    function computeRecent(users) {
+        const threshold = Math.floor(Date.now() / 1000) - (30 * 24 * 60 * 60);
+        return users.filter(user => Number(user.created_at) > threshold).length;
+    }
+
+    function updateStats(users) {
+        const total = users.length;
+        const active = users.filter(user => user.status === 'active').length;
+        const admins = users.filter(user => user.role === 'admin').length;
+        const recent = computeRecent(users);
+
+        $statTotal.text(total);
+        $statActive.text(active);
+        $statAdmins.text(admins);
+        $statRecent.text(recent);
+    }
+
+    function updateFilterCounts(users) {
+        const counts = {
+            all: users.length,
+            active: users.filter(user => user.status === 'active').length,
+            inactive: users.filter(user => user.status === 'inactive').length,
+            admin: users.filter(user => user.role === 'admin').length,
+            editor: users.filter(user => user.role === 'editor').length
+        };
+
+        $filterButtons.each(function () {
+            const $btn = $(this);
+            const type = $btn.data('users-filter');
+            const $count = $btn.find('.a11y-filter-count');
+            if ($count.length && Object.prototype.hasOwnProperty.call(counts, type)) {
+                $count.text(counts[type]);
+            }
         });
     }
 
-    $('#newUserBtn').on('click', function(){
-        $('#userFormTitle').text('Add User');
-        $('#userId').val('');
-        $('#userForm')[0].reset();
-        $('#userFormCard').show();
-        $('#cancelUserEdit').show();
+    function matchesFilter(user) {
+        switch (state.filter) {
+            case 'active':
+                return user.status === 'active';
+            case 'inactive':
+                return user.status === 'inactive';
+            case 'admin':
+                return user.role === 'admin';
+            case 'editor':
+                return user.role === 'editor';
+            default:
+                return true;
+        }
+    }
+
+    function matchesSearch(user) {
+        if (!state.search) {
+            return true;
+        }
+        const q = state.search;
+        const haystack = [user.username, roleLabel(user.role), statusLabel(user.status)].join(' ').toLowerCase();
+        return haystack.indexOf(q) !== -1;
+    }
+
+    function buildCard(user) {
+        const card = [
+            '<article class="a11y-page-card users-card" role="listitem" tabindex="0" data-user-id="' + user.id + '">',
+            '<div class="a11y-page-card__header">',
+            '<div class="users-status-badge ' + statusClass(user.status) + '">' + statusLabel(user.status) + '</div>',
+            '<h3 class="a11y-page-title">' + escapeHtml(user.username) + '</h3>',
+            '<p class="a11y-page-url">' + roleLabel(user.role) + '</p>',
+            '</div>',
+            '<div class="a11y-page-card__metrics">',
+            '<div><span class="label">Last login</span><span class="value">' + escapeHtml(formatRelative(user.last_login)) + '</span></div>',
+            '<div><span class="label">Member since</span><span class="value">' + escapeHtml(formatRelative(user.created_at)) + '</span></div>',
+            '<div><span class="label">Role</span><span class="value"><span class="users-role-badge ' + roleClass(user.role) + '">' + roleLabel(user.role) + '</span></span></div>',
+            '</div>',
+            '<div class="a11y-page-card__issues">',
+            '<div class="users-card-footer">',
+            '<span class="users-card-meta">Status: <strong>' + statusLabel(user.status) + '</strong></span>',
+            '<button type="button" class="a11y-btn a11y-btn--secondary" data-users-action="manage" data-user-id="' + user.id + '">',
+            '<i class="fas fa-user-cog" aria-hidden="true"></i><span>Manage access</span>',
+            '</button>',
+            '</div>',
+            '</div>',
+            '</article>'
+        ];
+        return card.join('');
+    }
+
+    function buildTableRow(user) {
+        const row = [
+            '<div class="a11y-table-row" role="row" data-user-id="' + user.id + '">',
+            '<div class="a11y-table-cell">',
+            '<div class="title">' + escapeHtml(user.username) + '</div>',
+            '<div class="subtitle">Member since ' + escapeHtml(formatRelative(user.created_at)) + '</div>',
+            '</div>',
+            '<div class="a11y-table-cell"><span class="users-role-badge ' + roleClass(user.role) + '">' + roleLabel(user.role) + '</span></div>',
+            '<div class="a11y-table-cell"><span class="users-status-badge ' + statusClass(user.status) + '">' + statusLabel(user.status) + '</span></div>',
+            '<div class="a11y-table-cell">' + escapeHtml(formatRelative(user.last_login)) + '</div>',
+            '<div class="a11y-table-cell actions">',
+            '<button type="button" class="a11y-btn a11y-btn--icon" data-users-action="manage" data-user-id="' + user.id + '">',
+            '<i class="fas fa-user-cog" aria-hidden="true"></i>',
+            '<span class="sr-only">Manage ' + escapeHtml(user.username) + '</span>',
+            '</button>',
+            '</div>',
+            '</div>'
+        ];
+        return row.join('');
+    }
+
+    function render() {
+        if (!state.filtered.length) {
+            $grid.empty().attr('hidden', true);
+            $tableView.attr('hidden', true);
+            $emptyState.attr('hidden', false);
+            return;
+        }
+
+        $emptyState.attr('hidden', true);
+
+        if (state.view === 'grid') {
+            $grid.attr('hidden', false);
+            $tableView.attr('hidden', true);
+            $grid.empty();
+            const cards = state.filtered.map(buildCard).join('');
+            $grid.html(cards);
+        } else {
+            $grid.attr('hidden', true).empty();
+            $tableView.attr('hidden', false);
+            const rows = state.filtered.map(buildTableRow).join('');
+            $tableBody.html(rows);
+        }
+    }
+
+    function applyFilters() {
+        state.filtered = state.users.filter(function (user) {
+            return matchesFilter(user) && matchesSearch(user);
+        });
+        render();
+    }
+
+    function closeDrawer() {
+        $drawer.attr('hidden', true).removeClass('is-visible');
+        $form[0].reset();
+        $userId.val('');
+        $password.val('');
+        $deleteBtn.hide().data('userId', '');
+    }
+
+    function openDrawer(user) {
+        if (user) {
+            $formTitle.text('Edit team member');
+            $formSubtitle.text('Update permissions, reset passwords, or deactivate an account.');
+            $userId.val(user.id);
+            $username.val(user.username);
+            $password.val('');
+            $role.val(user.role);
+            $status.val(user.status);
+            $deleteBtn.show().data('userId', user.id);
+        } else {
+            $formTitle.text('Add teammate');
+            $formSubtitle.text('Invite a new user or update their access level.');
+            $userId.val('');
+            $username.val('');
+            $password.val('');
+            $role.val('editor');
+            $status.val('active');
+            $deleteBtn.hide().data('userId', '');
+        }
+
+        $drawer.attr('hidden', false).addClass('is-visible');
+        setTimeout(function () {
+            $username.trigger('focus');
+        }, 100);
+    }
+
+    function findUser(id) {
+        id = Number(id);
+        return state.users.find(function (user) {
+            return Number(user.id) === id;
+        }) || null;
+    }
+
+    function fetchUsers() {
+        $.getJSON('modules/users/list_users.php', function (data) {
+            state.users = Array.isArray(data) ? data.slice() : [];
+            state.users.sort(function (a, b) {
+                return String(a.username).localeCompare(String(b.username));
+            });
+            $lastSync.text(nowLabel());
+            updateStats(state.users);
+            updateFilterCounts(state.users);
+            applyFilters();
+        });
+    }
+
+    $filterButtons.on('click', function () {
+        const $btn = $(this);
+        const filter = $btn.data('users-filter');
+        if (!filter) {
+            return;
+        }
+        state.filter = filter;
+        $filterButtons.removeClass('active');
+        $btn.addClass('active');
+        applyFilters();
     });
 
-    $('#cancelUserEdit').on('click', function(){
-        $('#userFormCard').hide();
-        $('#userForm')[0].reset();
+    $viewButtons.on('click', function () {
+        const $btn = $(this);
+        const view = $btn.data('users-view');
+        if (!view || state.view === view) {
+            return;
+        }
+        state.view = view;
+        $viewButtons.removeClass('active');
+        $btn.addClass('active');
+        render();
     });
 
-    $('#usersTable').on('click', '.editUser', function(){
-        const row = $(this).closest('tr');
-        $('#userFormTitle').text('Edit User');
-        $('#userId').val(row.data('id'));
-        $('#username').val(row.data('username'));
-        $('#password').val('');
-        $('#role').val(row.data('role'));
-        $('#status').val(row.data('status'));
-        $('#userFormCard').show();
-        $('#cancelUserEdit').show();
+    $searchInput.on('input', function () {
+        state.search = ($(this).val() || '').toLowerCase();
+        applyFilters();
     });
 
-    $('#usersTable').on('click', '.deleteUser', function(){
-        const row = $(this).closest('tr');
-        confirmModal('Delete this user?').then(ok => {
-            if(!ok) return;
-            $.post('modules/users/delete_user.php', {id: row.data('id')}, function(){
-                loadUsers();
+    $grid.on('click', '[data-users-action="manage"]', function (event) {
+        event.stopPropagation();
+        const id = $(this).data('user-id');
+        const user = findUser(id);
+        openDrawer(user);
+    });
+
+    $grid.on('click', '.users-card', function (event) {
+        if ($(event.target).closest('[data-users-action]').length) {
+            return;
+        }
+        const id = $(this).data('user-id');
+        const user = findUser(id);
+        openDrawer(user);
+    });
+
+    $grid.on('keydown', '.users-card', function (event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            const id = $(this).data('user-id');
+            const user = findUser(id);
+            openDrawer(user);
+        }
+    });
+
+    $tableBody.on('click', '[data-users-action="manage"]', function () {
+        const id = $(this).data('user-id');
+        const user = findUser(id);
+        openDrawer(user);
+    });
+
+    $newBtn.on('click', function () {
+        openDrawer(null);
+    });
+
+    $refreshBtn.on('click', function () {
+        fetchUsers();
+    });
+
+    $formClose.on('click', closeDrawer);
+    $formCancel.on('click', closeDrawer);
+
+    $form.on('submit', function (event) {
+        event.preventDefault();
+        const payload = $form.serialize();
+        $.post('modules/users/save_user.php', payload, function () {
+            closeDrawer();
+            fetchUsers();
+        });
+    });
+
+    $deleteBtn.on('click', function () {
+        const id = $(this).data('userId');
+        if (!id) {
+            return;
+        }
+        confirmModal('Delete this user? This action cannot be undone.').then(function (ok) {
+            if (!ok) {
+                return;
+            }
+            $.post('modules/users/delete_user.php', { id: id }, function () {
+                closeDrawer();
+                fetchUsers();
             });
         });
     });
 
-    $('#userForm').on('submit', function(e){
-        e.preventDefault();
-        $.post('modules/users/save_user.php', $(this).serialize(), function(){
-            $('#userFormCard').hide();
-            $('#userForm')[0].reset();
-            loadUsers();
-        });
-    });
-
-    loadUsers();
+    fetchUsers();
 });

--- a/CMS/modules/users/view.php
+++ b/CMS/modules/users/view.php
@@ -1,57 +1,136 @@
 <!-- File: view.php -->
-                <div class="content-section" id="users">
-                    <div class="table-card">
-                        <div class="table-header">
-                            <div class="table-title">Users</div>
-                            <div class="table-actions">
-                                <button class="btn btn-primary" id="newUserBtn">+ New User</button>
-                            </div>
-                        </div>
-                        <table class="data-table" id="usersTable">
-                            <thead>
-                                <tr>
-                                    <th>Username</th>
-                                    <th>Role</th>
-                                    <th>Status</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
-                    </div>
-
-                    <div class="form-card" id="userFormCard" style="margin-top:20px; display:none;">
-                        <h3 id="userFormTitle" style="margin-bottom:15px;">Add User</h3>
-                        <form id="userForm">
-                            <input type="hidden" name="id" id="userId">
-                            <div class="form-group">
-                                <label class="form-label">Username</label>
-                                <input type="text" class="form-input" name="username" id="username" required>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Password</label>
-                                <input type="password" class="form-input" name="password" id="password">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Role</label>
-                                <select class="form-select" name="role" id="role">
-                                    <option value="admin">Admin</option>
-                                    <option value="editor">Editor</option>
-                                    <option value="viewer">Viewer</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Status</label>
-                                <select class="form-select" name="status" id="status">
-                                    <option value="active">Active</option>
-                                    <option value="inactive">Inactive</option>
-                                </select>
-                            </div>
-                            <div style="display:flex; gap:10px;">
-                                <button type="submit" class="btn btn-primary">Save User</button>
-                                <button type="button" class="btn btn-secondary" id="cancelUserEdit">Cancel</button>
-                            </div>
-                        </form>
-                    </div>
+<div class="content-section" id="users">
+    <div class="a11y-dashboard users-dashboard" data-last-refresh="">
+        <header class="a11y-hero users-hero">
+            <div class="a11y-hero-content">
+                <h2 class="a11y-hero-title">Team access &amp; permissions</h2>
+                <p class="a11y-hero-subtitle">Review account health, monitor roles, and invite new collaborators from a single, polished dashboard.</p>
+                <div class="a11y-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="usersNewBtn">
+                        <i class="fas fa-user-plus" aria-hidden="true"></i>
+                        <span>Add teammate</span>
+                    </button>
+                    <button type="button" class="a11y-btn a11y-btn--ghost" id="usersRefreshBtn">
+                        <i class="fas fa-rotate" aria-hidden="true"></i>
+                        <span>Refresh</span>
+                    </button>
                 </div>
+                <span class="a11y-hero-meta users-last-sync">
+                    <i class="fas fa-clock" aria-hidden="true"></i>
+                    Last updated <span id="usersLastSync">just now</span>
+                </span>
+            </div>
+        </header>
+
+        <div class="a11y-overview-grid users-overview">
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="usersStatTotal">0</div>
+                <div class="a11y-overview-label">Total members</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="usersStatActive">0</div>
+                <div class="a11y-overview-label">Active accounts</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="usersStatAdmins">0</div>
+                <div class="a11y-overview-label">Administrators</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="usersStatRecent">0</div>
+                <div class="a11y-overview-label">New this month</div>
+            </div>
+        </div>
+
+        <div class="a11y-controls users-controls">
+            <label class="a11y-search" for="usersSearchInput">
+                <i class="fas fa-search" aria-hidden="true"></i>
+                <input type="search" id="usersSearchInput" placeholder="Search by name, role, or status" aria-label="Search team members">
+            </label>
+            <div class="a11y-filter-group" role="group" aria-label="User filters">
+                <button type="button" class="a11y-filter-btn active" data-users-filter="all">All team <span class="a11y-filter-count" data-count="all">0</span></button>
+                <button type="button" class="a11y-filter-btn" data-users-filter="active">Active <span class="a11y-filter-count" data-count="active">0</span></button>
+                <button type="button" class="a11y-filter-btn" data-users-filter="inactive">Inactive <span class="a11y-filter-count" data-count="inactive">0</span></button>
+                <button type="button" class="a11y-filter-btn" data-users-filter="admin">Admins <span class="a11y-filter-count" data-count="admin">0</span></button>
+                <button type="button" class="a11y-filter-btn" data-users-filter="editor">Editors <span class="a11y-filter-count" data-count="editor">0</span></button>
+            </div>
+            <div class="a11y-view-toggle" role="group" aria-label="Toggle layout">
+                <button type="button" class="a11y-view-btn active" data-users-view="grid" aria-label="Grid view">
+                    <i class="fas fa-th-large" aria-hidden="true"></i>
+                </button>
+                <button type="button" class="a11y-view-btn" data-users-view="table" aria-label="Table view">
+                    <i class="fas fa-list" aria-hidden="true"></i>
+                </button>
+            </div>
+        </div>
+
+        <div class="a11y-pages-grid users-grid" id="usersGrid" role="list"></div>
+
+        <div class="a11y-table-view users-table" id="usersTableView" hidden>
+            <div class="a11y-table-header">
+                <div>Member</div>
+                <div>Role</div>
+                <div>Status</div>
+                <div>Last login</div>
+                <div>Actions</div>
+            </div>
+            <div id="usersTableBody"></div>
+        </div>
+
+        <div class="a11y-empty-state users-empty" id="usersEmptyState" hidden>
+            <i class="fas fa-users" aria-hidden="true"></i>
+            <h3>No team members match your filters</h3>
+            <p>Try adjusting your search terms or select a different filter option.</p>
+        </div>
+    </div>
+
+    <div class="a11y-page-detail users-drawer" id="usersDrawer" hidden role="dialog" aria-modal="true" aria-labelledby="userFormTitle">
+        <div class="a11y-detail-content">
+            <button type="button" class="a11y-detail-close" id="userFormClose" aria-label="Close user form">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+            <header class="a11y-detail-modal-header">
+                <h2 id="userFormTitle">Add teammate</h2>
+                <p class="a11y-detail-description" id="userFormSubtitle">Invite a new user or update their access level.</p>
+            </header>
+            <form id="userForm" class="users-form" autocomplete="off">
+                <input type="hidden" name="id" id="userId">
+                <div class="form-group">
+                    <label class="form-label" for="username">Username</label>
+                    <input type="text" class="form-input" name="username" id="username" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="password">Password</label>
+                    <input type="password" class="form-input" name="password" id="password" placeholder="Leave blank to keep current password">
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="role">Role</label>
+                    <select class="form-select" name="role" id="role">
+                        <option value="admin">Administrator</option>
+                        <option value="editor">Editor</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label class="form-label" for="status">Status</label>
+                    <select class="form-select" name="status" id="status">
+                        <option value="active">Active</option>
+                        <option value="inactive">Inactive</option>
+                    </select>
+                </div>
+                <div class="users-form-actions">
+                    <button type="submit" class="a11y-btn a11y-btn--primary" id="userFormSubmit">
+                        <i class="fas fa-save" aria-hidden="true"></i>
+                        <span>Save changes</span>
+                    </button>
+                    <button type="button" class="a11y-btn a11y-btn--ghost" id="userFormCancel">
+                        <span>Cancel</span>
+                    </button>
+                    <button type="button" class="a11y-btn a11y-btn--secondary users-delete" id="userDeleteBtn">
+                        <i class="fas fa-trash" aria-hidden="true"></i>
+                        <span>Delete user</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
 

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -3252,6 +3252,120 @@
     font-style: italic;
 }
 
+/* Users module dashboard */
+.users-dashboard .a11y-hero {
+    background: linear-gradient(135deg, #2563eb 0%, #9333ea 100%);
+}
+
+.users-dashboard .a11y-hero::before {
+    background: rgba(255, 255, 255, 0.18);
+}
+
+.users-dashboard .users-last-sync {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 20px;
+    font-size: 14px;
+}
+
+.users-dashboard .users-grid .users-card {
+    cursor: pointer;
+}
+
+.users-dashboard .users-status-badge,
+.users-dashboard .users-role-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+
+.users-dashboard .users-role-badge {
+    background: #e0f2fe;
+    color: #1d4ed8;
+}
+
+.users-dashboard .users-card .users-card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.users-dashboard .users-card-meta {
+    color: #64748b;
+    font-size: 13px;
+}
+
+.users-dashboard .user-status--active {
+    background: #dcfce7;
+    color: #15803d;
+}
+
+.users-dashboard .user-status--inactive {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.users-dashboard .user-role--admin {
+    background: #ede9fe;
+    color: #5b21b6;
+}
+
+.users-dashboard .user-role--editor {
+    background: #dbeafe;
+    color: #1d4ed8;
+}
+
+.users-dashboard .users-card .a11y-btn {
+    white-space: nowrap;
+}
+
+.users-dashboard .users-table .a11y-table-cell.actions {
+    justify-content: flex-end;
+}
+
+.users-dashboard .users-table .a11y-btn--icon {
+    background: transparent;
+    border: 1px solid #e2e8f0;
+}
+
+.users-dashboard .users-form-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 24px;
+}
+
+.users-dashboard .users-delete {
+    margin-left: auto;
+}
+
+.users-drawer .a11y-detail-content {
+    max-width: 520px;
+}
+
+.users-drawer .form-group {
+    margin-bottom: 16px;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* Footer */
 .footer {
     background: #f0f0f0;


### PR DESCRIPTION
## Summary
- redesign the users module view to mirror the accessibility dashboard layout with hero stats, filters, and dual grid/table views
- rebuild the users.js client logic to support searching, filtering, view toggling, and a slide-out form for managing accounts
- add module-specific styling for status/role badges, action layouts, and an sr-only helper class

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d72674c4708331bae8269ef99dc3dd