### PR TITLE
Revamp analytics dashboard to mirror accessibility experience

### DIFF
--- a/CMS/modules/analytics/analytics.js
+++ b/CMS/modules/analytics/analytics.js
@@ -1,17 +1,442 @@
 // File: analytics.js
 $(function(){
-    function escapeHtml(str){ return $('<div>').text(str).html(); }
-    function loadAnalytics(){
-        $.getJSON('modules/analytics/analytics_data.php', function(data){
-            const tbody = $('#analyticsTable tbody').empty();
-            (data || []).forEach(row => {
-                tbody.append('<tr>'+
-                    '<td class="title">'+escapeHtml(row.title)+'</td>'+
-                    '<td class="slug">'+escapeHtml(row.slug)+'</td>'+
-                    '<td class="views">'+row.views+'</td>'+
-                '</tr>');
-            });
+    const state = {
+        entries: [],
+        filter: 'all',
+        view: 'grid',
+        summary: {
+            totalViews: 0,
+            averageViews: 0,
+            totalPages: 0,
+            zeroViews: 0,
+        },
+        counts: {
+            all: 0,
+            top: 0,
+            growing: 0,
+            'no-views': 0,
+        }
+    };
+
+    const $grid = $('#analyticsGrid');
+    const $table = $('#analyticsTableView');
+    const $tableBody = $('#analyticsTableBody');
+    const $empty = $('#analyticsEmptyState');
+    const $search = $('#analyticsSearchInput');
+    const $filterButtons = $('[data-analytics-filter]');
+    const $viewButtons = $('[data-analytics-view]');
+    const $counts = $('[data-analytics-count]');
+    const $refreshBtn = $('[data-analytics-action="refresh"]');
+    const $exportBtn = $('[data-analytics-action="export"]');
+    const $totalViews = $('#analyticsTotalViews');
+    const $averageViews = $('#analyticsAverageViews');
+    const $totalPages = $('#analyticsTotalPages');
+    const $zeroPages = $('#analyticsZeroPages');
+    const $lastUpdated = $('#analyticsLastUpdated');
+    const $topList = $('#analyticsTopList');
+    const $topEmpty = $('#analyticsTopEmpty');
+    const $zeroList = $('#analyticsZeroList');
+    const $zeroEmpty = $('#analyticsZeroEmpty');
+    const $zeroSummary = $('#analyticsZeroSummary');
+
+    function escapeHtml(str){
+        return $('<div>').text(str == null ? '' : String(str)).html();
+    }
+
+    function formatNumber(value){
+        const number = Number(value) || 0;
+        return number.toLocaleString(undefined, { maximumFractionDigits: 0 });
+    }
+
+    function formatAverage(value){
+        const number = Number(value) || 0;
+        return number.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+    }
+
+    function setButtonLoading($button, loading){
+        if (!$button.length) {
+            return;
+        }
+        const $text = $button.find('.analytics-btn__text');
+        const defaultText = $button.data('defaultText') ?? $text.text();
+        if ($button.data('defaultText') === undefined) {
+            $button.data('defaultText', defaultText);
+        }
+        const loadingText = $button.data('loadingText') || 'Working…';
+        if (loading) {
+            if ($text.length) {
+                $text.text(loadingText);
+            }
+            $button.addClass('is-loading').prop('disabled', true).attr('aria-busy', 'true');
+        } else {
+            if ($text.length) {
+                $text.text($button.data('defaultText'));
+            }
+            $button.removeClass('is-loading').prop('disabled', false).removeAttr('aria-busy');
+        }
+    }
+
+    function deriveState(rawEntries){
+        const entries = Array.isArray(rawEntries) ? rawEntries.slice() : [];
+        const sanitized = entries.map(function(entry){
+            const views = Number(entry && entry.views != null ? entry.views : 0);
+            return {
+                title: entry && entry.title ? String(entry.title) : 'Untitled',
+                slug: entry && entry.slug ? String(entry.slug) : '',
+                views: views < 0 ? 0 : views,
+            };
+        });
+
+        sanitized.sort(function(a, b){
+            return (b.views || 0) - (a.views || 0);
+        });
+
+        const totals = {
+            totalViews: 0,
+            totalPages: sanitized.length,
+            zeroViews: 0,
+            averageViews: 0,
+        };
+
+        sanitized.forEach(function(entry){
+            totals.totalViews += entry.views;
+            if (entry.views === 0) {
+                totals.zeroViews++;
+            }
+        });
+
+        totals.averageViews = totals.totalPages > 0 ? totals.totalViews / totals.totalPages : 0;
+
+        const counts = {
+            all: sanitized.length,
+            top: 0,
+            growing: 0,
+            'no-views': 0,
+        };
+
+        sanitized.forEach(function(entry, index){
+            let status = 'growing';
+            if (entry.views === 0) {
+                status = 'no-views';
+            } else if (index < 3 || entry.views >= totals.averageViews) {
+                status = 'top';
+            }
+
+            counts[status]++;
+
+            entry.status = status;
+            entry.rank = index + 1;
+            entry.badge = status === 'top' ? 'Top performer' : (status === 'no-views' ? 'Needs promotion' : 'Steady traffic');
+            entry.titleLower = entry.title.toLowerCase();
+            entry.slugLower = entry.slug.toLowerCase();
+        });
+
+        return {
+            entries: sanitized,
+            totals: totals,
+            counts: counts,
+        };
+    }
+
+    function updateSummary(){
+        $totalViews.text(formatNumber(state.summary.totalViews));
+        $averageViews.text(formatAverage(state.summary.averageViews));
+        $totalPages.text(formatNumber(state.summary.totalPages));
+        $zeroPages.text(formatNumber(state.summary.zeroViews));
+    }
+
+    function updateFilterCounts(){
+        $counts.each(function(){
+            const $count = $(this);
+            const key = $count.data('analyticsCount');
+            if (!key) {
+                return;
+            }
+            const value = state.counts[key] ?? 0;
+            $count.text(formatNumber(value));
         });
     }
-    loadAnalytics();
+
+    function updateLastUpdatedDisplay(value){
+        if (!$lastUpdated.length) {
+            return;
+        }
+        let label = 'Data refreshed moments ago';
+        if (value instanceof Date) {
+            label = 'Data refreshed ' + value.toLocaleString();
+            $lastUpdated.attr('data-timestamp', value.toISOString());
+        } else if (typeof value === 'string' && value.trim() !== '') {
+            label = value;
+        }
+        $lastUpdated.text(label);
+    }
+
+    function renderInsights(){
+        if ($topList.length) {
+            const topItems = state.entries.slice(0, 3);
+            $topList.empty();
+            if (topItems.length) {
+                topItems.forEach(function(item){
+                    $topList.append(
+                        '<li>' +
+                            '<div>' +
+                                '<span class="analytics-insight-item-title">' + escapeHtml(item.title) + '</span>' +
+                                '<span class="analytics-insight-item-slug">' + escapeHtml(item.slug) + '</span>' +
+                            '</div>' +
+                            '<span class="analytics-insight-metric">' + formatNumber(item.views) + ' views</span>' +
+                        '</li>'
+                    );
+                });
+                $topList.removeAttr('hidden');
+                $topEmpty.attr('hidden', true);
+            } else {
+                $topList.attr('hidden', true);
+                $topEmpty.removeAttr('hidden');
+            }
+        }
+
+        if ($zeroList.length) {
+            const zeroItems = state.entries.filter(function(item){
+                return item.views === 0;
+            }).slice(0, 3);
+            $zeroList.empty();
+            if (zeroItems.length) {
+                zeroItems.forEach(function(item){
+                    $zeroList.append(
+                        '<li>' +
+                            '<div>' +
+                                '<span class="analytics-insight-item-title">' + escapeHtml(item.title) + '</span>' +
+                                '<span class="analytics-insight-item-slug">' + escapeHtml(item.slug) + '</span>' +
+                            '</div>' +
+                            '<span class="analytics-insight-metric">0 views</span>' +
+                        '</li>'
+                    );
+                });
+                $zeroList.removeAttr('hidden');
+                $zeroEmpty.attr('hidden', true);
+                if ($zeroSummary.length) {
+                    const total = state.summary.zeroViews;
+                    $zeroSummary.text(total === 1
+                        ? 'You have 1 page with no recorded views.'
+                        : 'You have ' + formatNumber(total) + ' pages with no recorded views.');
+                }
+            } else {
+                $zeroList.attr('hidden', true);
+                $zeroEmpty.removeAttr('hidden');
+                if ($zeroSummary.length) {
+                    $zeroSummary.text('Great job! Every published page has at least one view.');
+                }
+            }
+        }
+    }
+
+    function renderGrid(items){
+        $grid.empty();
+        if (!items.length) {
+            return;
+        }
+        const fragments = items.map(function(item){
+            const badgeClass = item.status === 'top'
+                ? 'analytics-badge--success'
+                : (item.status === 'no-views' ? 'analytics-badge--warning' : 'analytics-badge--neutral');
+            const badge = '<span class="analytics-badge ' + badgeClass + '">' + escapeHtml(item.badge) + '</span>';
+            const rank = item.rank <= 3 ? '<span class="analytics-rank">#' + item.rank + '</span>' : '';
+            return (
+                '<article class="analytics-page-card" data-analytics-status="' + item.status + '" role="listitem">' +
+                    '<div class="analytics-page-card__header">' +
+                        '<div>' +
+                            '<h3 class="analytics-page-card__title">' + escapeHtml(item.title) + '</h3>' +
+                            '<p class="analytics-page-card__slug">/' + escapeHtml(item.slug) + '</p>' +
+                        '</div>' +
+                        '<div class="analytics-page-card__metric">' +
+                            '<span class="analytics-page-card__views">' + formatNumber(item.views) + '</span>' +
+                            '<span class="analytics-page-card__label">views</span>' +
+                        '</div>' +
+                    '</div>' +
+                    '<div class="analytics-page-card__footer">' +
+                        rank +
+                        badge +
+                    '</div>' +
+                '</article>'
+            );
+        });
+        $grid.html(fragments.join(''));
+    }
+
+    function renderTable(items){
+        $tableBody.empty();
+        if (!items.length) {
+            return;
+        }
+        const rows = items.map(function(item){
+            return (
+                '<tr>' +
+                    '<td class="analytics-table__title">' + escapeHtml(item.title) + '</td>' +
+                    '<td class="analytics-table__slug">/' + escapeHtml(item.slug) + '</td>' +
+                    '<td class="analytics-table__views">' + formatNumber(item.views) + '</td>' +
+                '</tr>'
+            );
+        });
+        $tableBody.html(rows.join(''));
+    }
+
+    function applyFilters(){
+        const term = ($search.val() || '').toString().trim().toLowerCase();
+        return state.entries.filter(function(item){
+            const matchesFilter = state.filter === 'all' || item.status === state.filter;
+            if (!matchesFilter) {
+                return false;
+            }
+            if (!term) {
+                return true;
+            }
+            return item.titleLower.includes(term) || item.slugLower.includes(term);
+        });
+    }
+
+    function updateEmptyState(hasResults){
+        if (!$empty.length) {
+            return;
+        }
+        if (hasResults) {
+            $empty.attr('hidden', true);
+        } else {
+            $empty.removeAttr('hidden');
+        }
+    }
+
+    function render(){
+        const results = applyFilters();
+        const hasResults = results.length > 0;
+        if (state.view === 'grid') {
+            renderGrid(results);
+            $tableBody.empty();
+            $grid.removeAttr('hidden');
+            $table.attr('hidden', true);
+        } else {
+            renderTable(results);
+            $grid.empty();
+            $grid.attr('hidden', true);
+            $table.removeAttr('hidden');
+        }
+        updateEmptyState(hasResults);
+    }
+
+    function setFilter(filter){
+        if (state.filter === filter) {
+            return;
+        }
+        state.filter = filter;
+        $filterButtons.removeClass('active');
+        $filterButtons.filter('[data-analytics-filter="' + filter + '"]').addClass('active');
+        render();
+    }
+
+    function setView(view){
+        if (state.view === view) {
+            return;
+        }
+        state.view = view;
+        $viewButtons.removeClass('active');
+        $viewButtons.filter('[data-analytics-view="' + view + '"]').addClass('active');
+        render();
+    }
+
+    function debounce(fn, delay){
+        let timer = null;
+        return function(){
+            const context = this;
+            const args = arguments;
+            clearTimeout(timer);
+            timer = setTimeout(function(){
+                fn.apply(context, args);
+            }, delay);
+        };
+    }
+
+    function setData(rawEntries){
+        const derived = deriveState(rawEntries);
+        state.entries = derived.entries;
+        state.summary = derived.totals;
+        state.counts = derived.counts;
+        updateSummary();
+        updateFilterCounts();
+        renderInsights();
+        render();
+    }
+
+    function loadFromServer(){
+        if (!$refreshBtn.length) {
+            return;
+        }
+        setButtonLoading($refreshBtn, true);
+        $.getJSON('modules/analytics/analytics_data.php')
+            .done(function(data){
+                setData(data || []);
+                updateLastUpdatedDisplay(new Date());
+            })
+            .fail(function(){
+                window.alert('Unable to refresh analytics data right now. Please try again later.');
+            })
+            .always(function(){
+                setButtonLoading($refreshBtn, false);
+            });
+    }
+
+    function exportCsv(){
+        if (!state.entries.length) {
+            window.alert('No analytics data to export yet.');
+            return;
+        }
+        const rows = ['"Title","Slug","Views"'];
+        state.entries.forEach(function(item){
+            const title = '"' + String(item.title).replace(/"/g, '""') + '"';
+            const slug = '"' + String(item.slug).replace(/"/g, '""') + '"';
+            rows.push([title, slug, item.views].join(','));
+        });
+        const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'analytics-export.csv';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    }
+
+    const initialEntries = window.analyticsInitialEntries || [];
+    const initialMeta = window.analyticsInitialMeta || {};
+    setData(initialEntries);
+    updateLastUpdatedDisplay(initialMeta.lastUpdated);
+
+    $filterButtons.on('click', function(){
+        const filter = $(this).data('analyticsFilter');
+        if (filter) {
+            setFilter(filter);
+        }
+    });
+
+    $viewButtons.on('click', function(){
+        const view = $(this).data('analyticsView');
+        if (view) {
+            setView(view);
+        }
+    });
+
+    $search.on('input', debounce(function(){
+        render();
+    }, 150));
+
+    if ($refreshBtn.length) {
+        $refreshBtn.on('click', function(){
+            loadFromServer();
+        });
+    }
+
+    if ($exportBtn.length) {
+        $exportBtn.on('click', function(){
+            exportCsv();
+        });
+    }
 });

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1199,6 +1199,541 @@
             color: #fff;
         }
 
+        /* Analytics dashboard */
+        #analytics {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .analytics-dashboard {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .analytics-hero {
+            position: relative;
+            background: linear-gradient(135deg, #0f172a, #2563eb);
+            color: #fff;
+            padding: 32px;
+            border-radius: 18px;
+            overflow: hidden;
+            box-shadow: 0 24px 48px rgba(37, 99, 235, 0.25);
+        }
+
+        .analytics-hero::before,
+        .analytics-hero::after {
+            content: '';
+            position: absolute;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.14);
+            filter: blur(1px);
+        }
+
+        .analytics-hero::before {
+            width: 220px;
+            height: 220px;
+            top: -80px;
+            right: -60px;
+        }
+
+        .analytics-hero::after {
+            width: 160px;
+            height: 160px;
+            bottom: -70px;
+            left: -40px;
+        }
+
+        .analytics-hero-content {
+            position: relative;
+            display: flex;
+            justify-content: space-between;
+            gap: 24px;
+            flex-wrap: wrap;
+        }
+
+        .analytics-hero-text {
+            max-width: 520px;
+        }
+
+        .analytics-hero-title {
+            font-size: 30px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .analytics-hero-subtitle {
+            font-size: 15px;
+            line-height: 1.6;
+            color: rgba(255,255,255,0.85);
+        }
+
+        .analytics-hero-actions {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            flex-wrap: wrap;
+        }
+
+        .analytics-hero-meta {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: rgba(15,23,42,0.35);
+            font-size: 13px;
+            color: rgba(255,255,255,0.85);
+        }
+
+        .analytics-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            border-radius: 12px;
+            border: none;
+            cursor: pointer;
+            font-weight: 600;
+            font-size: 14px;
+            padding: 10px 18px;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+        }
+
+        .analytics-btn i {
+            font-size: 14px;
+        }
+
+        .analytics-btn--primary {
+            background: #38bdf8;
+            color: #0f172a;
+            box-shadow: 0 16px 32px rgba(56, 189, 248, 0.35);
+        }
+
+        .analytics-btn--primary:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 20px 36px rgba(56, 189, 248, 0.45);
+        }
+
+        .analytics-btn--ghost {
+            background: rgba(15,23,42,0.35);
+            color: #e2e8f0;
+        }
+
+        .analytics-btn--ghost:hover {
+            background: rgba(15,23,42,0.5);
+        }
+
+        .analytics-btn.is-loading {
+            opacity: 0.7;
+            cursor: wait;
+        }
+
+        .analytics-overview-grid {
+            position: relative;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 18px;
+            margin-top: 28px;
+        }
+
+        .analytics-overview-card {
+            background: rgba(15,23,42,0.2);
+            border-radius: 16px;
+            padding: 18px 22px;
+            backdrop-filter: blur(8px);
+        }
+
+        .analytics-overview-value {
+            font-size: 30px;
+            font-weight: 600;
+        }
+
+        .analytics-overview-label {
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            margin-top: 4px;
+            color: rgba(255,255,255,0.8);
+        }
+
+        .analytics-overview-hint {
+            margin-top: 10px;
+            font-size: 13px;
+            color: rgba(255,255,255,0.7);
+        }
+
+        .analytics-insights {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 20px;
+        }
+
+        .analytics-insight-card {
+            background: #ffffff;
+            border-radius: 16px;
+            padding: 24px;
+            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+        }
+
+        .analytics-insight-card--secondary {
+            background: linear-gradient(135deg, #f8fafc, #e0f2fe);
+        }
+
+        .analytics-insight-header {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            margin-bottom: 20px;
+        }
+
+        .analytics-insight-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 12px;
+            background: #eef2ff;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: #4338ca;
+            font-size: 18px;
+        }
+
+        .analytics-insight-card--secondary .analytics-insight-icon {
+            background: rgba(14, 165, 233, 0.18);
+            color: #0ea5e9;
+        }
+
+        .analytics-insight-title {
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 4px;
+            color: #1e293b;
+        }
+
+        .analytics-insight-subtitle {
+            font-size: 14px;
+            color: #64748b;
+        }
+
+        .analytics-insight-summary {
+            font-size: 14px;
+            color: #1e293b;
+            margin-bottom: 16px;
+        }
+
+        .analytics-insight-list {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            margin: 0;
+            padding: 0;
+            list-style: none;
+        }
+
+        .analytics-insight-list li {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+        }
+
+        .analytics-insight-item-title {
+            display: block;
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .analytics-insight-item-slug {
+            font-size: 13px;
+            color: #64748b;
+        }
+
+        .analytics-insight-metric {
+            font-weight: 600;
+            color: #334155;
+            white-space: nowrap;
+        }
+
+        .analytics-insight-empty {
+            font-size: 14px;
+            color: #94a3b8;
+        }
+
+        .analytics-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .analytics-search {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px 16px;
+            border-radius: 12px;
+            border: 1px solid #e2e8f0;
+            background: #ffffff;
+            color: #64748b;
+            min-width: 260px;
+            flex: 1;
+            max-width: 420px;
+        }
+
+        .analytics-search i {
+            font-size: 15px;
+        }
+
+        .analytics-search input {
+            border: none;
+            outline: none;
+            flex: 1;
+            font-size: 14px;
+            color: #1f2937;
+        }
+
+        .analytics-filter-group {
+            display: inline-flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .analytics-filter-btn {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            color: #0f172a;
+            border-radius: 999px;
+            padding: 8px 16px;
+            font-size: 13px;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .analytics-filter-btn .analytics-filter-count {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2px 10px;
+            border-radius: 999px;
+            background: #e0f2fe;
+            font-size: 12px;
+        }
+
+        .analytics-filter-btn:hover,
+        .analytics-filter-btn.active {
+            background: linear-gradient(135deg, #2563eb, #4338ca);
+            color: #fff;
+            border-color: transparent;
+        }
+
+        .analytics-filter-btn:hover .analytics-filter-count,
+        .analytics-filter-btn.active .analytics-filter-count {
+            background: rgba(255,255,255,0.2);
+        }
+
+        .analytics-view-toggle {
+            display: inline-flex;
+            border: 1px solid #e2e8f0;
+            border-radius: 10px;
+            overflow: hidden;
+        }
+
+        .analytics-view-btn {
+            background: #fff;
+            border: none;
+            color: #64748b;
+            padding: 8px 14px;
+            cursor: pointer;
+            transition: background 0.2s ease, color 0.2s ease;
+        }
+
+        .analytics-view-btn i {
+            font-size: 15px;
+        }
+
+        .analytics-view-btn:hover,
+        .analytics-view-btn.active {
+            background: #2563eb;
+            color: #fff;
+        }
+
+        .analytics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 20px;
+        }
+
+        .analytics-page-card {
+            background: #ffffff;
+            border-radius: 16px;
+            padding: 22px;
+            box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            border: 1px solid rgba(226, 232, 240, 0.6);
+        }
+
+        .analytics-page-card__header {
+            display: flex;
+            justify-content: space-between;
+            gap: 18px;
+            align-items: flex-start;
+        }
+
+        .analytics-page-card__title {
+            font-size: 18px;
+            font-weight: 600;
+            color: #0f172a;
+            margin: 0 0 6px;
+        }
+
+        .analytics-page-card__slug {
+            font-size: 13px;
+            color: #64748b;
+            margin: 0;
+        }
+
+        .analytics-page-card__metric {
+            text-align: right;
+        }
+
+        .analytics-page-card__views {
+            font-size: 26px;
+            font-weight: 600;
+            color: #2563eb;
+            display: block;
+        }
+
+        .analytics-page-card__label {
+            font-size: 12px;
+            color: #64748b;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+
+        .analytics-page-card__footer {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .analytics-rank {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(37, 99, 235, 0.1);
+            color: #2563eb;
+            font-weight: 600;
+            font-size: 13px;
+        }
+
+        .analytics-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-size: 13px;
+            font-weight: 600;
+        }
+
+        .analytics-badge--success {
+            background: rgba(22, 163, 74, 0.12);
+            color: #15803d;
+        }
+
+        .analytics-badge--warning {
+            background: rgba(234, 179, 8, 0.16);
+            color: #b45309;
+        }
+
+        .analytics-badge--neutral {
+            background: rgba(59, 130, 246, 0.12);
+            color: #1d4ed8;
+        }
+
+        .analytics-table {
+            background: #ffffff;
+            border-radius: 16px;
+            box-shadow: 0 12px 30px rgba(15, 23, 42, 0.12);
+            overflow: hidden;
+            border: 1px solid rgba(226, 232, 240, 0.6);
+        }
+
+        .analytics-table__table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .analytics-table__table thead {
+            background: #f8fafc;
+        }
+
+        .analytics-table__table th,
+        .analytics-table__table td {
+            padding: 14px 18px;
+            text-align: left;
+            font-size: 14px;
+        }
+
+        .analytics-table__table th {
+            font-size: 13px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #64748b;
+        }
+
+        .analytics-table__table tbody tr:nth-child(even) {
+            background: #f8fafc;
+        }
+
+        .analytics-table__views {
+            text-align: right;
+            font-weight: 600;
+            color: #2563eb;
+        }
+
+        .analytics-empty-state {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+            padding: 48px;
+            border: 2px dashed #e2e8f0;
+            border-radius: 16px;
+            color: #94a3b8;
+            text-align: center;
+            background: #f8fafc;
+        }
+
+        .analytics-empty-state i {
+            font-size: 32px;
+        }
+
+        @media (max-width: 768px) {
+            .analytics-hero {
+                padding: 24px;
+            }
+
+            .analytics-overview-grid {
+                grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            }
+
+            .analytics-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
         .a11y-action-bar {
             display: flex;
             justify-content: space-between;


### PR DESCRIPTION
## Summary
- rebuild the analytics module view with a hero section, summary stats, insight cards, filters, and grid/table layouts similar to the accessibility dashboard
- add richer client-side interactions including filtering, search, refresh, CSV export, and dynamic insights rendering for analytics data
- introduce dedicated analytics styling in the shared stylesheet to support the refreshed layout and controls

## Testing
- php -l CMS/modules/analytics/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d72651d4cc83319e0e0aebecdf37ed