### PR TITLE
Revamp settings module UI and data handling

### DIFF
--- a/CMS/modules/settings/list_settings.php
+++ b/CMS/modules/settings/list_settings.php
@@ -4,6 +4,8 @@ require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
 require_login();
 
+header('Content-Type: application/json');
+
 $settingsFile = __DIR__ . '/../../data/settings.json';
 $settings = read_json_file($settingsFile);
 

--- a/CMS/modules/settings/save_settings.php
+++ b/CMS/modules/settings/save_settings.php
@@ -5,12 +5,23 @@ require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
+header('Content-Type: application/json');
+
 $settingsFile = __DIR__ . '/../../data/settings.json';
 $settings = read_json_file($settingsFile);
+if (!is_array($settings)) {
+    $settings = [];
+}
 
 $settings['site_name'] = sanitize_text($_POST['site_name'] ?? ($settings['site_name'] ?? ''));
 $settings['tagline'] = sanitize_text($_POST['tagline'] ?? ($settings['tagline'] ?? ''));
 $settings['admin_email'] = sanitize_text($_POST['admin_email'] ?? ($settings['admin_email'] ?? ''));
+$settings['timezone'] = sanitize_text($_POST['timezone'] ?? ($settings['timezone'] ?? 'America/Los_Angeles'));
+$settings['googleAnalytics'] = sanitize_text($_POST['googleAnalytics'] ?? ($settings['googleAnalytics'] ?? ''));
+$settings['googleSearchConsole'] = sanitize_text($_POST['googleSearchConsole'] ?? ($settings['googleSearchConsole'] ?? ''));
+$settings['facebookPixel'] = sanitize_text($_POST['facebookPixel'] ?? ($settings['facebookPixel'] ?? ''));
+$settings['generateSitemap'] = isset($_POST['generateSitemap']);
+$settings['allowIndexing'] = isset($_POST['allowIndexing']);
 
 $uploadDir = __DIR__ . '/../../uploads';
 if (!is_dir($uploadDir)) {
@@ -19,14 +30,43 @@ if (!is_dir($uploadDir)) {
 
 if (!empty($_FILES['logo']['name']) && is_uploaded_file($_FILES['logo']['tmp_name'])) {
     $ext = strtolower(pathinfo($_FILES['logo']['name'], PATHINFO_EXTENSION));
-    $safe = 'logo_' . uniqid() . '.' . $ext;
+    $safe = 'logo_' . uniqid('', true) . '.' . $ext;
     $dest = $uploadDir . '/' . $safe;
     if (move_uploaded_file($_FILES['logo']['tmp_name'], $dest)) {
         $settings['logo'] = 'uploads/' . $safe;
     }
 }
 
-file_put_contents($settingsFile, json_encode($settings, JSON_PRETTY_PRINT));
+$social = is_array($settings['social'] ?? null) ? $settings['social'] : [];
+$socialFields = ['facebook', 'twitter', 'instagram', 'linkedin', 'youtube', 'tiktok'];
+foreach ($socialFields as $field) {
+    $social[$field] = sanitize_url($_POST[$field] ?? ($social[$field] ?? ''));
+}
+$settings['social'] = $social;
 
-echo 'OK';
-?>
+$openGraph = is_array($settings['open_graph'] ?? null) ? $settings['open_graph'] : [];
+$openGraph['title'] = sanitize_text($_POST['ogTitle'] ?? ($openGraph['title'] ?? ''));
+$openGraph['description'] = sanitize_text($_POST['ogDescription'] ?? ($openGraph['description'] ?? ''));
+
+if (!empty($_FILES['ogImage']['name']) && is_uploaded_file($_FILES['ogImage']['tmp_name'])) {
+    $ext = strtolower(pathinfo($_FILES['ogImage']['name'], PATHINFO_EXTENSION));
+    $safe = 'og_' . uniqid('', true) . '.' . $ext;
+    $dest = $uploadDir . '/' . $safe;
+    if (move_uploaded_file($_FILES['ogImage']['tmp_name'], $dest)) {
+        $openGraph['image'] = 'uploads/' . $safe;
+    }
+}
+
+$settings['open_graph'] = $openGraph;
+$settings['last_updated'] = date('c');
+
+write_json_file($settingsFile, $settings);
+
+echo json_encode([
+    'status' => 'ok',
+    'last_updated' => $settings['last_updated'],
+    'logo' => $settings['logo'] ?? null,
+    'open_graph' => [
+        'image' => $openGraph['image'] ?? null,
+    ],
+]);

--- a/CMS/modules/settings/settings.js
+++ b/CMS/modules/settings/settings.js
@@ -1,30 +1,138 @@
 // File: settings.js
 $(function(){
+    const $form = $('#settingsForm');
+    const $dashboard = $('#settingsDashboard');
+    const $lastSaved = $('#settingsLastSaved');
+    const $saveButton = $('#saveSettingsButton');
+    const $logoPreview = $('#logoPreview');
+    const $ogPreview = $('#ogImagePreview');
+
+    function formatTimestamp(value){
+        if(!value){
+            return 'Not saved yet';
+        }
+        const date = new Date(value);
+        if(Number.isNaN(date.getTime())){
+            return value;
+        }
+        return date.toLocaleString(undefined, {
+            dateStyle: 'medium',
+            timeStyle: 'short'
+        });
+    }
+
+    function updateHeroMeta(timestamp){
+        $dashboard.attr('data-last-saved', timestamp || '');
+        $lastSaved.text(formatTimestamp(timestamp));
+    }
+
+    function updateOverview(){
+        const siteName = $('#site_name').val().trim();
+        $('#settingsOverviewName').text(siteName || 'Not set');
+
+        const socialSelectors = [
+            '#facebookLink',
+            '#twitterLink',
+            '#instagramLink',
+            '#linkedinLink',
+            '#youtubeLink',
+            '#tiktokLink'
+        ];
+        const socialCount = socialSelectors.reduce((count, selector) => {
+            return count + ($(selector).val().trim() ? 1 : 0);
+        }, 0);
+        $('#settingsOverviewSocials').text(socialCount);
+
+        const trackingFields = [
+            '#googleAnalytics',
+            '#googleSearchConsole',
+            '#facebookPixel'
+        ];
+        const trackingCount = trackingFields.reduce((count, selector) => {
+            return count + ($(selector).val().trim() ? 1 : 0);
+        }, 0);
+        $('#settingsOverviewTracking').text(trackingCount);
+
+        const sitemapOn = $('#generateSitemap').is(':checked');
+        const indexingOn = $('#allowIndexing').is(':checked');
+        const visibility = indexingOn ? 'Public' : 'Restricted';
+        const details = [];
+        details.push(sitemapOn ? 'Sitemap on' : 'Sitemap off');
+        details.push(indexingOn ? 'Indexing allowed' : 'Indexing blocked');
+        $('#settingsOverviewVisibility').text(visibility).attr('title', details.join(' • '));
+    }
+
+    function togglePreview($img, src){
+        if(src){
+            $img.attr('src', src).removeAttr('hidden');
+        } else {
+            $img.attr('src', '').attr('hidden', true);
+        }
+    }
+
     function loadSettings(){
         $.getJSON('modules/settings/list_settings.php', function(data){
+            data = data || {};
             $('#site_name').val(data.site_name || '');
             $('#tagline').val(data.tagline || '');
             $('#admin_email').val(data.admin_email || '');
-            if(data.logo){
-                $('#logoPreview').attr('src', data.logo).show();
-            }else{
-                $('#logoPreview').hide();
-            }
+
+            togglePreview($logoPreview, data.logo || '');
+
+            $('#timezone').val(data.timezone || 'America/Los_Angeles');
+            $('#googleAnalytics').val(data.googleAnalytics || '');
+            $('#googleSearchConsole').val(data.googleSearchConsole || '');
+            $('#facebookPixel').val(data.facebookPixel || '');
+
+            $('#generateSitemap').prop('checked', data.generateSitemap !== false);
+            $('#allowIndexing').prop('checked', data.allowIndexing !== false);
+
+            const social = data.social || {};
+            $('#facebookLink').val(social.facebook || '');
+            $('#twitterLink').val(social.twitter || '');
+            $('#instagramLink').val(social.instagram || '');
+            $('#linkedinLink').val(social.linkedin || '');
+            $('#youtubeLink').val(social.youtube || '');
+            $('#tiktokLink').val(social.tiktok || '');
+
+            const openGraph = data.open_graph || {};
+            $('#ogTitle').val(openGraph.title || '');
+            $('#ogDescription').val(openGraph.description || '');
+            togglePreview($ogPreview, openGraph.image || '');
+
+            updateHeroMeta(data.last_updated || '');
+            updateOverview();
         });
     }
 
     $('#logoFile').on('change', function(){
-        const file = this.files[0];
+        const file = this.files && this.files[0];
         if(file){
             const reader = new FileReader();
             reader.onload = function(e){
-                $('#logoPreview').attr('src', e.target.result).show();
+                togglePreview($logoPreview, e.target.result);
+                updateOverview();
             };
             reader.readAsDataURL(file);
         }
     });
 
-    $('#settingsForm').on('submit', function(e){
+    $('#ogImageFile').on('change', function(){
+        const file = this.files && this.files[0];
+        if(file){
+            const reader = new FileReader();
+            reader.onload = function(e){
+                togglePreview($ogPreview, e.target.result);
+            };
+            reader.readAsDataURL(file);
+        }
+    });
+
+    $form.on('input change', 'input, textarea, select', function(){
+        updateOverview();
+    });
+
+    $form.on('submit', function(e){
         e.preventDefault();
         const fd = new FormData(this);
         $.ajax({
@@ -33,9 +141,22 @@ $(function(){
             data: fd,
             processData: false,
             contentType: false,
-            success: function(){
+            dataType: 'json',
+            beforeSend: function(){
+                $saveButton.addClass('is-loading').prop('disabled', true);
+            },
+            complete: function(){
+                $saveButton.removeClass('is-loading').prop('disabled', false);
+            },
+            success: function(response){
                 alertModal('Settings saved');
+                if(response && response.last_updated){
+                    updateHeroMeta(response.last_updated);
+                }
                 loadSettings();
+            },
+            error: function(){
+                alertModal('Unable to save settings');
             }
         });
     });

--- a/CMS/modules/settings/view.php
+++ b/CMS/modules/settings/view.php
@@ -1,113 +1,162 @@
 <!-- File: view.php -->
-                <form id="settingsForm">
-                    <div class="content-section" id="settings">
-                        <div class="form-card" id="settingsFormCard" style="margin-top:20px;">
-                            <h3>General Settings</h3>
-                            <div class="form-group">
-                                <label class="form-label">Site Name</label>
-                                <input type="text" class="form-input" name="site_name" id="site_name">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Tagline</label>
-                                <input type="text" class="form-input" name="tagline" id="tagline">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Admin Email</label>
-                                <input type="email" class="form-input" name="admin_email" id="admin_email">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Site Logo</label>
-                                <input type="file" class="form-input" id="logoFile" name="logo" accept="image/*">
-                                <img id="logoPreview" src="" alt="Logo preview" style="max-height:50px;margin-top:10px;display:none;">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="timezone">Timezone</label>
-                                <select class="form-select" id="timezone" name="timezone">
-                                    <option value="America/New_York">Eastern Time (ET)</option>
-                                    <option value="America/Chicago">Central Time (CT)</option>
-                                    <option value="America/Denver">Mountain Time (MT)</option>
-                                    <option value="America/Los_Angeles" selected>Pacific Time (PT)</option>
-                                    <option value="UTC">UTC</option>
-                                </select>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="googleAnalytics">Google Analytics ID</label>
-                                <input type="text" class="form-input" id="googleAnalytics" name="googleAnalytics" placeholder="G-XXXXXXXXXX or UA-XXXXXXXX-X">
-                                <div class="form-help">Your Google Analytics measurement ID</div>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="googleSearchConsole">Google Search Console Verification Code</label>
-                                <input type="text" class="form-input" id="googleSearchConsole" name="googleSearchConsole" placeholder="google-site-verification=...">
-                                <div class="form-help">Meta tag verification code from Google Search Console</div>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="facebookPixel">Facebook Pixel ID</label>
-                                <input type="text" class="form-input" id="facebookPixel" name="facebookPixel" placeholder="1234567890123456">
-                                <div class="form-help">Your Facebook Pixel ID for conversion tracking</div>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label"><input type="checkbox" id="generateSitemap" name="generateSitemap" checked> Auto-generate XML sitemap</label>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label"><input type="checkbox" id="allowIndexing" name="allowIndexing" checked> Allow search engines to index this site</label>
-                            </div>
+<div class="content-section" id="settings">
+    <form id="settingsForm" class="settings-dashboard" enctype="multipart/form-data">
+        <div class="a11y-dashboard" id="settingsDashboard" data-last-saved="">
+            <header class="a11y-hero">
+                <div class="a11y-hero-content">
+                    <div>
+                        <h2 class="a11y-hero-title">Site Settings</h2>
+                        <p class="a11y-hero-subtitle">Fine-tune your brand voice, analytics, and sharing defaults from a single, polished workspace.</p>
+                    </div>
+                    <div class="a11y-hero-actions">
+                        <button type="submit" class="a11y-btn a11y-btn--primary" id="saveSettingsButton">
+                            <i class="fas fa-save" aria-hidden="true"></i>
+                            <span>Save Settings</span>
+                        </button>
+                        <span class="a11y-hero-meta">
+                            <i class="fas fa-clock" aria-hidden="true"></i>
+                            Last updated <span id="settingsLastSaved">—</span>
+                        </span>
+                    </div>
+                </div>
+                <div class="a11y-overview-grid">
+                    <div class="a11y-overview-card">
+                        <div class="a11y-overview-value" id="settingsOverviewName">—</div>
+                        <div class="a11y-overview-label">Site Name</div>
+                    </div>
+                    <div class="a11y-overview-card">
+                        <div class="a11y-overview-value" id="settingsOverviewSocials">0</div>
+                        <div class="a11y-overview-label">Social Profiles</div>
+                    </div>
+                    <div class="a11y-overview-card">
+                        <div class="a11y-overview-value" id="settingsOverviewTracking">0</div>
+                        <div class="a11y-overview-label">Tracking IDs</div>
+                    </div>
+                    <div class="a11y-overview-card">
+                        <div class="a11y-overview-value" id="settingsOverviewVisibility">—</div>
+                        <div class="a11y-overview-label">Visibility</div>
+                    </div>
+                </div>
+            </header>
+
+            <section class="a11y-detail-grid settings-grid" aria-label="Settings sections">
+                <article class="a11y-detail-card">
+                    <h2>Branding &amp; Basics</h2>
+                    <p class="settings-card-description">Control the essentials that shape how your site appears to visitors.</p>
+                    <div class="form-group">
+                        <label class="form-label" for="site_name">Site Name</label>
+                        <input type="text" class="form-input" name="site_name" id="site_name" autocomplete="organization">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="tagline">Tagline</label>
+                        <input type="text" class="form-input" name="tagline" id="tagline" autocomplete="off">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="admin_email">Admin Email</label>
+                        <input type="email" class="form-input" name="admin_email" id="admin_email" autocomplete="email">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="logoFile">Site Logo</label>
+                        <div class="settings-file-input">
+                            <input type="file" class="form-input" id="logoFile" name="logo" accept="image/*">
+                            <img id="logoPreview" class="settings-file-preview" src="" alt="Logo preview" hidden>
                         </div>
                     </div>
-                </div>
+                    <div class="form-group">
+                        <label class="form-label" for="timezone">Timezone</label>
+                        <select class="form-select" id="timezone" name="timezone">
+                            <option value="America/New_York">Eastern Time (ET)</option>
+                            <option value="America/Chicago">Central Time (CT)</option>
+                            <option value="America/Denver">Mountain Time (MT)</option>
+                            <option value="America/Los_Angeles">Pacific Time (PT)</option>
+                            <option value="UTC">UTC</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="googleAnalytics">Google Analytics ID</label>
+                        <input type="text" class="form-input" id="googleAnalytics" name="googleAnalytics" placeholder="G-XXXXXXXXXX or UA-XXXXXXXX-X">
+                        <div class="form-help">Your Google Analytics measurement ID.</div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="googleSearchConsole">Google Search Console Verification Code</label>
+                        <input type="text" class="form-input" id="googleSearchConsole" name="googleSearchConsole" placeholder="google-site-verification=...">
+                        <div class="form-help">Meta tag verification code from Google Search Console.</div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="facebookPixel">Facebook Pixel ID</label>
+                        <input type="text" class="form-input" id="facebookPixel" name="facebookPixel" placeholder="1234567890123456">
+                        <div class="form-help">Your Facebook Pixel ID for conversion tracking.</div>
+                    </div>
+                    <div class="settings-toggle-group" role="group" aria-label="Search visibility preferences">
+                        <label class="settings-toggle">
+                            <input type="checkbox" id="generateSitemap" name="generateSitemap" checked>
+                            <div>
+                                <span class="settings-toggle__title">Auto-generate XML sitemap</span>
+                                <p class="settings-toggle__description">Keep search engines in sync with your latest pages.</p>
+                            </div>
+                        </label>
+                        <label class="settings-toggle">
+                            <input type="checkbox" id="allowIndexing" name="allowIndexing" checked>
+                            <div>
+                                <span class="settings-toggle__title">Allow search indexing</span>
+                                <p class="settings-toggle__description">Let search engines discover and list your site.</p>
+                            </div>
+                        </label>
+                    </div>
+                </article>
 
-                <div class="content-section" id="social">
-                    <div class="form-card" id="socialFormCard" style="margin-top:20px;">
-                        <h3>Social Media</h3>
-                        <p>Connect your social media accounts and configure sharing</p>
-                            <div class="form-group">
-                                <label class="form-label" for="facebookLink">Facebook</label>
-                                <input type="url" class="form-input" id="facebookLink" name="facebook" placeholder="https://facebook.com/yourpage" value="https://facebook.com/mywebsite">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="twitterLink">Twitter</label>
-                                <input type="url" class="form-input" id="twitterLink" name="twitter" placeholder="https://twitter.com/youraccount" value="https://twitter.com/mywebsite">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="instagramLink">Instagram</label>
-                                <input type="url" class="form-input" id="instagramLink" name="instagram" placeholder="https://instagram.com/youraccount">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="linkedinLink">LinkedIn</label>
-                                <input type="url" class="form-input" id="linkedinLink" name="linkedin" placeholder="https://linkedin.com/company/yourcompany">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="youtubeLink">YouTube</label>
-                                <input type="url" class="form-input" id="youtubeLink" name="youtube" placeholder="https://youtube.com/c/yourchannel">
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="tiktokLink">TikTok</label>
-                                <input type="url" class="form-input" id="tiktokLink" name="tiktok" placeholder="https://tiktok.com/@youraccount">
-                            </div>
+                <article class="a11y-detail-card">
+                    <h2>Social Profiles</h2>
+                    <p class="settings-card-description">Connect your brand channels to power sharing and automation.</p>
+                    <div class="settings-social-grid">
+                        <div class="form-group">
+                            <label class="form-label" for="facebookLink">Facebook</label>
+                            <input type="url" class="form-input" id="facebookLink" name="facebook" placeholder="https://facebook.com/yourpage">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="twitterLink">Twitter</label>
+                            <input type="url" class="form-input" id="twitterLink" name="twitter" placeholder="https://twitter.com/youraccount">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="instagramLink">Instagram</label>
+                            <input type="url" class="form-input" id="instagramLink" name="instagram" placeholder="https://instagram.com/youraccount">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="linkedinLink">LinkedIn</label>
+                            <input type="url" class="form-input" id="linkedinLink" name="linkedin" placeholder="https://linkedin.com/company/yourcompany">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="youtubeLink">YouTube</label>
+                            <input type="url" class="form-input" id="youtubeLink" name="youtube" placeholder="https://youtube.com/c/yourchannel">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="tiktokLink">TikTok</label>
+                            <input type="url" class="form-input" id="tiktokLink" name="tiktok" placeholder="https://tiktok.com/@youraccount">
+                        </div>
                     </div>
-                </div>
+                </article>
 
-                <div class="content-section" id="openGraph">
-                    <div class="form-card" id="openGraphFormCard" style="margin-top:20px;">
-                        <h3>Open Graph Settings</h3>
-                        <p>Configure how your website appears when shared on social media</p>
-                            <div class="form-group">
-                                <label class="form-label" for="ogTitle">Default Share Title</label>
-                                <input type="text" class="form-input" id="ogTitle" name="ogTitle" value="My Awesome Website">
-                                <div class="form-help">Title that appears when pages are shared</div>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="ogDescription">Default Share Description</label>
-                                <textarea class="form-textarea" id="ogDescription" name="ogDescription">Check out this amazing website with great content and resources!</textarea>
-                                <div class="form-help">Description that appears when pages are shared</div>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label" for="ogImageFile">Default Share Image</label>
-                                <input type="file" id="ogImageFile" accept="image/*">
-                                <div class="form-help">Upload default share image (1200x630px recommended)</div>
-                            </div>
+                <article class="a11y-detail-card">
+                    <h2>Open Graph Defaults</h2>
+                    <p class="settings-card-description">Define how your pages look when shared across social platforms.</p>
+                    <div class="form-group">
+                        <label class="form-label" for="ogTitle">Default Share Title</label>
+                        <input type="text" class="form-input" id="ogTitle" name="ogTitle" placeholder="My Awesome Website">
                     </div>
-                </div>
-                    <div class="form-actions">
-                        <button type="submit" class="btn btn-primary">Save Settings</button>
+                    <div class="form-group">
+                        <label class="form-label" for="ogDescription">Default Share Description</label>
+                        <textarea class="form-textarea" id="ogDescription" name="ogDescription" rows="4" placeholder="Give people a compelling reason to click."></textarea>
                     </div>
-                </form>
+                    <div class="form-group">
+                        <label class="form-label" for="ogImageFile">Default Share Image</label>
+                        <div class="settings-file-input">
+                            <input type="file" id="ogImageFile" name="ogImage" accept="image/*">
+                            <img id="ogImagePreview" class="settings-file-preview" src="" alt="Open graph image preview" hidden>
+                        </div>
+                        <div class="form-help">Upload a 1200 × 630px image for social sharing cards.</div>
+                    </div>
+                </article>
+            </section>
+        </div>
+    </form>
+</div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1731,6 +1731,70 @@
             color: #1e293b;
         }
 
+        .settings-dashboard .settings-card-description {
+            margin: 0;
+            color: #475569;
+            font-size: 14px;
+        }
+
+        .settings-file-input {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        .settings-file-preview {
+            width: 72px;
+            height: 72px;
+            object-fit: contain;
+            border-radius: 12px;
+            border: 1px dashed #cbd5f5;
+            background: #f8fafc;
+            padding: 8px;
+        }
+
+        .settings-toggle-group {
+            display: grid;
+            gap: 12px;
+        }
+
+        .settings-toggle {
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+            padding: 12px 16px;
+            border-radius: 12px;
+            border: 1px solid #e2e8f0;
+            background: #f8fafc;
+            cursor: pointer;
+        }
+
+        .settings-toggle input {
+            margin-top: 4px;
+        }
+
+        .settings-toggle__title {
+            font-weight: 600;
+            color: #1f2937;
+        }
+
+        .settings-toggle__description {
+            margin: 4px 0 0;
+            font-size: 13px;
+            color: #64748b;
+        }
+
+        .settings-social-grid {
+            display: grid;
+            gap: 16px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .settings-social-grid .form-group {
+            margin-bottom: 0;
+        }
+
         .a11y-detail-metrics div {
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
## Summary
- restyle the settings module with the accessibility dashboard layout, hero header, and card-based sections
- enhance the frontend logic to surface live summaries, previews, and save metadata for settings
- expand the PHP endpoints to persist additional settings fields, support Open Graph assets, and return JSON responses

## Testing
- php -l CMS/modules/settings/save_settings.php
- php -l CMS/modules/settings/list_settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d726605cc8833197f1ff0d267b1dad