### PR TITLE
Add front-end form embed block

### DIFF
--- a/forms/get.php
+++ b/forms/get.php
@@ -1,0 +1,96 @@
+<?php
+// File: forms/get.php
+require_once __DIR__ . '/../CMS/includes/data.php';
+require_once __DIR__ . '/../CMS/includes/sanitize.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+$formsFile = __DIR__ . '/../CMS/data/forms.json';
+$forms = read_json_file($formsFile);
+if (!is_array($forms)) {
+    $forms = [];
+}
+
+$id = isset($_GET['id']) ? (int) $_GET['id'] : 0;
+
+function sanitize_field_name(string $name, string $label, int $index): string
+{
+    $candidate = $name !== '' ? $name : $label;
+    if ($candidate === '') {
+        $candidate = 'field_' . ($index + 1);
+    }
+    $sanitized = preg_replace('/[^a-z0-9_\-]/i', '_', $candidate);
+    if ($sanitized === '') {
+        $sanitized = 'field_' . ($index + 1);
+    }
+    return $sanitized;
+}
+
+function normalize_form(array $form, bool $includeFields = false): array
+{
+    $normalized = [
+        'id' => isset($form['id']) ? (int) $form['id'] : null,
+        'name' => isset($form['name']) ? sanitize_text((string) $form['name']) : '',
+    ];
+
+    if ($includeFields) {
+        $fields = [];
+        $index = 0;
+        if (!empty($form['fields']) && is_array($form['fields'])) {
+            foreach ($form['fields'] as $field) {
+                if (!is_array($field)) {
+                    continue;
+                }
+                $type = isset($field['type']) ? preg_replace('/[^a-z0-9_\-]/i', '', (string) $field['type']) : 'text';
+                $rawName = isset($field['name']) ? (string) $field['name'] : '';
+                $label = isset($field['label']) ? sanitize_text((string) $field['label']) : '';
+                $name = sanitize_field_name($rawName, $label, $index);
+                $required = !empty($field['required']);
+                $options = [];
+                if (!empty($field['options'])) {
+                    $parts = is_array($field['options']) ? $field['options'] : explode(',', (string) $field['options']);
+                    foreach ($parts as $part) {
+                        $option = trim((string) $part);
+                        if ($option !== '') {
+                            $options[] = $option;
+                        }
+                    }
+                }
+                $fields[] = [
+                    'type' => $type ?: 'text',
+                    'name' => $name,
+                    'label' => $label,
+                    'required' => $required,
+                    'options' => $options,
+                ];
+                $index++;
+            }
+        }
+        $normalized['fields'] = $fields;
+    }
+
+    return $normalized;
+}
+
+if ($id > 0) {
+    foreach ($forms as $form) {
+        if (!is_array($form)) {
+            continue;
+        }
+        if ((int) ($form['id'] ?? 0) === $id) {
+            echo json_encode(normalize_form($form, true), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            return;
+        }
+    }
+    http_response_code(404);
+    echo json_encode(['error' => 'Form not found'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    return;
+}
+
+$list = array_map(function ($form) {
+    return is_array($form) ? normalize_form($form, false) : [];
+}, $forms);
+
+echo json_encode($list, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/forms/submit.php
+++ b/forms/submit.php
@@ -1,0 +1,316 @@
+<?php
+// File: forms/submit.php
+require_once __DIR__ . '/../CMS/includes/data.php';
+require_once __DIR__ . '/../CMS/includes/sanitize.php';
+
+header('Content-Type: application/json; charset=utf-8');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    return;
+}
+
+$formsFile = __DIR__ . '/../CMS/data/forms.json';
+$forms = read_json_file($formsFile);
+if (!is_array($forms)) {
+    $forms = [];
+}
+
+$formId = isset($_POST['form_id']) ? (int) $_POST['form_id'] : 0;
+if ($formId <= 0) {
+    http_response_code(422);
+    echo json_encode([
+        'success' => false,
+        'errors' => [
+            ['field' => 'form_id', 'message' => 'Invalid form identifier.'],
+        ],
+    ]);
+    return;
+}
+
+$formDefinition = null;
+foreach ($forms as $form) {
+    if (!is_array($form)) {
+        continue;
+    }
+    if ((int) ($form['id'] ?? 0) === $formId) {
+        $formDefinition = $form;
+        break;
+    }
+}
+
+if (!$formDefinition) {
+    http_response_code(404);
+    echo json_encode([
+        'success' => false,
+        'errors' => [
+            ['field' => 'form_id', 'message' => 'Form not found.'],
+        ],
+    ]);
+    return;
+}
+
+$fields = [];
+if (!empty($formDefinition['fields']) && is_array($formDefinition['fields'])) {
+    $fields = $formDefinition['fields'];
+}
+
+$errors = [];
+$data = [];
+$fileMeta = [];
+$pendingFiles = [];
+
+function sanitize_field_name(string $name, string $label, int $index): string
+{
+    $candidate = $name !== '' ? $name : $label;
+    if ($candidate === '') {
+        $candidate = 'field_' . ($index + 1);
+    }
+    $sanitized = preg_replace('/[^a-z0-9_\-]/i', '_', $candidate);
+    if ($sanitized === '') {
+        $sanitized = 'field_' . ($index + 1);
+    }
+    return $sanitized;
+}
+
+foreach ($fields as $index => $field) {
+    if (!is_array($field)) {
+        continue;
+    }
+    $type = isset($field['type']) ? strtolower(trim((string) $field['type'])) : 'text';
+    $name = isset($field['name']) ? (string) $field['name'] : '';
+    $label = isset($field['label']) ? sanitize_text((string) $field['label']) : '';
+    $required = !empty($field['required']);
+    $optionsRaw = $field['options'] ?? [];
+    if (!is_array($optionsRaw)) {
+        $optionsRaw = explode(',', (string) $optionsRaw);
+    }
+    $options = [];
+    foreach ($optionsRaw as $opt) {
+        $option = trim((string) $opt);
+        if ($option !== '') {
+            $options[] = $option;
+        }
+    }
+
+    $normalizedName = sanitize_field_name($name, $label, $index);
+
+    switch ($type) {
+        case 'select':
+        case 'radio':
+            $value = isset($_POST[$normalizedName]) ? sanitize_text((string) $_POST[$normalizedName]) : '';
+            if ($required && $value === '') {
+                $errors[] = ['field' => $normalizedName, 'message' => ($label ?: 'This field') . ' is required.'];
+                break;
+            }
+            if ($value !== '' && $options && !in_array($value, $options, true)) {
+                $errors[] = ['field' => $normalizedName, 'message' => 'Please select a valid option.'];
+                break;
+            }
+            if ($value !== '') {
+                $data[$normalizedName] = $value;
+            }
+            break;
+        case 'checkbox':
+            if ($options) {
+                $raw = $_POST[$normalizedName] ?? [];
+                if (!is_array($raw)) {
+                    $raw = [$raw];
+                }
+                $selected = [];
+                foreach ($raw as $val) {
+                    $clean = sanitize_text((string) $val);
+                    if ($clean !== '' && in_array($clean, $options, true)) {
+                        $selected[] = $clean;
+                    }
+                }
+                if ($required && !$selected) {
+                    $errors[] = ['field' => $normalizedName, 'message' => 'Please choose at least one option.'];
+                    break;
+                }
+                if ($selected) {
+                    $data[$normalizedName] = $selected;
+                }
+            } else {
+                $checked = isset($_POST[$normalizedName]);
+                if ($required && !$checked) {
+                    $errors[] = ['field' => $normalizedName, 'message' => ($label ?: 'This checkbox') . ' must be checked.'];
+                    break;
+                }
+                if ($checked) {
+                    $data[$normalizedName] = 'Yes';
+                }
+            }
+            break;
+        case 'file':
+            $file = $_FILES[$normalizedName] ?? null;
+            if ($file && isset($file['error']) && $file['error'] !== UPLOAD_ERR_NO_FILE) {
+                if ($file['error'] !== UPLOAD_ERR_OK) {
+                    $errors[] = ['field' => $normalizedName, 'message' => 'Unable to upload file.'];
+                    break;
+                }
+                $originalName = (string) ($file['name'] ?? 'upload');
+                $ext = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
+                $baseName = preg_replace('/[^a-z0-9_\-]/i', '', pathinfo($originalName, PATHINFO_FILENAME));
+                if ($baseName === '') {
+                    $baseName = 'upload';
+                }
+                $filename = $baseName . '-' . bin2hex(random_bytes(8));
+                if ($ext) {
+                    $filename .= '.' . $ext;
+                }
+                $targetDir = __DIR__ . '/../CMS/uploads/forms';
+                $relativePath = 'uploads/forms/' . $filename;
+                $pendingFiles[] = [
+                    'tmp_name' => $file['tmp_name'],
+                    'target_dir' => $targetDir,
+                    'target_path' => $targetDir . '/' . $filename,
+                    'relative' => $relativePath,
+                    'name' => $normalizedName,
+                    'original' => $originalName,
+                    'size' => (int) ($file['size'] ?? 0),
+                    'type' => isset($file['type']) ? (string) $file['type'] : '',
+                ];
+            } elseif ($required) {
+                $errors[] = ['field' => $normalizedName, 'message' => 'Please upload a file.'];
+            }
+            break;
+        case 'email':
+            $value = isset($_POST[$normalizedName]) ? sanitize_text((string) $_POST[$normalizedName]) : '';
+            if ($required && $value === '') {
+                $errors[] = ['field' => $normalizedName, 'message' => 'Email address is required.'];
+                break;
+            }
+            if ($value !== '' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                $errors[] = ['field' => $normalizedName, 'message' => 'Please enter a valid email address.'];
+                break;
+            }
+            if ($value !== '') {
+                $data[$normalizedName] = $value;
+            }
+            break;
+        case 'textarea':
+        case 'text':
+        case 'password':
+        case 'number':
+        case 'date':
+        default:
+            $value = isset($_POST[$normalizedName]) ? sanitize_text((string) $_POST[$normalizedName]) : '';
+            if ($required && $value === '') {
+                $errors[] = ['field' => $normalizedName, 'message' => ($label ?: 'This field') . ' is required.'];
+                break;
+            }
+            if ($value !== '') {
+                $data[$normalizedName] = $value;
+            }
+            break;
+    }
+}
+
+if ($errors) {
+    http_response_code(422);
+    echo json_encode(['success' => false, 'errors' => $errors]);
+    return;
+}
+
+$filesMoved = [];
+if ($pendingFiles) {
+    foreach ($pendingFiles as $fileInfo) {
+        if (!is_dir($fileInfo['target_dir'])) {
+            if (!mkdir($fileInfo['target_dir'], 0775, true) && !is_dir($fileInfo['target_dir'])) {
+                $errors[] = ['field' => $fileInfo['name'], 'message' => 'Unable to store uploaded file.'];
+                continue;
+            }
+        }
+        if (!move_uploaded_file($fileInfo['tmp_name'], $fileInfo['target_path'])) {
+            $errors[] = ['field' => $fileInfo['name'], 'message' => 'Unable to store uploaded file.'];
+            continue;
+        }
+        $filesMoved[] = $fileInfo;
+        $data[$fileInfo['name']] = $fileInfo['relative'];
+        $fileMeta[$fileInfo['name']] = [
+            'original_name' => $fileInfo['original'],
+            'size' => $fileInfo['size'],
+            'type' => $fileInfo['type'],
+        ];
+    }
+    if ($errors) {
+        foreach ($filesMoved as $fileInfo) {
+            if (is_file($fileInfo['target_path'])) {
+                @unlink($fileInfo['target_path']);
+            }
+            unset($data[$fileInfo['name']]);
+            unset($fileMeta[$fileInfo['name']]);
+        }
+        http_response_code(500);
+        echo json_encode(['success' => false, 'errors' => $errors]);
+        return;
+    }
+}
+
+$meta = [
+    'ip' => isset($_SERVER['REMOTE_ADDR']) ? sanitize_text((string) $_SERVER['REMOTE_ADDR']) : null,
+    'user_agent' => isset($_SERVER['HTTP_USER_AGENT']) ? substr(sanitize_text((string) $_SERVER['HTTP_USER_AGENT']), 0, 255) : null,
+];
+
+$referer = isset($_SERVER['HTTP_REFERER']) ? sanitize_url((string) $_SERVER['HTTP_REFERER']) : '';
+if ($referer !== '') {
+    $meta['referer'] = $referer;
+}
+if ($fileMeta) {
+    $meta['files'] = $fileMeta;
+}
+
+$submission = [
+    'id' => bin2hex(random_bytes(8)),
+    'form_id' => $formId,
+    'data' => $data,
+    'meta' => array_filter($meta, static function ($value) {
+        return $value !== null && $value !== '' && $value !== [];
+    }),
+    'submitted_at' => date(DATE_ATOM),
+    'source' => $referer,
+];
+
+$submissionsFile = __DIR__ . '/../CMS/data/form_submissions.json';
+if (!file_exists($submissionsFile)) {
+    $dir = dirname($submissionsFile);
+    if (!is_dir($dir)) {
+        mkdir($dir, 0775, true);
+    }
+    file_put_contents($submissionsFile, '[]');
+}
+
+$handle = fopen($submissionsFile, 'c+');
+if ($handle === false) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'errors' => [['field' => null, 'message' => 'Unable to store submission.']]]);
+    return;
+}
+
+flock($handle, LOCK_EX);
+try {
+    rewind($handle);
+    $existing = stream_get_contents($handle);
+    $submissions = $existing ? json_decode($existing, true) : [];
+    if (!is_array($submissions)) {
+        $submissions = [];
+    }
+    $submissions[] = $submission;
+    $encoded = json_encode($submissions, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    if ($encoded === false) {
+        throw new RuntimeException('Encoding error');
+    }
+    ftruncate($handle, 0);
+    rewind($handle);
+    fwrite($handle, $encoded);
+} finally {
+    fflush($handle);
+    flock($handle, LOCK_UN);
+    fclose($handle);
+}
+
+echo json_encode(['success' => true]);

--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -9,6 +9,77 @@ let settingsContent;
 let savePageFn;
 let renderDebounce;
 
+const FORMS_SELECT_ATTR = 'data-forms-select';
+let cachedForms = null;
+let formsRequest = null;
+
+function getFormsEndpoint() {
+  const base = (window.builderBase || window.cmsBase || '').replace(/\/$/, '');
+  return (base || '') + '/CMS/modules/forms/list_forms.php';
+}
+
+function fetchFormsList() {
+  if (cachedForms) return Promise.resolve(cachedForms);
+  if (formsRequest) return formsRequest;
+  const endpoint = getFormsEndpoint();
+  formsRequest = fetch(endpoint, { credentials: 'same-origin' })
+    .then((response) => {
+      if (!response.ok) throw new Error('Failed to load forms');
+      return response.json();
+    })
+    .then((data) => {
+      cachedForms = Array.isArray(data) ? data : [];
+      return cachedForms;
+    })
+    .catch(() => {
+      cachedForms = [];
+      return cachedForms;
+    });
+  return formsRequest;
+}
+
+function populateFormsSelects(container, block) {
+  if (!container) return;
+  const selects = container.querySelectorAll(`select[${FORMS_SELECT_ATTR}]`);
+  if (!selects.length) return;
+
+  fetchFormsList().then((forms) => {
+    selects.forEach((select) => {
+      const placeholder = select.dataset.placeholder || 'Select a form...';
+      const storedValue = block ? getSetting(block, select.name) : select.value;
+      const fragment = document.createDocumentFragment();
+      const placeholderOption = document.createElement('option');
+      placeholderOption.value = '';
+      placeholderOption.textContent = placeholder;
+      fragment.appendChild(placeholderOption);
+
+      forms.forEach((form) => {
+        if (!form || typeof form !== 'object') return;
+        const option = document.createElement('option');
+        option.value = String(form.id ?? '');
+        option.textContent = form.name || `Form ${form.id}`;
+        fragment.appendChild(option);
+      });
+
+      const previousValue = select.value;
+      select.innerHTML = '';
+      select.appendChild(fragment);
+      const targetValue = storedValue || previousValue || '';
+      if (targetValue) {
+        select.value = targetValue;
+        if (select.value !== targetValue) {
+          // Ensure value is set even if the option list changed type
+          const manualOption = document.createElement('option');
+          manualOption.value = targetValue;
+          manualOption.textContent = targetValue;
+          select.appendChild(manualOption);
+          select.value = targetValue;
+        }
+      }
+    });
+  });
+}
+
 function scheduleRender(block) {
   clearTimeout(renderDebounce);
   renderDebounce = setTimeout(() => renderBlock(block), 100);
@@ -204,6 +275,7 @@ function getSettingsForm(template, block) {
 function initTemplateSettingValues(block) {
   const templateSetting = getTemplateSettingElement(block);
   if (!templateSetting || !settingsPanel) return;
+  populateFormsSelects(settingsPanel, block);
   // Prefill alt text suggestions for any alt inputs
   const altInputs = templateSetting.querySelectorAll('input[name^="custom_alt"]');
   altInputs.forEach((inp) => {

--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -1095,3 +1095,34 @@ section.container-fluid {
     border: 1px solid #dee2e6;
 }
 
+
+.spark-form-embed {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+}
+
+.spark-form-embed .spark-form-placeholder,
+.spark-form-embed .spark-form-loading,
+.spark-form-embed .spark-form-error {
+    padding: 1rem;
+    border: 1px dashed var(--border-color-dark, rgba(0, 0, 0, 0.1));
+    border-radius: 0.5rem;
+    background-color: var(--light, #f8f9fa);
+}
+
+.spark-form-embed .spark-form-error {
+    border-color: var(--danger, #dc3545);
+    background-color: rgba(220, 53, 69, 0.08);
+}
+
+.spark-form-embed .spark-choice-group .form-check {
+    margin-bottom: 0.5rem;
+}
+
+.spark-form-embed .spark-form-actions {
+    margin-top: 1rem;
+}
+
+.spark-form-status {
+    min-height: 1.5rem;
+}

--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -3,40 +3,489 @@
 
 /* File: script.js */
 // File: script.js
-document.addEventListener('DOMContentLoaded', function () {
-  var toggle = document.querySelector('.nav-toggle');
-  var nav = document.getElementById('main-nav');
-  if (toggle && nav) {
-    toggle.addEventListener('click', function () {
-      nav.classList.toggle('active');
+(function () {
+  var formCache = {};
+  var formRequests = {};
+
+  function basePath() {
+    var base = typeof window.cmsBase === 'string' ? window.cmsBase : '';
+    base = base.trim();
+    if (!base) return '';
+    if (base.charAt(0) !== '/') {
+      base = '/' + base;
+    }
+    return base.replace(/\/$/, '');
+  }
+
+  function fetchFormDefinition(id) {
+    var key = String(id);
+    if (formCache[key]) return Promise.resolve(formCache[key]);
+    if (formRequests[key]) return formRequests[key];
+    var prefix = basePath();
+    var url = (prefix || '') + '/forms/get.php?id=' + encodeURIComponent(id);
+    formRequests[key] = fetch(url, { credentials: 'same-origin' })
+      .then(function (response) {
+        if (!response.ok) throw new Error('Failed to load form');
+        return response.json();
+      })
+      .then(function (data) {
+        formCache[key] = data;
+        return data;
+      })
+      .catch(function (err) {
+        delete formRequests[key];
+        throw err;
+      });
+    return formRequests[key];
+  }
+
+  function escapeSelector(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+    return value.replace(/([\.\#\[\]:,])/g, '\\$1');
+  }
+
+  function prepareContainer(container) {
+    if (!container) return;
+    if (!container.dataset.successMessage) {
+      var successTemplate = container.querySelector('template[data-success-template]');
+      if (successTemplate) {
+        container.dataset.successMessage = successTemplate.textContent.trim();
+        successTemplate.remove();
+      } else {
+        container.dataset.successMessage = 'Thank you!';
+      }
+    }
+    if (!container.dataset.placeholderMessage) {
+      var placeholderEl = container.querySelector('.spark-form-placeholder');
+      if (placeholderEl) {
+        container.dataset.placeholderMessage = placeholderEl.textContent.trim();
+      } else if (container.dataset.placeholder) {
+        container.dataset.placeholderMessage = container.dataset.placeholder;
+      } else {
+        container.dataset.placeholderMessage = 'Select a form to display.';
+      }
+    }
+  }
+
+  function showPlaceholder(container, message) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    var placeholder = document.createElement('div');
+    placeholder.className = 'spark-form-placeholder text-muted';
+    placeholder.textContent = message || container.dataset.placeholderMessage || '';
+    container.appendChild(placeholder);
+    container.removeAttribute('data-rendered-form-id');
+  }
+
+  function showLoading(container) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    var loading = document.createElement('div');
+    loading.className = 'spark-form-loading text-muted';
+    loading.textContent = 'Loading form…';
+    container.appendChild(loading);
+  }
+
+  function showError(container, message) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    var error = document.createElement('div');
+    error.className = 'spark-form-error text-danger';
+    error.textContent = message || 'This form is currently unavailable.';
+    container.appendChild(error);
+    container.removeAttribute('data-rendered-form-id');
+  }
+
+  function buildField(field, index) {
+    var type = (field.type || 'text').toLowerCase();
+    var name = field.name || ('field_' + index);
+    var labelText = field.label || name;
+    var required = !!field.required;
+    var options = Array.isArray(field.options) ? field.options : [];
+    var fieldId = 'spark-form-' + name + '-' + index;
+    var wrapper = document.createElement('div');
+    wrapper.className = 'mb-3 spark-form-field';
+    wrapper.setAttribute('data-field-name', name);
+
+    if (type === 'submit') {
+      var submitBtn = document.createElement('button');
+      submitBtn.type = 'submit';
+      submitBtn.className = 'btn btn-primary';
+      submitBtn.textContent = labelText || 'Submit';
+      wrapper.classList.add('spark-form-actions');
+      wrapper.appendChild(submitBtn);
+      return wrapper;
+    }
+
+    function appendFeedback(target, blockDisplay) {
+      var feedback = document.createElement('div');
+      feedback.className = 'invalid-feedback' + (blockDisplay ? ' d-block' : '');
+      target.appendChild(feedback);
+      return feedback;
+    }
+
+    if (type === 'checkbox' && !options.length) {
+      var checkboxWrap = document.createElement('div');
+      checkboxWrap.className = 'form-check';
+      var checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'form-check-input';
+      checkbox.id = fieldId;
+      checkbox.name = name;
+      checkbox.value = '1';
+      if (required) checkbox.required = true;
+      var checkboxLabel = document.createElement('label');
+      checkboxLabel.className = 'form-check-label';
+      checkboxLabel.setAttribute('for', fieldId);
+      checkboxLabel.textContent = labelText + (required ? ' *' : '');
+      checkboxWrap.appendChild(checkbox);
+      checkboxWrap.appendChild(checkboxLabel);
+      wrapper.appendChild(checkboxWrap);
+      appendFeedback(wrapper, true);
+      return wrapper;
+    }
+
+    if ((type === 'checkbox' && options.length) || type === 'radio') {
+      var groupLabel = document.createElement('span');
+      groupLabel.className = 'form-label d-block';
+      groupLabel.textContent = labelText + (required ? ' *' : '');
+      wrapper.appendChild(groupLabel);
+      var choices = document.createElement('div');
+      choices.className = 'spark-choice-group';
+      options.forEach(function (option, optionIndex) {
+        var checkWrap = document.createElement('div');
+        checkWrap.className = 'form-check';
+        var input = document.createElement('input');
+        input.type = type;
+        input.className = 'form-check-input';
+        var optionName = type === 'checkbox' ? name + '[]' : name;
+        input.name = optionName;
+        var optionId = fieldId + '-' + optionIndex;
+        input.id = optionId;
+        input.value = option;
+        if (required) {
+          if (type === 'radio') {
+            input.required = true;
+          } else if (type === 'checkbox' && optionIndex === 0) {
+            input.required = true;
+          }
+        }
+        var optLabel = document.createElement('label');
+        optLabel.className = 'form-check-label';
+        optLabel.setAttribute('for', optionId);
+        optLabel.textContent = option;
+        checkWrap.appendChild(input);
+        checkWrap.appendChild(optLabel);
+        choices.appendChild(checkWrap);
+      });
+      wrapper.appendChild(choices);
+      appendFeedback(wrapper, true);
+      return wrapper;
+    }
+
+    var label = document.createElement('label');
+    label.className = 'form-label';
+    label.setAttribute('for', fieldId);
+    label.textContent = labelText + (required ? ' *' : '');
+    wrapper.appendChild(label);
+
+    if (type === 'textarea') {
+      var textarea = document.createElement('textarea');
+      textarea.className = 'form-control';
+      textarea.id = fieldId;
+      textarea.name = name;
+      textarea.rows = 4;
+      if (required) textarea.required = true;
+      wrapper.appendChild(textarea);
+      appendFeedback(wrapper);
+      return wrapper;
+    }
+
+    if (type === 'select') {
+      var select = document.createElement('select');
+      select.className = 'form-select';
+      select.id = fieldId;
+      select.name = name;
+      if (required) select.required = true;
+      var placeholderOption = document.createElement('option');
+      placeholderOption.value = '';
+      placeholderOption.textContent = 'Please select';
+      select.appendChild(placeholderOption);
+      options.forEach(function (option) {
+        var opt = document.createElement('option');
+        opt.value = option;
+        opt.textContent = option;
+        select.appendChild(opt);
+      });
+      wrapper.appendChild(select);
+      appendFeedback(wrapper);
+      return wrapper;
+    }
+
+    var input = document.createElement('input');
+    input.id = fieldId;
+    input.name = name;
+    if (required) input.required = true;
+    switch (type) {
+      case 'date':
+        input.type = 'date';
+        break;
+      case 'number':
+        input.type = 'number';
+        break;
+      case 'password':
+        input.type = 'password';
+        break;
+      case 'file':
+        input.type = 'file';
+        break;
+      case 'email':
+        input.type = 'email';
+        break;
+      default:
+        input.type = 'text';
+        break;
+    }
+    input.className = input.type === 'file' ? 'form-control' : 'form-control';
+    wrapper.appendChild(input);
+    appendFeedback(wrapper);
+    return wrapper;
+  }
+
+  function clearFieldErrors(formEl) {
+    formEl.querySelectorAll('.spark-form-field').forEach(function (wrapper) {
+      wrapper.classList.remove('has-error');
+      wrapper.querySelectorAll('.is-invalid').forEach(function (el) {
+        el.classList.remove('is-invalid');
+      });
+      var feedback = wrapper.querySelector('.invalid-feedback');
+      if (feedback) {
+        feedback.textContent = '';
+        feedback.style.display = '';
+      }
     });
   }
 
-  var accordions = document.querySelectorAll('.accordion');
-  accordions.forEach(function (acc) {
-    var btn = acc.querySelector('.accordion-button');
-    var panel = acc.querySelector('.accordion-panel');
-    if (!btn || !panel) return;
-
-    if (acc.classList.contains('open')) {
-      btn.setAttribute('aria-expanded', 'true');
-      panel.style.display = 'block';
-    } else {
-      btn.setAttribute('aria-expanded', 'false');
-      panel.style.display = 'none';
-    }
-
-    btn.addEventListener('click', function () {
-      if (acc.classList.contains('open')) {
-        acc.classList.remove('open');
-        btn.setAttribute('aria-expanded', 'false');
-        panel.style.display = 'none';
-      } else {
-        acc.classList.add('open');
-        btn.setAttribute('aria-expanded', 'true');
-        panel.style.display = 'block';
+  function applyFieldErrors(formEl, errors) {
+    if (!Array.isArray(errors)) return;
+    errors.forEach(function (error) {
+      if (!error || !error.field) return;
+      var selector = '[data-field-name="' + escapeSelector(error.field) + '"]';
+      var wrapper = formEl.querySelector(selector);
+      if (!wrapper) return;
+      wrapper.classList.add('has-error');
+      var inputs = wrapper.querySelectorAll('input, textarea, select');
+      inputs.forEach(function (input) {
+        input.classList.add('is-invalid');
+      });
+      var feedback = wrapper.querySelector('.invalid-feedback');
+      if (feedback) {
+        feedback.textContent = error.message || 'Please correct this field.';
+        feedback.style.display = 'block';
       }
     });
+  }
+
+  function attachSubmitHandler(formEl, statusEl, successMessage) {
+    if (!formEl) return;
+    formEl.addEventListener('submit', function (event) {
+      event.preventDefault();
+      if (formEl.dataset.submitting === 'true') return;
+      clearFieldErrors(formEl);
+      if (statusEl) {
+        statusEl.textContent = 'Submitting…';
+        statusEl.classList.remove('text-success', 'text-danger');
+      }
+      formEl.dataset.submitting = 'true';
+      var submitButtons = formEl.querySelectorAll('button[type="submit"], input[type="submit"]');
+      submitButtons.forEach(function (btn) {
+        btn.disabled = true;
+      });
+      var prefix = basePath();
+      var url = (prefix || '') + '/forms/submit.php';
+      var formData = new FormData(formEl);
+      fetch(url, {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin',
+      })
+        .then(function (response) {
+          return response.json().then(function (data) {
+            return { ok: response.ok, data: data };
+          });
+        })
+        .then(function (result) {
+          if (!result.ok || !result.data || result.data.success === false) {
+            var errors = result.data && result.data.errors ? result.data.errors : null;
+            applyFieldErrors(formEl, errors);
+            if (statusEl) {
+              statusEl.textContent = (result.data && result.data.message) || 'We were unable to submit the form.';
+              statusEl.classList.add('text-danger');
+            }
+            return;
+          }
+          formEl.reset();
+          if (statusEl) {
+            statusEl.textContent = successMessage || 'Thank you!';
+            statusEl.classList.add('text-success');
+          }
+        })
+        .catch(function () {
+          if (statusEl) {
+            statusEl.textContent = 'We were unable to submit the form.';
+            statusEl.classList.add('text-danger');
+          }
+        })
+        .finally(function () {
+          formEl.dataset.submitting = 'false';
+          submitButtons.forEach(function (btn) {
+            btn.disabled = false;
+          });
+        });
+    });
+  }
+
+  function renderSparkForm(container, form) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    if (!form || !Array.isArray(form.fields) || !form.fields.length) {
+      showError(container, 'This form has no fields yet.');
+      return;
+    }
+    var formEl = document.createElement('form');
+    formEl.className = 'spark-form needs-validation';
+    formEl.setAttribute('novalidate', 'novalidate');
+    formEl.setAttribute('enctype', 'multipart/form-data');
+    formEl.dataset.formId = form.id;
+
+    var hiddenId = document.createElement('input');
+    hiddenId.type = 'hidden';
+    hiddenId.name = 'form_id';
+    hiddenId.value = form.id;
+    formEl.appendChild(hiddenId);
+
+    form.fields.forEach(function (field, index) {
+      formEl.appendChild(buildField(field, index));
+    });
+
+    var status = document.createElement('div');
+    status.className = 'spark-form-status mt-3';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+
+    container.appendChild(formEl);
+    container.appendChild(status);
+
+    var successMessage = container.dataset.successMessage || 'Thank you!';
+    attachSubmitHandler(formEl, status, successMessage);
+  }
+
+  function initializeSparkForms() {
+    var containers = document.querySelectorAll('.spark-form-embed[data-form-id]');
+    containers.forEach(function (container) {
+      if (!container) return;
+      prepareContainer(container);
+      var rawId = container.getAttribute('data-form-id') || '';
+      var formId = parseInt(rawId, 10);
+      if (!formId) {
+        showPlaceholder(container, container.dataset.placeholderMessage || 'Select a form to display.');
+        return;
+      }
+      var renderedId = parseInt(container.getAttribute('data-rendered-form-id') || '0', 10);
+      if (renderedId === formId && container.querySelector('form.spark-form')) {
+        return;
+      }
+      showLoading(container);
+      var token = Date.now().toString(36) + Math.random().toString(36).slice(2);
+      container.setAttribute('data-render-token', token);
+      fetchFormDefinition(formId)
+        .then(function (form) {
+          if (container.getAttribute('data-render-token') !== token) return;
+          renderSparkForm(container, form);
+          container.setAttribute('data-rendered-form-id', String(formId));
+          container.removeAttribute('data-render-token');
+        })
+        .catch(function () {
+          if (container.getAttribute('data-render-token') !== token) return;
+          showError(container, 'We were unable to load this form.');
+          container.removeAttribute('data-render-token');
+        });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.querySelector('.nav-toggle');
+    var nav = document.getElementById('main-nav');
+    if (toggle && nav) {
+      toggle.addEventListener('click', function () {
+        nav.classList.toggle('active');
+      });
+    }
+
+    var accordions = document.querySelectorAll('.accordion');
+    accordions.forEach(function (acc) {
+      var btn = acc.querySelector('.accordion-button');
+      var panel = acc.querySelector('.accordion-panel');
+      if (!btn || !panel) return;
+
+      if (acc.classList.contains('open')) {
+        btn.setAttribute('aria-expanded', 'true');
+        panel.style.display = 'block';
+      } else {
+        btn.setAttribute('aria-expanded', 'false');
+        panel.style.display = 'none';
+      }
+
+      btn.addEventListener('click', function () {
+        if (acc.classList.contains('open')) {
+          acc.classList.remove('open');
+          btn.setAttribute('aria-expanded', 'false');
+          panel.style.display = 'none';
+        } else {
+          acc.classList.add('open');
+          btn.setAttribute('aria-expanded', 'true');
+          panel.style.display = 'block';
+        }
+      });
+    });
+
+    initializeSparkForms();
+    document.addEventListener('canvasUpdated', initializeSparkForms);
+
+    if (window.MutationObserver) {
+      var observer = new MutationObserver(function (mutations) {
+        var needsRefresh = false;
+        mutations.forEach(function (mutation) {
+          if (mutation.type === 'attributes' && mutation.attributeName === 'data-form-id') {
+            var target = mutation.target;
+            if (target && target.classList && target.classList.contains('spark-form-embed')) {
+              needsRefresh = true;
+            }
+          }
+          if (mutation.type === 'childList') {
+            mutation.addedNodes.forEach(function (node) {
+              if (node.nodeType !== 1) return;
+              if (node.classList && node.classList.contains('spark-form-embed')) {
+                needsRefresh = true;
+              } else if (node.querySelector && node.querySelector('.spark-form-embed')) {
+                needsRefresh = true;
+              }
+            });
+          }
+        });
+        if (needsRefresh) {
+          initializeSparkForms();
+        }
+      });
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['data-form-id'],
+      });
+    }
   });
-});
+})();
 

--- a/theme/js/script.js
+++ b/theme/js/script.js
@@ -1,37 +1,486 @@
 // File: script.js
-document.addEventListener('DOMContentLoaded', function () {
-  var toggle = document.querySelector('.nav-toggle');
-  var nav = document.getElementById('main-nav');
-  if (toggle && nav) {
-    toggle.addEventListener('click', function () {
-      nav.classList.toggle('active');
+(function () {
+  var formCache = {};
+  var formRequests = {};
+
+  function basePath() {
+    var base = typeof window.cmsBase === 'string' ? window.cmsBase : '';
+    base = base.trim();
+    if (!base) return '';
+    if (base.charAt(0) !== '/') {
+      base = '/' + base;
+    }
+    return base.replace(/\/$/, '');
+  }
+
+  function fetchFormDefinition(id) {
+    var key = String(id);
+    if (formCache[key]) return Promise.resolve(formCache[key]);
+    if (formRequests[key]) return formRequests[key];
+    var prefix = basePath();
+    var url = (prefix || '') + '/forms/get.php?id=' + encodeURIComponent(id);
+    formRequests[key] = fetch(url, { credentials: 'same-origin' })
+      .then(function (response) {
+        if (!response.ok) throw new Error('Failed to load form');
+        return response.json();
+      })
+      .then(function (data) {
+        formCache[key] = data;
+        return data;
+      })
+      .catch(function (err) {
+        delete formRequests[key];
+        throw err;
+      });
+    return formRequests[key];
+  }
+
+  function escapeSelector(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+    return value.replace(/([\.\#\[\]:,])/g, '\\$1');
+  }
+
+  function prepareContainer(container) {
+    if (!container) return;
+    if (!container.dataset.successMessage) {
+      var successTemplate = container.querySelector('template[data-success-template]');
+      if (successTemplate) {
+        container.dataset.successMessage = successTemplate.textContent.trim();
+        successTemplate.remove();
+      } else {
+        container.dataset.successMessage = 'Thank you!';
+      }
+    }
+    if (!container.dataset.placeholderMessage) {
+      var placeholderEl = container.querySelector('.spark-form-placeholder');
+      if (placeholderEl) {
+        container.dataset.placeholderMessage = placeholderEl.textContent.trim();
+      } else if (container.dataset.placeholder) {
+        container.dataset.placeholderMessage = container.dataset.placeholder;
+      } else {
+        container.dataset.placeholderMessage = 'Select a form to display.';
+      }
+    }
+  }
+
+  function showPlaceholder(container, message) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    var placeholder = document.createElement('div');
+    placeholder.className = 'spark-form-placeholder text-muted';
+    placeholder.textContent = message || container.dataset.placeholderMessage || '';
+    container.appendChild(placeholder);
+    container.removeAttribute('data-rendered-form-id');
+  }
+
+  function showLoading(container) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    var loading = document.createElement('div');
+    loading.className = 'spark-form-loading text-muted';
+    loading.textContent = 'Loading form…';
+    container.appendChild(loading);
+  }
+
+  function showError(container, message) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    var error = document.createElement('div');
+    error.className = 'spark-form-error text-danger';
+    error.textContent = message || 'This form is currently unavailable.';
+    container.appendChild(error);
+    container.removeAttribute('data-rendered-form-id');
+  }
+
+  function buildField(field, index) {
+    var type = (field.type || 'text').toLowerCase();
+    var name = field.name || ('field_' + index);
+    var labelText = field.label || name;
+    var required = !!field.required;
+    var options = Array.isArray(field.options) ? field.options : [];
+    var fieldId = 'spark-form-' + name + '-' + index;
+    var wrapper = document.createElement('div');
+    wrapper.className = 'mb-3 spark-form-field';
+    wrapper.setAttribute('data-field-name', name);
+
+    if (type === 'submit') {
+      var submitBtn = document.createElement('button');
+      submitBtn.type = 'submit';
+      submitBtn.className = 'btn btn-primary';
+      submitBtn.textContent = labelText || 'Submit';
+      wrapper.classList.add('spark-form-actions');
+      wrapper.appendChild(submitBtn);
+      return wrapper;
+    }
+
+    function appendFeedback(target, blockDisplay) {
+      var feedback = document.createElement('div');
+      feedback.className = 'invalid-feedback' + (blockDisplay ? ' d-block' : '');
+      target.appendChild(feedback);
+      return feedback;
+    }
+
+    if (type === 'checkbox' && !options.length) {
+      var checkboxWrap = document.createElement('div');
+      checkboxWrap.className = 'form-check';
+      var checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.className = 'form-check-input';
+      checkbox.id = fieldId;
+      checkbox.name = name;
+      checkbox.value = '1';
+      if (required) checkbox.required = true;
+      var checkboxLabel = document.createElement('label');
+      checkboxLabel.className = 'form-check-label';
+      checkboxLabel.setAttribute('for', fieldId);
+      checkboxLabel.textContent = labelText + (required ? ' *' : '');
+      checkboxWrap.appendChild(checkbox);
+      checkboxWrap.appendChild(checkboxLabel);
+      wrapper.appendChild(checkboxWrap);
+      appendFeedback(wrapper, true);
+      return wrapper;
+    }
+
+    if ((type === 'checkbox' && options.length) || type === 'radio') {
+      var groupLabel = document.createElement('span');
+      groupLabel.className = 'form-label d-block';
+      groupLabel.textContent = labelText + (required ? ' *' : '');
+      wrapper.appendChild(groupLabel);
+      var choices = document.createElement('div');
+      choices.className = 'spark-choice-group';
+      options.forEach(function (option, optionIndex) {
+        var checkWrap = document.createElement('div');
+        checkWrap.className = 'form-check';
+        var input = document.createElement('input');
+        input.type = type;
+        input.className = 'form-check-input';
+        var optionName = type === 'checkbox' ? name + '[]' : name;
+        input.name = optionName;
+        var optionId = fieldId + '-' + optionIndex;
+        input.id = optionId;
+        input.value = option;
+        if (required) {
+          if (type === 'radio') {
+            input.required = true;
+          } else if (type === 'checkbox' && optionIndex === 0) {
+            input.required = true;
+          }
+        }
+        var optLabel = document.createElement('label');
+        optLabel.className = 'form-check-label';
+        optLabel.setAttribute('for', optionId);
+        optLabel.textContent = option;
+        checkWrap.appendChild(input);
+        checkWrap.appendChild(optLabel);
+        choices.appendChild(checkWrap);
+      });
+      wrapper.appendChild(choices);
+      appendFeedback(wrapper, true);
+      return wrapper;
+    }
+
+    var label = document.createElement('label');
+    label.className = 'form-label';
+    label.setAttribute('for', fieldId);
+    label.textContent = labelText + (required ? ' *' : '');
+    wrapper.appendChild(label);
+
+    if (type === 'textarea') {
+      var textarea = document.createElement('textarea');
+      textarea.className = 'form-control';
+      textarea.id = fieldId;
+      textarea.name = name;
+      textarea.rows = 4;
+      if (required) textarea.required = true;
+      wrapper.appendChild(textarea);
+      appendFeedback(wrapper);
+      return wrapper;
+    }
+
+    if (type === 'select') {
+      var select = document.createElement('select');
+      select.className = 'form-select';
+      select.id = fieldId;
+      select.name = name;
+      if (required) select.required = true;
+      var placeholderOption = document.createElement('option');
+      placeholderOption.value = '';
+      placeholderOption.textContent = 'Please select';
+      select.appendChild(placeholderOption);
+      options.forEach(function (option) {
+        var opt = document.createElement('option');
+        opt.value = option;
+        opt.textContent = option;
+        select.appendChild(opt);
+      });
+      wrapper.appendChild(select);
+      appendFeedback(wrapper);
+      return wrapper;
+    }
+
+    var input = document.createElement('input');
+    input.id = fieldId;
+    input.name = name;
+    if (required) input.required = true;
+    switch (type) {
+      case 'date':
+        input.type = 'date';
+        break;
+      case 'number':
+        input.type = 'number';
+        break;
+      case 'password':
+        input.type = 'password';
+        break;
+      case 'file':
+        input.type = 'file';
+        break;
+      case 'email':
+        input.type = 'email';
+        break;
+      default:
+        input.type = 'text';
+        break;
+    }
+    input.className = input.type === 'file' ? 'form-control' : 'form-control';
+    wrapper.appendChild(input);
+    appendFeedback(wrapper);
+    return wrapper;
+  }
+
+  function clearFieldErrors(formEl) {
+    formEl.querySelectorAll('.spark-form-field').forEach(function (wrapper) {
+      wrapper.classList.remove('has-error');
+      wrapper.querySelectorAll('.is-invalid').forEach(function (el) {
+        el.classList.remove('is-invalid');
+      });
+      var feedback = wrapper.querySelector('.invalid-feedback');
+      if (feedback) {
+        feedback.textContent = '';
+        feedback.style.display = '';
+      }
     });
   }
 
-  var accordions = document.querySelectorAll('.accordion');
-  accordions.forEach(function (acc) {
-    var btn = acc.querySelector('.accordion-button');
-    var panel = acc.querySelector('.accordion-panel');
-    if (!btn || !panel) return;
-
-    if (acc.classList.contains('open')) {
-      btn.setAttribute('aria-expanded', 'true');
-      panel.style.display = 'block';
-    } else {
-      btn.setAttribute('aria-expanded', 'false');
-      panel.style.display = 'none';
-    }
-
-    btn.addEventListener('click', function () {
-      if (acc.classList.contains('open')) {
-        acc.classList.remove('open');
-        btn.setAttribute('aria-expanded', 'false');
-        panel.style.display = 'none';
-      } else {
-        acc.classList.add('open');
-        btn.setAttribute('aria-expanded', 'true');
-        panel.style.display = 'block';
+  function applyFieldErrors(formEl, errors) {
+    if (!Array.isArray(errors)) return;
+    errors.forEach(function (error) {
+      if (!error || !error.field) return;
+      var selector = '[data-field-name="' + escapeSelector(error.field) + '"]';
+      var wrapper = formEl.querySelector(selector);
+      if (!wrapper) return;
+      wrapper.classList.add('has-error');
+      var inputs = wrapper.querySelectorAll('input, textarea, select');
+      inputs.forEach(function (input) {
+        input.classList.add('is-invalid');
+      });
+      var feedback = wrapper.querySelector('.invalid-feedback');
+      if (feedback) {
+        feedback.textContent = error.message || 'Please correct this field.';
+        feedback.style.display = 'block';
       }
     });
+  }
+
+  function attachSubmitHandler(formEl, statusEl, successMessage) {
+    if (!formEl) return;
+    formEl.addEventListener('submit', function (event) {
+      event.preventDefault();
+      if (formEl.dataset.submitting === 'true') return;
+      clearFieldErrors(formEl);
+      if (statusEl) {
+        statusEl.textContent = 'Submitting…';
+        statusEl.classList.remove('text-success', 'text-danger');
+      }
+      formEl.dataset.submitting = 'true';
+      var submitButtons = formEl.querySelectorAll('button[type="submit"], input[type="submit"]');
+      submitButtons.forEach(function (btn) {
+        btn.disabled = true;
+      });
+      var prefix = basePath();
+      var url = (prefix || '') + '/forms/submit.php';
+      var formData = new FormData(formEl);
+      fetch(url, {
+        method: 'POST',
+        body: formData,
+        credentials: 'same-origin',
+      })
+        .then(function (response) {
+          return response.json().then(function (data) {
+            return { ok: response.ok, data: data };
+          });
+        })
+        .then(function (result) {
+          if (!result.ok || !result.data || result.data.success === false) {
+            var errors = result.data && result.data.errors ? result.data.errors : null;
+            applyFieldErrors(formEl, errors);
+            if (statusEl) {
+              statusEl.textContent = (result.data && result.data.message) || 'We were unable to submit the form.';
+              statusEl.classList.add('text-danger');
+            }
+            return;
+          }
+          formEl.reset();
+          if (statusEl) {
+            statusEl.textContent = successMessage || 'Thank you!';
+            statusEl.classList.add('text-success');
+          }
+        })
+        .catch(function () {
+          if (statusEl) {
+            statusEl.textContent = 'We were unable to submit the form.';
+            statusEl.classList.add('text-danger');
+          }
+        })
+        .finally(function () {
+          formEl.dataset.submitting = 'false';
+          submitButtons.forEach(function (btn) {
+            btn.disabled = false;
+          });
+        });
+    });
+  }
+
+  function renderSparkForm(container, form) {
+    prepareContainer(container);
+    container.innerHTML = '';
+    if (!form || !Array.isArray(form.fields) || !form.fields.length) {
+      showError(container, 'This form has no fields yet.');
+      return;
+    }
+    var formEl = document.createElement('form');
+    formEl.className = 'spark-form needs-validation';
+    formEl.setAttribute('novalidate', 'novalidate');
+    formEl.setAttribute('enctype', 'multipart/form-data');
+    formEl.dataset.formId = form.id;
+
+    var hiddenId = document.createElement('input');
+    hiddenId.type = 'hidden';
+    hiddenId.name = 'form_id';
+    hiddenId.value = form.id;
+    formEl.appendChild(hiddenId);
+
+    form.fields.forEach(function (field, index) {
+      formEl.appendChild(buildField(field, index));
+    });
+
+    var status = document.createElement('div');
+    status.className = 'spark-form-status mt-3';
+    status.setAttribute('role', 'status');
+    status.setAttribute('aria-live', 'polite');
+
+    container.appendChild(formEl);
+    container.appendChild(status);
+
+    var successMessage = container.dataset.successMessage || 'Thank you!';
+    attachSubmitHandler(formEl, status, successMessage);
+  }
+
+  function initializeSparkForms() {
+    var containers = document.querySelectorAll('.spark-form-embed[data-form-id]');
+    containers.forEach(function (container) {
+      if (!container) return;
+      prepareContainer(container);
+      var rawId = container.getAttribute('data-form-id') || '';
+      var formId = parseInt(rawId, 10);
+      if (!formId) {
+        showPlaceholder(container, container.dataset.placeholderMessage || 'Select a form to display.');
+        return;
+      }
+      var renderedId = parseInt(container.getAttribute('data-rendered-form-id') || '0', 10);
+      if (renderedId === formId && container.querySelector('form.spark-form')) {
+        return;
+      }
+      showLoading(container);
+      var token = Date.now().toString(36) + Math.random().toString(36).slice(2);
+      container.setAttribute('data-render-token', token);
+      fetchFormDefinition(formId)
+        .then(function (form) {
+          if (container.getAttribute('data-render-token') !== token) return;
+          renderSparkForm(container, form);
+          container.setAttribute('data-rendered-form-id', String(formId));
+          container.removeAttribute('data-render-token');
+        })
+        .catch(function () {
+          if (container.getAttribute('data-render-token') !== token) return;
+          showError(container, 'We were unable to load this form.');
+          container.removeAttribute('data-render-token');
+        });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.querySelector('.nav-toggle');
+    var nav = document.getElementById('main-nav');
+    if (toggle && nav) {
+      toggle.addEventListener('click', function () {
+        nav.classList.toggle('active');
+      });
+    }
+
+    var accordions = document.querySelectorAll('.accordion');
+    accordions.forEach(function (acc) {
+      var btn = acc.querySelector('.accordion-button');
+      var panel = acc.querySelector('.accordion-panel');
+      if (!btn || !panel) return;
+
+      if (acc.classList.contains('open')) {
+        btn.setAttribute('aria-expanded', 'true');
+        panel.style.display = 'block';
+      } else {
+        btn.setAttribute('aria-expanded', 'false');
+        panel.style.display = 'none';
+      }
+
+      btn.addEventListener('click', function () {
+        if (acc.classList.contains('open')) {
+          acc.classList.remove('open');
+          btn.setAttribute('aria-expanded', 'false');
+          panel.style.display = 'none';
+        } else {
+          acc.classList.add('open');
+          btn.setAttribute('aria-expanded', 'true');
+          panel.style.display = 'block';
+        }
+      });
+    });
+
+    initializeSparkForms();
+    document.addEventListener('canvasUpdated', initializeSparkForms);
+
+    if (window.MutationObserver) {
+      var observer = new MutationObserver(function (mutations) {
+        var needsRefresh = false;
+        mutations.forEach(function (mutation) {
+          if (mutation.type === 'attributes' && mutation.attributeName === 'data-form-id') {
+            var target = mutation.target;
+            if (target && target.classList && target.classList.contains('spark-form-embed')) {
+              needsRefresh = true;
+            }
+          }
+          if (mutation.type === 'childList') {
+            mutation.addedNodes.forEach(function (node) {
+              if (node.nodeType !== 1) return;
+              if (node.classList && node.classList.contains('spark-form-embed')) {
+                needsRefresh = true;
+              } else if (node.querySelector && node.querySelector('.spark-form-embed')) {
+                needsRefresh = true;
+              }
+            });
+          }
+        });
+        if (needsRefresh) {
+          initializeSparkForms();
+        }
+      });
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['data-form-id'],
+      });
+    }
   });
-});
+})();

--- a/theme/templates/blocks/interactive.form.php
+++ b/theme/templates/blocks/interactive.form.php
@@ -1,0 +1,23 @@
+<!-- File: interactive.form.php -->
+<!-- Template: interactive.form -->
+<templateSetting caption="Form Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Select Form</dt>
+        <dd>
+            <select name="custom_form_id" class="form-select" data-forms-select data-placeholder="Select a form...">
+                <option value="">Select a form...</option>
+            </select>
+            <p class="mt-2 small text-muted">Manage forms from the Forms tab in the CMS.</p>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Success Message</dt>
+        <dd>
+            <input type="text" name="custom_success_message" value="Thank you! We'll be in touch soon." />
+        </dd>
+    </dl>
+</templateSetting>
+<div class="spark-form-embed" data-form-id="{custom_form_id}">
+    <template data-success-template>{custom_success_message}</template>
+    <div class="spark-form-placeholder">Select a form to display.</div>
+</div>


### PR DESCRIPTION
## Summary
- add a reusable interactive form block that lets editors drop configured forms into pages and customize the success message
- populate the block settings with available forms and reuse them on the front-end via a new fetch-and-render workflow with submission handling
- expose public endpoints for retrieving form definitions and storing submissions, plus light styling to match the theme

## Testing
- php -l forms/get.php
- php -l forms/submit.php

------
https://chatgpt.com/codex/tasks/task_e_68d725faaaa083319d4b1f51570a18b9