### PR TITLE
Restyle forms dashboard to match accessibility UI

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -1,12 +1,22 @@
 // File: forms.js
 $(function(){
-    function escapeHtml(str){ return $('<div>').text(str).html(); }
+    function escapeHtml(str){
+        return $('<div>').text(str).html();
+    }
 
     let currentField = null;
     let currentFormId = null;
+    let hasLoadedInitialForm = false;
+    let formsData = [];
+    let activeFilter = 'all';
+    let searchQuery = '';
+    const formsMeta = window.formsFormMeta || {};
+    let formsFilterCounts = window.formsFilterCounts || {};
+    const formsDashboardStats = window.formsDashboardStats || {};
 
     function resetSubmissionsCard(message){
         currentFormId = null;
+        hasLoadedInitialForm = false;
         const text = message || 'Select a form to view submissions';
         const rowMessage = /[.!?]$/.test(text) ? text : text + '.';
         $('#formsTable tbody tr').removeClass('selected');
@@ -42,136 +52,309 @@ $(function(){
         return String(value);
     }
 
-    function loadFormSubmissions(formId, formName){
-        currentFormId = formId;
-        $('#formsTable tbody tr').removeClass('selected');
-        $('#formsTable tbody tr').filter(function(){ return $(this).data('id') == formId; }).addClass('selected');
-        $('#selectedFormName').text(formName);
-        const tbody = $('#formSubmissionsTable tbody').empty();
-        tbody.append('<tr class="loading-row"><td colspan="2">Loading submissions...</td></tr>');
-        $.getJSON('modules/forms/list_submissions.php', { form_id: formId }, function(data){
-            tbody.empty();
-            const submissions = Array.isArray(data) ? data : [];
-            if(!submissions.length){
-                tbody.append('<tr class="empty-row"><td colspan="2">No submissions yet.</td></tr>');
-                return;
-            }
-            submissions.forEach(function(submission){
-                const submittedAt = formatSubmissionDate(submission.submitted_at || submission.created_at || submission.timestamp);
-                const fields = submission.data && typeof submission.data === 'object' ? submission.data : {};
-                const meta = submission.meta && typeof submission.meta === 'object' ? Object.assign({}, submission.meta) : {};
-                if(submission.source && !meta.source){
-                    meta.source = submission.source;
-                }
-                if(submission.id && !meta.id){
-                    meta.id = submission.id;
-                }
-                const fieldKeys = Object.keys(fields).sort();
-                const metaKeys = Object.keys(meta).sort();
-                const details = [];
-                fieldKeys.forEach(function(key){
-                    const value = normalizeSubmissionValue(fields[key]);
-                    details.push('<div class="submission-detail"><div class="submission-label">'+escapeHtml(key)+'</div><div class="submission-value">'+escapeHtml(value)+'</div></div>');
-                });
-                if(metaKeys.length){
-                    details.push('<div class="submission-meta-group"><div class="submission-meta-title">Metadata</div>');
-                    metaKeys.forEach(function(key){
-                        const value = normalizeSubmissionValue(meta[key]);
-                        details.push('<div class="submission-detail"><div class="submission-label">'+escapeHtml(key)+'</div><div class="submission-value">'+escapeHtml(value)+'</div></div>');
-                    });
-                    details.push('</div>');
-                }
-                if(!details.length){
-                    details.push('<div class="submission-detail"><div class="submission-label">Details</div><div class="submission-value"><em>No submission data provided.</em></div></div>');
-                }
-                tbody.append('<tr><td class="submitted">'+escapeHtml(submittedAt)+'</td><td class="details">'+details.join('')+'</td></tr>');
-            });
-        }).fail(function(){
-            tbody.empty().append('<tr class="error-row"><td colspan="2">Unable to load submissions.</td></tr>');
+    function determineStatus(meta){
+        if((meta.submissions || 0) > 0){
+            return 'collecting';
+        }
+        if((meta.fields || 0) > 0){
+            return 'ready';
+        }
+        return 'draft';
+    }
+
+    function syncFormMeta(form){
+        if(!form || typeof form !== 'object') return null;
+        const key = String(form.id || '');
+        if(!key) return null;
+        const meta = formsMeta[key] || {};
+        const fieldsCount = Array.isArray(form.fields) ? form.fields.length : 0;
+        meta.fields = fieldsCount;
+        if(typeof meta.submissions !== 'number'){
+            meta.submissions = 0;
+        }
+        if(form.name){
+            meta.name = form.name;
+        } else if(!meta.name){
+            meta.name = 'Untitled form';
+        }
+        if(!meta.lastSubmission){
+            meta.lastSubmission = null;
+        }
+        meta.status = determineStatus(meta);
+        formsMeta[key] = meta;
+        return meta;
+    }
+
+    function formatStatusLabel(status){
+        switch(status){
+            case 'collecting':
+                return 'Collecting responses';
+            case 'ready':
+                return 'Ready to publish';
+            default:
+                return 'Draft';
+        }
+    }
+
+    function matchesFilter(meta){
+        const status = meta.status || determineStatus(meta);
+        switch(activeFilter){
+            case 'collecting':
+                return status === 'collecting';
+            case 'ready':
+                return status === 'ready';
+            case 'draft':
+                return status === 'draft';
+            default:
+                return true;
+        }
+    }
+
+    function matchesSearch(form, meta){
+        if(!searchQuery) return true;
+        const haystack = [
+            form.name || '',
+            formatStatusLabel(meta.status || ''),
+            String(meta.submissions || ''),
+            String(meta.fields || '')
+        ].join(' ').toLowerCase();
+        return haystack.includes(searchQuery);
+    }
+
+    function updateFilterCountsDisplay(){
+        $('[data-forms-count]').each(function(){
+            const key = $(this).data('forms-count');
+            const value = formsFilterCounts && Object.prototype.hasOwnProperty.call(formsFilterCounts, key) ? formsFilterCounts[key] : 0;
+            $(this).text(value);
         });
     }
 
-    function updatePreview($li){
-        const type = $li.data('type');
-        const label = $li.find('.field-label').val() || '';
-        const name = $li.find('.field-name').val() || '';
-        const required = $li.find('.field-required').is(':checked') ? ' required' : '';
-        const options = $li.find('.field-options-input').val() || '';
-        let html = '';
-        switch(type){
-            case 'textarea':
-                html = '<div class="form-group"><label>'+label+'</label><textarea name="'+name+'"'+required+'></textarea></div>'; break;
-            case 'select':
-                const opts = options.split(',').map(o=>o.trim()).filter(Boolean);
-                html = '<div class="form-group"><label>'+label+'</label><select name="'+name+'"'+required+'>'+opts.map(o=>'<option>'+o+'</option>').join('')+'</select></div>'; break;
-            case 'checkbox':
-            case 'radio':
-                const optList = options.split(',').map(o=>o.trim()).filter(Boolean);
-                if(optList.length){
-                    html = '<div class="form-group"><label>'+label+'</label><div>';
-                    optList.forEach(o=>{ html += '<label><input type="'+type+'" name="'+name+'" value="'+o+'"> '+o+'</label> '; });
-                    html += '</div></div>';
-                } else {
-                    html = '<div class="form-group"><label><input type="'+type+'" name="'+name+'"'+required+'> '+label+'</label></div>';
-                }
-                break;
-            case 'submit':
-                html = '<div class="form-group"><button type="submit">'+(label||'Submit')+'</button></div>'; break;
-            default:
-                const inputType = type === 'date' ? 'date' : type;
-                html = '<div class="form-group"><label>'+label+'</label><input type="'+inputType+'" name="'+name+'"'+required+'></div>'; break;
-        }
-        $li.find('.field-preview').html(html);
+    function recalcFilterCounts(){
+        const counts = { all: formsData.length, collecting: 0, ready: 0, draft: 0 };
+        formsData.forEach(function(form){
+            const meta = syncFormMeta(form);
+            if(!meta) return;
+            meta.status = determineStatus(meta);
+            if(meta.status === 'collecting') counts.collecting++;
+            if(meta.status === 'ready') counts.ready++;
+            if(meta.status === 'draft') counts.draft++;
+        });
+        formsFilterCounts = counts;
+        window.formsFilterCounts = counts;
+        updateFilterCountsDisplay();
     }
 
-    function selectField($li){
-        if(currentField && currentField[0] === ($li && $li[0])) return;
-        if(currentField){
-            currentField.append($('#fieldSettings .field-body').hide());
-            currentField.removeClass('selected');
+    function updateOverviewStats(){
+        const totalForms = formsData.length;
+        let totalResponses = 0;
+        let activeForms = 0;
+        let totalFields = 0;
+        let latestIso = formsDashboardStats.lastSubmissionIso || null;
+
+        formsData.forEach(function(form){
+            const meta = syncFormMeta(form);
+            if(!meta) return;
+            const submissions = meta.submissions || 0;
+            totalResponses += submissions;
+            if(submissions > 0) activeForms++;
+            totalFields += meta.fields || 0;
+            if(meta.lastSubmission){
+                const ts = Date.parse(meta.lastSubmission);
+                if(!Number.isNaN(ts)){
+                    if(!latestIso || ts > Date.parse(latestIso)){
+                        latestIso = meta.lastSubmission;
+                    }
+                }
+            }
+        });
+
+        const avgFields = totalForms ? totalFields / totalForms : 0;
+        const roundedAvg = avgFields ? Math.round(avgFields * 10) / 10 : 0;
+        $('#formsStatTotal').text(totalForms);
+        $('#formsStatResponses').text(totalResponses);
+        $('#formsStatActive').text(activeForms);
+        $('#formsStatFields').text(roundedAvg % 1 === 0 ? roundedAvg.toFixed(0) : roundedAvg.toFixed(1));
+
+        const $meta = $('#formsLastSubmissionMeta');
+        if($meta.length){
+            const label = latestIso ? 'Last submission: ' + formatSubmissionDate(latestIso) : 'Last submission: None yet';
+            $meta.html('<i class="fas fa-clock" aria-hidden="true"></i> '+escapeHtml(label));
         }
-        currentField = $li;
-        $('#fieldSettings').empty();
-        if($li){
-            currentField.addClass('selected');
-            $('#fieldSettings').append(currentField.find('.field-body').show());
+
+        formsDashboardStats.totalForms = totalForms;
+        formsDashboardStats.totalSubmissions = totalResponses;
+        formsDashboardStats.activeForms = activeForms;
+        formsDashboardStats.avgFields = roundedAvg;
+        formsDashboardStats.lastSubmissionIso = latestIso;
+        formsDashboardStats.lastSubmission = latestIso ? formatSubmissionDate(latestIso) : 'No submissions yet';
+    }
+
+    function renderFormsTable(){
+        const tbody = $('#formsTable tbody').empty();
+        let rendered = 0;
+
+        formsData.forEach(function(form){
+            const meta = syncFormMeta(form);
+            if(!meta) return;
+            meta.status = determineStatus(meta);
+            if(!matchesFilter(meta) || !matchesSearch(form, meta)){
+                return;
+            }
+
+            const row = $('<tr></tr>')
+                .attr('data-id', form.id)
+                .attr('data-status', meta.status)
+                .attr('data-fields', meta.fields || 0)
+                .attr('data-submissions', meta.submissions || 0)
+                .attr('data-name', form.name || '')
+                .data('id', form.id)
+                .data('name', form.name || '')
+                .data('status', meta.status)
+                .data('fields', meta.fields || 0)
+                .data('submissions', meta.submissions || 0);
+
+            if(currentFormId && Number(form.id) === Number(currentFormId)){
+                row.addClass('selected');
+            }
+
+            const nameCell = $('<td class="name"></td>');
+            nameCell.append('<div class="forms-table-name">'+escapeHtml(form.name || 'Untitled form')+'</div>');
+            nameCell.append('<span class="forms-table-status status-'+meta.status+'">'+escapeHtml(formatStatusLabel(meta.status))+'</span>');
+
+            const fieldsCell = $('<td class="count"></td>').text(meta.fields || 0);
+            const responsesCell = $('<td class="responses"></td>').text(meta.submissions || 0);
+            const lastText = meta.lastSubmission ? formatSubmissionDate(meta.lastSubmission) : 'No submissions yet';
+            const lastCell = $('<td class="last"></td>').text(lastText);
+
+            const actionsCell = $('<td class="actions"></td>');
+            const actionsWrap = $('<div class="forms-table-actions"></div>');
+            actionsWrap.append('<button type="button" class="a11y-btn a11y-btn--secondary viewSubmissions"><i class="fas fa-inbox" aria-hidden="true"></i><span>Submissions</span></button>');
+            actionsWrap.append('<button type="button" class="a11y-btn a11y-btn--ghost editForm"><i class="fas fa-pen" aria-hidden="true"></i><span>Edit</span></button>');
+            actionsWrap.append('<button type="button" class="a11y-btn a11y-btn--ghost deleteForm"><i class="fas fa-trash" aria-hidden="true"></i><span>Delete</span></button>');
+            actionsCell.append(actionsWrap);
+
+            row.append(nameCell, fieldsCell, responsesCell, lastCell, actionsCell);
+            tbody.append(row);
+            rendered++;
+        });
+
+        if(rendered === 0){
+            $('#formsTableWrapper').attr('hidden', true);
+            $('#formsEmptyState').removeAttr('hidden');
         } else {
-            $('#fieldSettings').html('<p>Select a field to edit</p>');
+            $('#formsTableWrapper').removeAttr('hidden');
+            $('#formsEmptyState').attr('hidden', true);
         }
+    }
+
+    function loadFormSubmissions(formId, formName){
+        currentFormId = formId;
+        $('#formsTable tbody tr').removeClass('selected');
+        $('#formsTable tbody tr').filter(function(){ return Number($(this).data('id')) === Number(formId); }).addClass('selected');
+        $('#selectedFormName').text(formName || 'Form submissions');
+
+        const tbody = $('#formSubmissionsTable tbody').empty();
+        tbody.append('<tr class="loading-row"><td colspan="2">Loading submissions...</td></tr>');
+
+        $.getJSON('modules/forms/list_submissions.php', { form_id: formId }).done(function(data){
+            tbody.empty();
+            const submissions = Array.isArray(data) ? data : [];
+            const form = formsData.find(f => Number(f.id) === Number(formId)) || { id: formId, name: formName, fields: [] };
+            const meta = syncFormMeta(form) || {};
+            meta.submissions = submissions.length;
+
+            if(submissions.length){
+                const first = submissions[0];
+                const iso = first.submitted_at || first.created_at || first.timestamp || null;
+                meta.lastSubmission = iso || null;
+            } else {
+                meta.lastSubmission = null;
+            }
+
+            meta.status = determineStatus(meta);
+            formsMeta[String(formId)] = meta;
+
+            if(!submissions.length){
+                tbody.append('<tr class="empty-row"><td colspan="2">No submissions yet.</td></tr>');
+            } else {
+                submissions.forEach(function(submission){
+                    const submittedAt = formatSubmissionDate(submission.submitted_at || submission.created_at || submission.timestamp);
+                    const fields = submission.data && typeof submission.data === 'object' ? submission.data : {};
+                    const metaInfo = submission.meta && typeof submission.meta === 'object' ? Object.assign({}, submission.meta) : {};
+                    if(submission.source && !metaInfo.source){
+                        metaInfo.source = submission.source;
+                    }
+                    if(submission.id && !metaInfo.id){
+                        metaInfo.id = submission.id;
+                    }
+                    const fieldKeys = Object.keys(fields).sort();
+                    const metaKeys = Object.keys(metaInfo).sort();
+                    const details = [];
+                    fieldKeys.forEach(function(key){
+                        const value = normalizeSubmissionValue(fields[key]);
+                        details.push('<div class="submission-detail"><div class="submission-label">'+escapeHtml(key)+'</div><div class="submission-value">'+escapeHtml(value)+'</div></div>');
+                    });
+                    if(metaKeys.length){
+                        details.push('<div class="submission-meta-group"><div class="submission-meta-title">Metadata</div>');
+                        metaKeys.forEach(function(key){
+                            const value = normalizeSubmissionValue(metaInfo[key]);
+                            details.push('<div class="submission-detail"><div class="submission-label">'+escapeHtml(key)+'</div><div class="submission-value">'+escapeHtml(value)+'</div></div>');
+                        });
+                        details.push('</div>');
+                    }
+                    if(!details.length){
+                        details.push('<div class="submission-detail"><div class="submission-label">Details</div><div class="submission-value"><em>No submission data provided.</em></div></div>');
+                    }
+                    tbody.append('<tr><td class="submitted">'+escapeHtml(submittedAt)+'</td><td class="details">'+details.join('')+'</td></tr>');
+                });
+            }
+
+            updateOverviewStats();
+            recalcFilterCounts();
+            renderFormsTable();
+        }).fail(function(){
+            tbody.empty().append('<tr class="error-row"><td colspan="2">Unable to load submissions.</td></tr>');
+        });
+
+        hasLoadedInitialForm = true;
     }
 
     function loadForms(){
         $.getJSON('modules/forms/list_forms.php', function(data){
-            const forms = Array.isArray(data) ? data : [];
-            const tbody = $('#formsTable tbody').empty();
-            forms.forEach(function(f){
-                tbody.append('<tr data-id="'+f.id+'">'+
-                    '<td class="name">'+escapeHtml(f.name)+'</td>'+
-                    '<td class="count">'+(f.fields?f.fields.length:0)+'</td>'+
-                    '<td><button class="btn btn-secondary viewSubmissions">Submissions</button> '+
-                    '<button class="btn btn-secondary editForm">Edit</button> '+
-                    '<button class="btn btn-danger deleteForm">Delete</button></td>'+
-                    '</tr>');
+            formsData = Array.isArray(data) ? data : [];
+            const seen = new Set(formsData.map(function(form){ return String(form.id || ''); }));
+            Object.keys(formsMeta).forEach(function(key){
+                if(!seen.has(key)){
+                    delete formsMeta[key];
+                }
             });
-            if(!forms.length){
+
+            formsData.forEach(syncFormMeta);
+            recalcFilterCounts();
+            updateOverviewStats();
+            renderFormsTable();
+
+            if(!formsData.length){
                 resetSubmissionsCard('Create a form to start collecting submissions');
                 return;
             }
+
             if(currentFormId){
-                const activeRow = tbody.find('tr[data-id="'+currentFormId+'"]').first();
-                if(activeRow.length){
-                    loadFormSubmissions(currentFormId, activeRow.find('.name').text());
-                } else {
-                    resetSubmissionsCard();
-                    const fallbackRow = tbody.find('tr').first();
-                    if(fallbackRow.length){
-                        loadFormSubmissions(fallbackRow.data('id'), fallbackRow.find('.name').text());
-                    }
+                const exists = formsData.some(function(form){ return Number(form.id) === Number(currentFormId); });
+                if(!exists){
+                    currentFormId = null;
+                    hasLoadedInitialForm = false;
                 }
-            } else {
-                const firstRow = tbody.find('tr').first();
+            }
+
+            if(!currentFormId && !hasLoadedInitialForm){
+                const firstRow = $('#formsTable tbody tr').first();
                 if(firstRow.length){
-                    loadFormSubmissions(firstRow.data('id'), firstRow.find('.name').text());
+                    const id = firstRow.data('id');
+                    const name = firstRow.data('name') || firstRow.find('.forms-table-name').text();
+                    if(id){
+                        loadFormSubmissions(id, name);
+                    }
                 }
             }
         });
@@ -180,7 +363,12 @@ $(function(){
     function addField(type, field){
         field = field || {};
         const $li = $('<li class="field-item" data-type="'+type+'"></li>');
-        $li.append('<div class="field-bar"><span class="drag-handle">&#9776;</span> <span class="field-type">'+type+'</span> <button type="button" class="btn btn-danger btn-sm removeField">X</button></div>');
+        const bar = $('<div class="field-bar"></div>');
+        bar.append('<span class="drag-handle" aria-hidden="true">&#9776;</span>');
+        bar.append('<span class="field-type">'+escapeHtml(type)+'</span>');
+        bar.append('<button type="button" class="a11y-btn a11y-btn--ghost removeField" aria-label="Remove field"><i class="fas fa-times" aria-hidden="true"></i></button>');
+        $li.append(bar);
+
         const preview = $('<div class="field-preview"></div>');
         const body = $('<div class="field-body"></div>');
         body.append('<div class="form-group"><label class="form-label">Label</label><input type="text" class="form-input field-label"></div>');
@@ -202,6 +390,64 @@ $(function(){
         $('#formPreview').append($li);
     }
 
+    function updatePreview($li){
+        const type = $li.data('type');
+        const label = $li.find('.field-label').val() || '';
+        const name = $li.find('.field-name').val() || '';
+        const required = $li.find('.field-required').is(':checked') ? ' required' : '';
+        const options = $li.find('.field-options-input').val() || '';
+        let html = '';
+        switch(type){
+            case 'textarea':
+                html = '<div class="form-group"><label>'+escapeHtml(label)+'</label><textarea name="'+escapeHtml(name)+'"'+required+'></textarea></div>';
+                break;
+            case 'select': {
+                const opts = options.split(',').map(o => o.trim()).filter(Boolean);
+                html = '<div class="form-group"><label>'+escapeHtml(label)+'</label><select name="'+escapeHtml(name)+'"'+required+'>'+opts.map(o => '<option>'+escapeHtml(o)+'</option>').join('')+'</select></div>';
+                break;
+            }
+            case 'checkbox':
+            case 'radio': {
+                const optList = options.split(',').map(o => o.trim()).filter(Boolean);
+                if(optList.length){
+                    html = '<div class="form-group"><label>'+escapeHtml(label)+'</label><div>';
+                    optList.forEach(function(o){
+                        html += '<label><input type="'+type+'" name="'+escapeHtml(name)+'" value="'+escapeHtml(o)+'"> '+escapeHtml(o)+'</label> ';
+                    });
+                    html += '</div></div>';
+                } else {
+                    html = '<div class="form-group"><label><input type="'+type+'" name="'+escapeHtml(name)+'"'+required+'> '+escapeHtml(label)+'</label></div>';
+                }
+                break;
+            }
+            case 'submit':
+                html = '<div class="form-group"><button type="submit">'+escapeHtml(label || 'Submit')+'</button></div>';
+                break;
+            default: {
+                const inputType = type === 'date' ? 'date' : type;
+                html = '<div class="form-group"><label>'+escapeHtml(label)+'</label><input type="'+inputType+'" name="'+escapeHtml(name)+'"'+required+'></div>';
+                break;
+            }
+        }
+        $li.find('.field-preview').html(html);
+    }
+
+    function selectField($li){
+        if(currentField && currentField[0] === ($li && $li[0])) return;
+        if(currentField){
+            currentField.append($('#fieldSettings .field-body').hide());
+            currentField.removeClass('selected');
+        }
+        currentField = $li;
+        $('#fieldSettings').empty();
+        if($li){
+            currentField.addClass('selected');
+            $('#fieldSettings').append(currentField.find('.field-body').show());
+        } else {
+            $('#fieldSettings').html('<p>Select a field to edit</p>');
+        }
+    }
+
     $('.palette-item').draggable({ helper:'clone', revert:'invalid' });
 
     $('#formPreview').sortable({ placeholder:'ui-sortable-placeholder' }).droppable({
@@ -210,15 +456,16 @@ $(function(){
     });
 
     $('#newFormBtn').on('click', function(){
-        $('#formBuilderTitle').text('Add Form');
+        $('#formBuilderTitle').text('Add form');
         $('#formId').val('');
         $('#formName').val('');
         $('#formPreview').empty();
-        $('#formBuilderCard').show();
+        selectField(null);
+        $('#formBuilderCard').removeAttr('hidden');
     });
 
     $('#cancelFormEdit').on('click', function(){
-        $('#formBuilderCard').hide();
+        $('#formBuilderCard').attr('hidden', true);
         $('#formBuilderForm')[0].reset();
         $('#formPreview').empty();
         selectField(null);
@@ -227,7 +474,7 @@ $(function(){
     $('#formsTable').on('click', '.viewSubmissions', function(){
         const row = $(this).closest('tr');
         const id = row.data('id');
-        const name = row.find('.name').text();
+        const name = row.data('name') || row.find('.forms-table-name').text();
         if(id){
             loadFormSubmissions(id, name);
         }
@@ -238,29 +485,32 @@ $(function(){
         const row = $(this);
         const id = row.data('id');
         if(id){
-            loadFormSubmissions(id, row.find('.name').text());
+            const name = row.data('name') || row.find('.forms-table-name').text();
+            loadFormSubmissions(id, name);
         }
     });
 
     $('#formsTable').on('click', '.editForm', function(){
         const id = $(this).closest('tr').data('id');
-        $.getJSON('modules/forms/list_forms.php', function(forms){
-            const f = forms.find(x=>x.id==id);
-            if(!f) return;
-            $('#formBuilderTitle').text('Edit Form');
-            $('#formId').val(f.id);
-            $('#formName').val(f.name);
-            $('#formPreview').empty();
-            (f.fields||[]).forEach(fd=>addField(fd.type, fd));
-            $('#formBuilderCard').show();
-        });
+        const form = formsData.find(function(item){ return Number(item.id) === Number(id); });
+        if(!form) return;
+        $('#formBuilderTitle').text('Edit form');
+        $('#formId').val(form.id);
+        $('#formName').val(form.name);
+        $('#formPreview').empty();
+        (form.fields || []).forEach(function(fd){ addField(fd.type, fd); });
+        selectField(null);
+        $('#formBuilderCard').removeAttr('hidden');
     });
 
     $('#formsTable').on('click', '.deleteForm', function(){
         const row = $(this).closest('tr');
-        confirmModal('Delete this form?').then(ok=>{
+        confirmModal('Delete this form?').then(function(ok){
             if(ok){
-                $.post('modules/forms/delete_form.php',{id:row.data('id')}, loadForms);
+                $.post('modules/forms/delete_form.php', { id: row.data('id') }, function(){
+                    resetSubmissionsCard();
+                    loadForms();
+                });
             }
         });
     });
@@ -279,15 +529,17 @@ $(function(){
             if(f.type !== 'submit'){
                 f.required = $li.find('.field-required').is(':checked');
             }
-            if(['select','radio','checkbox'].includes(f.type)) f.options = $li.find('.field-options-input').val();
+            if(['select','radio','checkbox'].includes(f.type)){
+                f.options = $li.find('.field-options-input').val();
+            }
             fields.push(f);
         });
-        $.post('modules/forms/save_form.php',{
+        $.post('modules/forms/save_form.php', {
             id: $('#formId').val(),
             name: $('#formName').val(),
             fields: JSON.stringify(fields)
         }, function(){
-            $('#formBuilderCard').hide();
+            $('#formBuilderCard').attr('hidden', true);
             $('#formBuilderForm')[0].reset();
             $('#formPreview').empty();
             selectField(null);
@@ -295,7 +547,7 @@ $(function(){
         });
     });
 
-    $('#formPreview').on('click','.removeField',function(e){
+    $('#formPreview').on('click', '.removeField', function(e){
         e.stopPropagation();
         const li = $(this).closest('li');
         if(currentField && currentField[0] === li[0]) selectField(null);
@@ -306,6 +558,22 @@ $(function(){
         if(currentField) updatePreview(currentField);
     });
 
+    $('#formsSearchInput').on('input', function(){
+        searchQuery = $(this).val().toLowerCase().trim();
+        renderFormsTable();
+    });
+
+    $('#forms').on('click', '[data-forms-filter]', function(){
+        const btn = $(this);
+        const filter = btn.data('forms-filter');
+        if(filter === activeFilter) return;
+        activeFilter = filter;
+        btn.closest('.a11y-filter-group').find('[data-forms-filter]').removeClass('active');
+        btn.addClass('active');
+        renderFormsTable();
+    });
+
+    updateFilterCountsDisplay();
     resetSubmissionsCard();
     loadForms();
 });

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -1,79 +1,295 @@
-<!-- File: view.php -->
+<?php
+// File: view.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
+
+$formsFile = __DIR__ . '/../../data/forms.json';
+$forms = read_json_file($formsFile);
+if (!is_array($forms)) {
+    $forms = [];
+}
+
+$submissionsFile = __DIR__ . '/../../data/form_submissions.json';
+$submissions = read_json_file($submissionsFile);
+if (!is_array($submissions)) {
+    $submissions = [];
+}
+
+$submissionCounts = [];
+$lastSubmissionPerForm = [];
+$latestSubmissionTimestamp = 0;
+
+$extractTimestamp = static function (array $entry): int {
+    foreach (['submitted_at', 'created_at', 'timestamp'] as $key) {
+        if (empty($entry[$key])) {
+            continue;
+        }
+
+        $value = $entry[$key];
+        if (is_numeric($value)) {
+            $numeric = (float) $value;
+            if ($numeric > 0) {
+                return $numeric < 1000000000000 ? (int) round($numeric) : (int) round($numeric / 1000);
+            }
+            continue;
+        }
+
+        $time = strtotime((string) $value);
+        if ($time !== false) {
+            return $time;
+        }
+    }
+
+    return 0;
+};
+
+foreach ($submissions as $submission) {
+    if (!is_array($submission)) {
+        continue;
+    }
+
+    $formId = isset($submission['form_id']) ? (int) $submission['form_id'] : null;
+    if (!$formId) {
+        continue;
+    }
+
+    $submissionCounts[$formId] = ($submissionCounts[$formId] ?? 0) + 1;
+
+    $timestamp = $extractTimestamp($submission);
+    if ($timestamp > 0) {
+        if (!isset($lastSubmissionPerForm[$formId]) || $timestamp > $lastSubmissionPerForm[$formId]) {
+            $lastSubmissionPerForm[$formId] = $timestamp;
+        }
+
+        if ($timestamp > $latestSubmissionTimestamp) {
+            $latestSubmissionTimestamp = $timestamp;
+        }
+    }
+}
+
+$totalForms = count($forms);
+$totalSubmissions = array_sum($submissionCounts);
+$totalFields = 0;
+$collectingForms = 0;
+$draftForms = 0;
+$readyForms = 0;
+$formsMeta = [];
+
+foreach ($forms as $form) {
+    $formId = isset($form['id']) ? (int) $form['id'] : null;
+    if (!$formId) {
+        continue;
+    }
+
+    $fields = $form['fields'] ?? [];
+    if (!is_array($fields)) {
+        $fields = [];
+    }
+
+    $fieldCount = count($fields);
+    $totalFields += $fieldCount;
+
+    $submissionCount = $submissionCounts[$formId] ?? 0;
+    if ($submissionCount > 0) {
+        $collectingForms++;
+    }
+
+    if ($fieldCount === 0) {
+        $draftForms++;
+    } elseif ($submissionCount === 0) {
+        $readyForms++;
+    }
+
+    $status = 'draft';
+    if ($submissionCount > 0) {
+        $status = 'collecting';
+    } elseif ($fieldCount > 0) {
+        $status = 'ready';
+    }
+
+    $lastSubmissionIso = isset($lastSubmissionPerForm[$formId]) ? date(DATE_ATOM, $lastSubmissionPerForm[$formId]) : null;
+
+    $formsMeta[$formId] = [
+        'fields' => $fieldCount,
+        'submissions' => $submissionCount,
+        'status' => $status,
+        'lastSubmission' => $lastSubmissionIso,
+        'name' => (string) ($form['name'] ?? 'Untitled form'),
+    ];
+}
+
+$avgFields = $totalForms > 0 ? round($totalFields / $totalForms, 1) : 0;
+$lastSubmissionLabel = $latestSubmissionTimestamp > 0 ? date('M j, Y g:i A', $latestSubmissionTimestamp) : 'No submissions yet';
+
+$dashboardStats = [
+    'totalForms' => $totalForms,
+    'totalSubmissions' => $totalSubmissions,
+    'activeForms' => $collectingForms,
+    'avgFields' => $avgFields,
+    'lastSubmission' => $lastSubmissionLabel,
+    'lastSubmissionIso' => $latestSubmissionTimestamp > 0 ? date(DATE_ATOM, $latestSubmissionTimestamp) : null,
+];
+
+$filterCounts = [
+    'all' => $totalForms,
+    'collecting' => $collectingForms,
+    'ready' => $readyForms,
+    'draft' => $draftForms,
+];
+?>
 <div class="content-section" id="forms">
-    <div class="table-card">
-        <div class="table-header">
-            <div class="table-title">Forms</div>
-            <div class="table-actions">
-                <button class="btn btn-primary" id="newFormBtn">+ New Form</button>
-            </div>
-        </div>
-        <table class="data-table" id="formsTable">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Fields</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
-
-    <div class="table-card" id="formSubmissionsCard" style="margin-top:20px;">
-        <div class="table-header">
-            <div class="table-title">Form Submissions</div>
-            <div class="table-actions">
-                <span id="selectedFormName" class="form-submissions-label">Select a form to view submissions</span>
-            </div>
-        </div>
-        <table class="data-table" id="formSubmissionsTable">
-            <thead>
-                <tr>
-                    <th>Submitted</th>
-                    <th>Details</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr class="placeholder-row">
-                    <td colspan="2">Select a form to view submissions.</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-
-    <div class="form-card" id="formBuilderCard" style="margin-top:20px; display:none;">
-        <h3 id="formBuilderTitle" style="margin-bottom:15px;">Add Form</h3>
-        <form id="formBuilderForm">
-            <input type="hidden" name="id" id="formId">
-            <div class="form-group">
-                <label class="form-label" for="formName">Form Name</label>
-                <input type="text" class="form-input" id="formName" name="name" required>
-            </div>
-            <div class="builder-container">
-                <div id="fieldPalette">
-                    <div class="palette-item" data-type="text" role="button" tabindex="0">Text Input</div>
-                    <div class="palette-item" data-type="email" role="button" tabindex="0">Email</div>
-                    <div class="palette-item" data-type="password" role="button" tabindex="0">Password</div>
-                    <div class="palette-item" data-type="number" role="button" tabindex="0">Number</div>
-                    <div class="palette-item" data-type="date" role="button" tabindex="0">Date</div>
-                    <div class="palette-item" data-type="textarea" role="button" tabindex="0">Textarea</div>
-                    <div class="palette-item" data-type="select" role="button" tabindex="0">Select</div>
-                    <div class="palette-item" data-type="checkbox" role="button" tabindex="0">Checkbox</div>
-                    <div class="palette-item" data-type="radio" role="button" tabindex="0">Radio</div>
-                    <div class="palette-item" data-type="file" role="button" tabindex="0">File</div>
-                    <div class="palette-item" data-type="submit" role="button" tabindex="0">Submit Button</div>
+    <div class="forms-dashboard" data-last-submission="<?php echo htmlspecialchars($dashboardStats['lastSubmission'], ENT_QUOTES); ?>">
+        <header class="a11y-hero forms-hero">
+            <div class="a11y-hero-content">
+                <div>
+                    <h2 class="a11y-hero-title">Forms &amp; Responses</h2>
+                    <p class="a11y-hero-subtitle">Build conversion-ready forms and keep tabs on every submission from one place.</p>
                 </div>
-                <div class="builder-columns">
-                    <ul id="formPreview" class="field-list" aria-label="Form preview" data-placeholder="Drop fields here"></ul>
-                    <div id="fieldSettings" class="field-settings">
-                        <p>Select a field to edit</p>
+                <div class="a11y-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="newFormBtn">
+                        <i class="fas fa-plus" aria-hidden="true"></i>
+                        <span>New form</span>
+                    </button>
+                    <span class="a11y-hero-meta" id="formsLastSubmissionMeta">
+                        <i class="fas fa-clock" aria-hidden="true"></i>
+                        Last submission: <?php echo htmlspecialchars($dashboardStats['lastSubmission']); ?>
+                    </span>
+                </div>
+            </div>
+        </header>
+
+        <div class="a11y-overview-grid forms-overview">
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="formsStatTotal"><?php echo (int) $dashboardStats['totalForms']; ?></div>
+                <div class="a11y-overview-label">Total forms</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="formsStatResponses"><?php echo (int) $dashboardStats['totalSubmissions']; ?></div>
+                <div class="a11y-overview-label">Responses collected</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="formsStatActive"><?php echo (int) $dashboardStats['activeForms']; ?></div>
+                <div class="a11y-overview-label">Collecting responses</div>
+            </div>
+            <div class="a11y-overview-card">
+                <div class="a11y-overview-value" id="formsStatFields"><?php echo htmlspecialchars($dashboardStats['avgFields']); ?></div>
+                <div class="a11y-overview-label">Average fields / form</div>
+            </div>
+        </div>
+
+        <div class="forms-controls">
+            <label class="a11y-search" for="formsSearchInput">
+                <i class="fas fa-search" aria-hidden="true"></i>
+                <input type="search" id="formsSearchInput" placeholder="Search forms by name or status" aria-label="Search forms">
+            </label>
+            <div class="a11y-filter-group" role="group" aria-label="Form filters">
+                <button type="button" class="a11y-filter-btn active" data-forms-filter="all">All forms <span class="a11y-filter-count" data-forms-count="all"><?php echo (int) $filterCounts['all']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-forms-filter="collecting">Collecting responses <span class="a11y-filter-count" data-forms-count="collecting"><?php echo (int) $filterCounts['collecting']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-forms-filter="ready">Ready to publish <span class="a11y-filter-count" data-forms-count="ready"><?php echo (int) $filterCounts['ready']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-forms-filter="draft">Drafts <span class="a11y-filter-count" data-forms-count="draft"><?php echo (int) $filterCounts['draft']; ?></span></button>
+            </div>
+        </div>
+
+        <div class="forms-content-grid">
+            <section class="forms-card forms-card--list" aria-labelledby="formsListTitle">
+                <header class="forms-card__header">
+                    <div>
+                        <h3 id="formsListTitle">Forms</h3>
+                        <p class="forms-card__subtitle">Track performance, review responses, and refine every interaction.</p>
+                    </div>
+                </header>
+                <div class="forms-table-wrapper" id="formsTableWrapper">
+                    <table class="forms-table" id="formsTable">
+                        <thead>
+                            <tr>
+                                <th scope="col">Form</th>
+                                <th scope="col">Fields</th>
+                                <th scope="col">Responses</th>
+                                <th scope="col">Last activity</th>
+                                <th scope="col">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+                <div class="forms-empty-state" id="formsEmptyState" hidden>
+                    <i class="fas fa-clipboard-list" aria-hidden="true"></i>
+                    <h4>No forms match your filters</h4>
+                    <p>Try adjusting the search or create a new form to get started.</p>
+                </div>
+            </section>
+
+            <section class="forms-card forms-card--submissions" id="formSubmissionsCard" aria-labelledby="formsSubmissionsTitle">
+                <header class="forms-card__header">
+                    <div>
+                        <h3 id="formsSubmissionsTitle">Form submissions</h3>
+                        <p id="selectedFormName" class="forms-card__subtitle">Select a form to view submissions</p>
+                    </div>
+                </header>
+                <div class="forms-table-wrapper forms-table-wrapper--submissions">
+                    <table class="forms-table forms-table--submissions" id="formSubmissionsTable">
+                        <thead>
+                            <tr>
+                                <th scope="col">Submitted</th>
+                                <th scope="col">Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="placeholder-row">
+                                <td colspan="2">Select a form to view submissions.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        </div>
+
+        <section class="forms-builder-card" id="formBuilderCard" hidden aria-labelledby="formBuilderTitle">
+            <header class="forms-card__header">
+                <div>
+                    <h3 id="formBuilderTitle">Add form</h3>
+                    <p class="forms-card__subtitle">Use the palette to drag fields into your form layout, then fine-tune each input.</p>
+                </div>
+            </header>
+            <form id="formBuilderForm">
+                <input type="hidden" name="id" id="formId">
+                <div class="form-group">
+                    <label class="form-label" for="formName">Form name</label>
+                    <input type="text" class="form-input" id="formName" name="name" required>
+                </div>
+                <div class="builder-container" role="application" aria-label="Form builder">
+                    <div id="fieldPalette" class="forms-palette" aria-label="Field palette">
+                        <span class="forms-palette__label">Drag fields</span>
+                        <div class="palette-item" data-type="text" role="button" tabindex="0">Text input</div>
+                        <div class="palette-item" data-type="email" role="button" tabindex="0">Email</div>
+                        <div class="palette-item" data-type="password" role="button" tabindex="0">Password</div>
+                        <div class="palette-item" data-type="number" role="button" tabindex="0">Number</div>
+                        <div class="palette-item" data-type="date" role="button" tabindex="0">Date</div>
+                        <div class="palette-item" data-type="textarea" role="button" tabindex="0">Textarea</div>
+                        <div class="palette-item" data-type="select" role="button" tabindex="0">Select</div>
+                        <div class="palette-item" data-type="checkbox" role="button" tabindex="0">Checkbox</div>
+                        <div class="palette-item" data-type="radio" role="button" tabindex="0">Radio</div>
+                        <div class="palette-item" data-type="file" role="button" tabindex="0">File upload</div>
+                        <div class="palette-item" data-type="submit" role="button" tabindex="0">Submit button</div>
+                    </div>
+                    <div class="builder-columns">
+                        <ul id="formPreview" class="field-list" aria-label="Form preview" data-placeholder="Drop fields here"></ul>
+                        <div id="fieldSettings" class="field-settings">
+                            <p>Select a field to edit</p>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="form-actions">
-                <button type="submit" class="btn btn-primary">Save Form</button>
-                <button type="button" class="btn btn-secondary" id="cancelFormEdit">Cancel</button>
-            </div>
-        </form>
+                <div class="form-actions forms-builder-actions">
+                    <button type="submit" class="a11y-btn a11y-btn--primary">Save form</button>
+                    <button type="button" class="a11y-btn a11y-btn--ghost" id="cancelFormEdit">Cancel</button>
+                </div>
+            </form>
+        </section>
     </div>
 </div>
+<script>
+window.formsDashboardStats = <?php echo json_encode($dashboardStats, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+window.formsFilterCounts = <?php echo json_encode($filterCounts, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+window.formsFormMeta = <?php echo json_encode($formsMeta, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+</script>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -3193,13 +3193,205 @@
 }
 
 /* Forms module */
+#forms .forms-dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+#forms .forms-hero {
+    margin-bottom: 12px;
+}
+
+#forms .forms-overview {
+    margin-top: 8px;
+}
+
+.forms-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    justify-content: space-between;
+}
+
+.forms-controls .a11y-search {
+    flex: 1;
+    max-width: 420px;
+}
+
+.forms-content-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+    gap: 24px;
+    align-items: start;
+}
+
+.forms-card,
+.forms-builder-card {
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 16px;
+    padding: 24px;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.06);
+}
+
+.forms-builder-card[hidden] {
+    display: none !important;
+}
+
+.forms-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.forms-card__header h3 {
+    margin: 0;
+    font-size: 18px;
+    color: #111827;
+}
+
+.forms-card__subtitle {
+    margin: 6px 0 0;
+    color: #6b7280;
+    font-size: 14px;
+}
+
+.forms-table-wrapper {
+    overflow-x: auto;
+}
+
+.forms-table-wrapper--submissions {
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 0 16px 16px;
+    background: #f9fafb;
+    max-height: 540px;
+    overflow-y: auto;
+}
+
+.forms-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 100%;
+}
+
+.forms-table thead th {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #6b7280;
+    text-align: left;
+    padding: 16px 0 12px;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.forms-table tbody td {
+    padding: 14px 0;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 14px;
+    color: #1f2937;
+    vertical-align: top;
+}
+
+.forms-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.forms-table tbody tr:hover {
+    background: #f8fafc;
+}
+
 #formsTable tbody tr.selected {
     background: #eef2ff;
 }
 
-.form-submissions-label {
-    font-size: 14px;
+.forms-table-name {
+    font-weight: 600;
+    color: #111827;
+}
+
+.forms-table-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-top: 6px;
+}
+
+.forms-table-status.status-collecting {
+    background: #ecfdf5;
+    color: #047857;
+}
+
+.forms-table-status.status-ready {
+    background: #eff6ff;
+    color: #1d4ed8;
+}
+
+.forms-table-status.status-draft {
+    background: #fef2f2;
+    color: #b91c1c;
+}
+
+.forms-table-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.forms-table-actions .a11y-btn {
+    padding: 6px 10px;
+    font-size: 12px;
+    line-height: 1.3;
+}
+
+.forms-table-actions .a11y-btn i {
+    font-size: 12px;
+    margin-right: 6px;
+}
+
+.forms-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 48px 16px;
     color: #6b7280;
+    text-align: center;
+    border: 1px dashed #d1d5db;
+    border-radius: 16px;
+    background: #f9fafb;
+    margin-top: 12px;
+}
+
+.forms-empty-state i {
+    font-size: 32px;
+    color: #cbd5f5;
+}
+
+.forms-card--submissions .forms-card__subtitle {
+    color: #4b5563;
+}
+
+.forms-table--submissions thead th {
+    position: sticky;
+    top: 0;
+    background: #f9fafb;
+    z-index: 1;
+}
+
+.forms-table--submissions tbody td {
+    padding: 12px 0;
 }
 
 #formSubmissionsTable .submission-detail {
@@ -3250,6 +3442,171 @@
 #formSubmissionsTable tbody .placeholder-row td {
     color: #6b7280;
     font-style: italic;
+}
+
+.forms-palette {
+    width: 220px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.forms-palette__label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #6b7280;
+}
+
+#fieldPalette {
+    width: auto;
+}
+
+.palette-item {
+    background: #ffffff;
+    border: 1px solid #dbeafe;
+    border-radius: 10px;
+    padding: 10px 12px;
+    text-align: left;
+    font-weight: 600;
+    color: #1d4ed8;
+    cursor: grab;
+    transition: all 0.2s ease;
+}
+
+.palette-item:hover {
+    background: #eef2ff;
+    border-color: #c7d2fe;
+}
+
+.palette-item:active {
+    cursor: grabbing;
+}
+
+.field-list {
+    list-style: none;
+    padding: 16px;
+    flex: 1;
+    border: 2px dashed #dbeafe;
+    border-radius: 12px;
+    min-height: 160px;
+    background: #ffffff;
+    position: relative;
+}
+
+.field-item {
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    padding: 12px;
+    margin-bottom: 12px;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+}
+
+.field-item.selected {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+#fieldSettings {
+    width: 280px;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 16px;
+    background: #ffffff;
+    height: fit-content;
+}
+
+.forms-builder-actions {
+    margin-top: 24px;
+}
+
+.forms-builder-card .field-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    gap: 12px;
+}
+
+.forms-builder-card .field-type {
+    font-weight: 600;
+    color: #4b5563;
+    text-transform: capitalize;
+}
+
+.forms-builder-card .removeField {
+    padding: 4px 8px;
+    font-size: 12px;
+}
+
+.forms-builder-card .removeField i {
+    margin: 0;
+}
+
+@media (max-width: 1280px) {
+    .forms-content-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .forms-table-wrapper--submissions {
+        max-height: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .forms-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .forms-controls .a11y-search {
+        max-width: none;
+    }
+
+    .forms-card,
+    .forms-builder-card {
+        padding: 20px;
+    }
+
+    .forms-card__header {
+        flex-direction: column;
+    }
+
+    .builder-container {
+        flex-direction: column;
+    }
+
+    .forms-palette {
+        width: 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    .forms-palette__label {
+        width: 100%;
+    }
+
+    #fieldSettings {
+        width: 100%;
+    }
+}
+
+@media (max-width: 480px) {
+    .forms-table thead th:nth-child(4),
+    .forms-table tbody td:nth-child(4) {
+        display: none;
+    }
+
+    .forms-table-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- rebuild the forms module view with a dashboard hero, overview metrics, filters, refreshed tables, and a modernized builder card
- extend forms.js to compute stats, power search and filtering, keep submission metadata in sync, and enhance builder interactions
- expand the forms-specific CSS to mirror the accessibility module styling across cards, tables, and builder components

## Testing
- php -l CMS/modules/forms/view.php
- node --check CMS/modules/forms/forms.js

------
https://chatgpt.com/codex/tasks/task_e_68d7267de4988331a9a35b92f47265c4