### PR TITLE
Revamp menus module to match accessibility dashboard

### DIFF
--- a/CMS/modules/menus/menus.js
+++ b/CMS/modules/menus/menus.js
@@ -1,44 +1,235 @@
 // File: menus.js
-$(function(){
+$(function () {
     let pages = [];
+    let menuData = Array.isArray(window.menuDashboardInitialData) ? window.menuDashboardInitialData : [];
+    let searchTerm = '';
+    let activeFilter = 'all';
 
-    function loadPages(callback){
-        $.getJSON('modules/pages/list_pages.php', function(data){
-            pages = data;
-            if(callback) callback();
+    const $menuTable = $('#menuTable');
+    const $menuTableBody = $('#menuTableBody');
+    const $menuEmptyState = $('#menuEmptyState');
+    const $menuNoResults = $('#menuNoResults');
+    const $filterButtons = $('.menu-filter-btn');
+
+    function escapeHtml(value) {
+        return $('<div>').text(value == null ? '' : value).html();
+    }
+
+    function loadPages(callback) {
+        $.getJSON('modules/pages/list_pages.php', function (data) {
+            pages = Array.isArray(data) ? data : [];
+            if (callback) callback();
         });
     }
 
-    function countItems(items){
-        let c = 0;
-        if(Array.isArray(items)){
-            items.forEach(it => {
-                c++;
-                if(it.children) c += countItems(it.children);
-            });
+    function countItems(items) {
+        if (!Array.isArray(items)) {
+            return 0;
         }
+        let c = 0;
+        items.forEach((it) => {
+            c++;
+            if (Array.isArray(it.children) && it.children.length) {
+                c += countItems(it.children);
+            }
+        });
         return c;
     }
 
-    function loadMenus(){
-        $.getJSON('modules/menus/list_menus.php', function(data){
-            const tbody = $('#menusTable tbody').empty();
-            data.forEach(menu => {
-                tbody.append(
-                    '<tr data-id="'+menu.id+'">'+
-                    '<td class="name">'+menu.name+'</td>'+
-                    '<td class="count">'+countItems(menu.items)+'</td>'+
-                    '<td><button class="btn btn-secondary editMenu">Edit</button> '+
-                    '<button class="btn btn-danger deleteMenu">Delete</button></td>'+
-                    '</tr>'
-                );
-            });
+    function hasNested(items) {
+        if (!Array.isArray(items)) {
+            return false;
+        }
+        return items.some((it) => Array.isArray(it.children) && it.children.length > 0);
+    }
+
+    function maxDepth(items, depth = 1) {
+        if (!Array.isArray(items) || !items.length) {
+            return depth === 1 ? 0 : depth - 1;
+        }
+        let max = depth;
+        items.forEach((it) => {
+            if (Array.isArray(it.children) && it.children.length) {
+                max = Math.max(max, maxDepth(it.children, depth + 1));
+            }
+        });
+        return max;
+    }
+
+    function collectLabels(items, results) {
+        if (!Array.isArray(items)) {
+            return results;
+        }
+        items.forEach((item) => {
+            if (item.label) {
+                results.push(String(item.label).toLowerCase());
+            }
+            if (Array.isArray(item.children) && item.children.length) {
+                collectLabels(item.children, results);
+            }
+        });
+        return results;
+    }
+
+    function buildPreview(items) {
+        if (!Array.isArray(items) || !items.length) {
+            return '';
+        }
+        const labels = [];
+        items.forEach((item) => {
+            if (item.label) {
+                labels.push(item.label);
+            }
+        });
+        if (!labels.length) {
+            return '';
+        }
+        const preview = labels.slice(0, 3).map((label) => String(label)).join(' • ');
+        return labels.length > 3 ? preview + '…' : preview;
+    }
+
+    function matchesSearch(menu) {
+        if (!searchTerm) {
+            return true;
+        }
+        const lowerName = String(menu.name || '').toLowerCase();
+        if (lowerName.includes(searchTerm)) {
+            return true;
+        }
+        const labels = collectLabels(menu.items, []);
+        return labels.some((label) => label.includes(searchTerm));
+    }
+
+    function matchesFilter(menu) {
+        if (activeFilter === 'nested') {
+            return hasNested(menu.items);
+        }
+        if (activeFilter === 'single') {
+            return !hasNested(menu.items);
+        }
+        return true;
+    }
+
+    function updateDashboardStats() {
+        const totalMenus = menuData.length;
+        const totalLinks = menuData.reduce((sum, menu) => sum + countItems(menu.items), 0);
+        const nestedMenus = menuData.reduce((sum, menu) => sum + (hasNested(menu.items) ? 1 : 0), 0);
+        const averageLinks = totalMenus > 0 ? Math.round((totalLinks / totalMenus) * 10) / 10 : 0;
+
+        $('#menuStatTotal').text(totalMenus);
+        $('#menuStatLinks').text(totalLinks);
+        $('#menuStatNested').text(nestedMenus);
+        $('#menuStatAverage').text(averageLinks);
+    }
+
+    function updateFilterCounts() {
+        const counts = {
+            all: menuData.length,
+            nested: menuData.filter((menu) => hasNested(menu.items)).length,
+            single: menuData.filter((menu) => !hasNested(menu.items)).length,
+        };
+
+        Object.keys(counts).forEach((key) => {
+            $filterButtons
+                .filter(`[data-menu-filter="${key}"]`)
+                .find('.menu-filter-count')
+                .text(counts[key]);
         });
     }
 
-    function toggleFields($item){
+    function renderMenus() {
+        const totalMenus = menuData.length;
+        const filteredMenus = menuData
+            .filter((menu) => matchesFilter(menu) && matchesSearch(menu))
+            .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
+
+        if (!totalMenus) {
+            $menuTable.hide();
+            $menuNoResults.prop('hidden', true);
+            $menuEmptyState.prop('hidden', false);
+            $menuTableBody.empty();
+            return;
+        }
+
+        $menuEmptyState.prop('hidden', true);
+
+        if (!filteredMenus.length) {
+            $menuTable.hide();
+            $menuNoResults.prop('hidden', false);
+            $menuTableBody.empty();
+            return;
+        }
+
+        $menuNoResults.prop('hidden', true);
+        $menuTable.show();
+        $menuTableBody.empty();
+
+        filteredMenus.forEach((menu) => {
+            const itemCount = countItems(menu.items);
+            const depth = maxDepth(menu.items);
+            const nested = depth > 1;
+            const structureLabel = nested ? 'Nested menu' : 'Single level';
+            const structureMeta = nested ? `Depth ${depth}` : 'Top-level links';
+            const preview = buildPreview(menu.items);
+
+            const $row = $('<div class="menu-table-row"></div>').attr('data-id', menu.id);
+
+            const $nameCell = $('<div class="menu-table-cell menu-table-cell--name"></div>');
+            $nameCell.append($('<div class="menu-name"></div>').text(menu.name || 'Untitled menu'));
+            if (preview) {
+                $nameCell.append($('<div class="menu-preview"></div>').text(preview));
+            }
+
+            const $linksCell = $('<div class="menu-table-cell menu-table-cell--links"></div>');
+            $linksCell.append($('<span class="menu-count"></span>').text(itemCount));
+            $linksCell.append($('<span class="menu-count-label">Links</span>'));
+
+            const $structureCell = $('<div class="menu-table-cell menu-table-cell--structure"></div>');
+            $structureCell.append($('<span class="menu-structure-badge"></span>').text(structureLabel));
+            $structureCell.append($('<span class="menu-structure-meta"></span>').text(structureMeta));
+
+            const $actionsCell = $('<div class="menu-table-cell menu-table-actions"></div>');
+            const $editBtn = $(
+                '<button type="button" class="menu-btn menu-btn--ghost menu-btn--sm editMenu">' +
+                    '<i class="fas fa-pen" aria-hidden="true"></i>' +
+                    '<span>Edit</span>' +
+                '</button>'
+            );
+            const $deleteBtn = $(
+                '<button type="button" class="menu-btn menu-btn--danger menu-btn--sm deleteMenu">' +
+                    '<i class="fas fa-trash" aria-hidden="true"></i>' +
+                    '<span>Delete</span>' +
+                '</button>'
+            );
+            $actionsCell.append($editBtn, $deleteBtn);
+
+            $row.append($nameCell, $linksCell, $structureCell, $actionsCell);
+            $menuTableBody.append($row);
+        });
+    }
+
+    function setMenuData(data) {
+        menuData = Array.isArray(data) ? data : [];
+        updateDashboardStats();
+        updateFilterCounts();
+        renderMenus();
+    }
+
+    function loadMenus(showLoading = true) {
+        const $refreshBtn = $('#refreshMenusBtn');
+        if (showLoading) {
+            $refreshBtn.addClass('is-loading');
+        }
+        $.getJSON('modules/menus/list_menus.php', function (data) {
+            setMenuData(data);
+        }).always(function () {
+            $refreshBtn.removeClass('is-loading');
+        });
+    }
+
+    function toggleFields($item) {
         const type = $item.find('.type-select').val();
-        if(type === 'page'){
+        if (type === 'page') {
             $item.find('.page-select').show();
             $item.find('.link-input').hide();
         } else {
@@ -47,14 +238,14 @@ $(function(){
         }
     }
 
-    function prepareItem(item){
+    function prepareItem(item) {
         item = item || {};
-        if(!item.type){
-            if(item.link && item.link.startsWith('/')){
+        if (!item.type) {
+            if (item.link && item.link.startsWith('/')) {
                 item.type = 'page';
                 const slug = item.link.substring(1);
-                const p = pages.find(pg => pg.slug === slug);
-                if(p) item.page = p.id;
+                const p = pages.find((pg) => pg.slug === slug);
+                if (p) item.page = p.id;
             } else {
                 item.type = 'custom';
             }
@@ -62,138 +253,195 @@ $(function(){
         return item;
     }
 
-    function initSortable($list){
+    function initSortable($list) {
         $list.sortable({
             handle: '.drag-handle',
             connectWith: '.menu-list',
-            placeholder: 'menu-placeholder'
+            placeholder: 'menu-placeholder',
         });
     }
 
-    function createItemElement(item){
+    function createItemElement(item) {
         item = prepareItem(item);
-        const pageOptions = pages.map(p => '<option value="'+p.id+'">'+p.title+'</option>').join('');
+        const pageOptions = pages
+            .map((p) => '<option value="' + p.id + '">' + escapeHtml(p.title) + '</option>')
+            .join('');
         const $li = $('<li></li>');
         const $item = $('<div class="menu-item"></div>');
-        $item.append('<span class="drag-handle">&#9776;</span>');
+        $item.append('<span class="drag-handle" aria-hidden="true">&#9776;</span>');
         $item.append('<select class="form-select type-select"><option value="page">Link to Page</option><option value="custom">Custom Link</option></select>');
-        $item.append('<select class="form-select page-select">'+pageOptions+'</select>');
+        $item.append('<select class="form-select page-select">' + pageOptions + '</select>');
         $item.append('<input type="text" class="form-input link-input" placeholder="URL">');
         $item.append('<input type="text" class="form-input label-input" placeholder="Title">');
-        $item.append('<label style="white-space:nowrap;"><input type="checkbox" class="new-tab"> New Tab</label>');
-        $item.append('<button type="button" class="btn btn-secondary btn-sm addChild">+ Sub</button>');
-        $item.append('<button type="button" class="btn btn-danger removeItem">X</button>');
+        $item.append('<label class="menu-item-checkbox"><input type="checkbox" class="new-tab"> <span>New Tab</span></label>');
+        $item.append('<button type="button" class="menu-chip-btn addChild"><i class="fas fa-level-down-alt" aria-hidden="true"></i><span>Sub</span></button>');
+        $item.append('<button type="button" class="menu-chip-btn menu-chip-btn--danger removeItem"><i class="fas fa-trash" aria-hidden="true"></i><span>Remove</span></button>');
         $li.append($item);
         $li.append('<ul class="menu-list"></ul>');
         $item.find('.type-select').val(item.type);
-        if(item.page) $item.find('.page-select').val(item.page);
+        if (item.page) $item.find('.page-select').val(item.page);
         $item.find('.link-input').val(item.link || '');
         $item.find('.label-input').val(item.label || '');
-        $item.find('.new-tab').prop('checked', item.new_tab ? true : false);
+        $item.find('.new-tab').prop('checked', !!item.new_tab);
         toggleFields($item);
         return $li;
     }
 
-    function addItem(item, $parent){
+    function addItem(item, $parent) {
         $parent = $parent || $('#menuItems');
         const $el = createItemElement(item || {});
         $parent.append($el);
         initSortable($el.children('ul'));
-        if(item && item.children){
-            item.children.forEach(ch => addItem(ch, $el.children('ul')));
+        if (item && Array.isArray(item.children)) {
+            item.children.forEach((ch) => addItem(ch, $el.children('ul')));
         }
     }
 
-    $('#addMenuItem').on('click', function(){ addItem(); });
-
-    initSortable($('#menuItems'));
-
-    $('#menuItems').on('click', '.removeItem', function(){ $(this).closest('li').remove(); });
-    $('#menuItems').on('click', '.addChild', function(){
-        const $li = $(this).closest('li');
-        addItem({}, $li.children('ul'));
-    });
-    $('#menuItems').on('change', '.type-select', function(){ toggleFields($(this).closest('.menu-item')); });
-
-    $('#newMenuBtn').on('click', function(){
-        $('#menuFormTitle').text('Add Menu');
-        $('#menuId').val('');
-        $('#menuName').val('');
-        $('#menuItems').empty();
-        addItem();
-        $('#menuFormCard').show();
-        $('#cancelMenuEdit').show();
-    });
-
-    $('#cancelMenuEdit').on('click', function(){
-        $('#menuFormCard').hide();
-        $('#menuForm')[0].reset();
-        $('#menuItems').empty();
-    });
-
-    $('#menusTable').on('click', '.editMenu', function(){
-        const id = $(this).closest('tr').data('id');
-        $.getJSON('modules/menus/list_menus.php', function(data){
-            const menu = data.find(m => m.id == id);
-            if(!menu) return;
-            $('#menuFormTitle').text('Edit Menu');
-            $('#menuId').val(menu.id);
-            $('#menuName').val(menu.name);
-            $('#menuItems').empty();
-            if(menu.items && menu.items.length){
-                menu.items.forEach(it => addItem(it));
-            } else {
-                addItem();
-            }
-            $('#menuFormCard').show();
-            $('#cancelMenuEdit').show();
-        });
-    });
-
-    $('#menusTable').on('click', '.deleteMenu', function(){
-        const row = $(this).closest('tr');
-        confirmModal('Delete this menu?').then(ok => {
-            if(!ok) return;
-            $.post('modules/menus/delete_menu.php', {id: row.data('id')}, function(){
-                loadMenus();
-            });
-        });
-    });
-
-    function gatherItems($list){
+    function gatherItems($list) {
         const items = [];
-        $list.children('li').each(function(){
+        $list.children('li').each(function () {
             const $it = $(this).children('.menu-item');
             const item = {
                 type: $it.find('.type-select').val(),
-                page: parseInt($it.find('.page-select').val()) || null,
+                page: parseInt($it.find('.page-select').val(), 10) || null,
                 link: $it.find('.link-input').val(),
                 label: $it.find('.label-input').val(),
-                new_tab: $it.find('.new-tab').is(':checked')
+                new_tab: $it.find('.new-tab').is(':checked'),
             };
             const children = gatherItems($(this).children('ul'));
-            if(children.length) item.children = children;
+            if (children.length) item.children = children;
             items.push(item);
         });
         return items;
     }
 
-    $('#menuForm').on('submit', function(e){
+    function resetMenuForm() {
+        const form = $('#menuForm')[0];
+        if (form) {
+            form.reset();
+        }
+        $('#menuId').val('');
+        $('#menuItems').empty();
+    }
+
+    function openMenuEditor(title) {
+        $('#menuFormTitle').text(title);
+        $('#menuFormCard').addClass('is-visible').attr('aria-hidden', 'false');
+        setTimeout(() => {
+            $('#menuName').trigger('focus');
+        }, 10);
+    }
+
+    function closeMenuEditor() {
+        $('#menuFormCard').removeClass('is-visible').attr('aria-hidden', 'true');
+        resetMenuForm();
+    }
+
+    $('#addMenuItem').on('click', function () {
+        addItem();
+    });
+
+    initSortable($('#menuItems'));
+
+    $('#menuItems').on('click', '.removeItem', function () {
+        $(this).closest('li').remove();
+    });
+
+    $('#menuItems').on('click', '.addChild', function () {
+        const $li = $(this).closest('li');
+        addItem({}, $li.children('ul'));
+    });
+
+    $('#menuItems').on('change', '.type-select', function () {
+        toggleFields($(this).closest('.menu-item'));
+    });
+
+    $('#newMenuBtn').on('click', function () {
+        resetMenuForm();
+        addItem();
+        openMenuEditor('Create Menu');
+    });
+
+    $('#emptyStateCreateMenu').on('click', function () {
+        $('#newMenuBtn').trigger('click');
+    });
+
+    $('#closeMenuEditor').on('click', function () {
+        closeMenuEditor();
+    });
+
+    $('#cancelMenuEdit').on('click', function () {
+        closeMenuEditor();
+    });
+
+    $menuTableBody.on('click', '.editMenu', function () {
+        const id = $(this).closest('.menu-table-row').data('id');
+        $.getJSON('modules/menus/list_menus.php', function (data) {
+            menuData = Array.isArray(data) ? data : [];
+            const menu = menuData.find((m) => String(m.id) === String(id));
+            if (!menu) {
+                return;
+            }
+            resetMenuForm();
+            $('#menuId').val(menu.id);
+            $('#menuName').val(menu.name || '');
+            if (Array.isArray(menu.items) && menu.items.length) {
+                menu.items.forEach((it) => addItem(it));
+            } else {
+                addItem();
+            }
+            openMenuEditor('Edit Menu');
+            setMenuData(menuData);
+        });
+    });
+
+    $menuTableBody.on('click', '.deleteMenu', function () {
+        const row = $(this).closest('.menu-table-row');
+        const id = row.data('id');
+        confirmModal('Delete this menu?').then((ok) => {
+            if (!ok) return;
+            $.post('modules/menus/delete_menu.php', { id }, function () {
+                loadMenus();
+            });
+        });
+    });
+
+    $('#menuForm').on('submit', function (e) {
         e.preventDefault();
         const data = {
             id: $('#menuId').val(),
             name: $('#menuName').val(),
-            items: JSON.stringify(gatherItems($('#menuItems')))
+            items: JSON.stringify(gatherItems($('#menuItems'))),
         };
-        $.post('modules/menus/save_menu.php', data, function(){
-            $('#menuFormCard').hide();
-            $('#menuForm')[0].reset();
-            $('#menuItems').empty();
+        $.post('modules/menus/save_menu.php', data, function () {
+            closeMenuEditor();
             loadMenus();
         });
     });
 
-    loadPages(function(){
+    $('#menuSearchInput').on('input', function () {
+        searchTerm = $(this).val().trim().toLowerCase();
+        renderMenus();
+    });
+
+    $filterButtons.on('click', function () {
+        const $btn = $(this);
+        if ($btn.hasClass('active')) {
+            return;
+        }
+        $filterButtons.removeClass('active');
+        $btn.addClass('active');
+        activeFilter = $btn.data('menu-filter');
+        renderMenus();
+    });
+
+    $('#refreshMenusBtn').on('click', function () {
         loadMenus();
+    });
+
+    setMenuData(menuData);
+    loadPages(function () {
+        setMenuData(menuData);
+        loadMenus(false);
     });
 });

--- a/CMS/modules/menus/view.php
+++ b/CMS/modules/menus/view.php
@@ -1,42 +1,205 @@
-<!-- File: view.php -->
-                <div class="content-section" id="menus">
-                    <div class="table-card">
-                        <div class="table-header">
-                            <div class="table-title">Menus</div>
-                            <div class="table-actions">
-                                <button class="btn btn-primary" id="newMenuBtn">+ New Menu</button>
-                            </div>
-                        </div>
-                        <table class="data-table" id="menusTable">
-                            <thead>
-                                <tr>
-                                    <th>Name</th>
-                                    <th>Items</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
-                    </div>
+<?php
+// File: view.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
 
-                    <div class="form-card" id="menuFormCard" style="margin-top:20px; display:none;">
-                        <h3 id="menuFormTitle" style="margin-bottom:15px;">Add Menu</h3>
-                        <form id="menuForm">
-                            <input type="hidden" name="id" id="menuId">
-                            <div class="form-group">
-                                <label class="form-label">Name</label>
-                                <input type="text" class="form-input" name="name" id="menuName" required>
-                            </div>
-                            <div class="form-group">
-                                <label class="form-label">Items</label>
-                                <ul id="menuItems" class="menu-list"></ul>
-                                <button type="button" class="btn btn-secondary" id="addMenuItem" style="margin-top:5px;">+ Add Item</button>
-                            </div>
-                            <div style="display:flex; gap:10px;">
-                                <button type="submit" class="btn btn-primary">Save Menu</button>
-                                <button type="button" class="btn btn-secondary" id="cancelMenuEdit">Cancel</button>
-                            </div>
-                        </form>
-                    </div>
+$menusFile = __DIR__ . '/../../data/menus.json';
+$menus = read_json_file($menusFile);
+if (!is_array($menus)) {
+    $menus = [];
+}
+
+function count_menu_items_recursive(?array $items): int
+{
+    if (empty($items)) {
+        return 0;
+    }
+
+    $count = 0;
+    foreach ($items as $item) {
+        $count++;
+        if (!empty($item['children']) && is_array($item['children'])) {
+            $count += count_menu_items_recursive($item['children']);
+        }
+    }
+
+    return $count;
+}
+
+function menu_has_nested_children(?array $items): bool
+{
+    if (empty($items)) {
+        return false;
+    }
+
+    foreach ($items as $item) {
+        if (!empty($item['children']) && is_array($item['children'])) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function menu_max_depth(?array $items, int $depth = 1): int
+{
+    if (empty($items)) {
+        return $depth === 1 ? 0 : $depth - 1;
+    }
+
+    $maxDepth = $depth;
+    foreach ($items as $item) {
+        if (!empty($item['children']) && is_array($item['children'])) {
+            $maxDepth = max($maxDepth, menu_max_depth($item['children'], $depth + 1));
+        }
+    }
+
+    return $maxDepth;
+}
+
+$totalMenus = count($menus);
+$totalLinks = 0;
+$menusWithNested = 0;
+$deepestLevel = 0;
+
+foreach ($menus as $menu) {
+    $items = isset($menu['items']) && is_array($menu['items']) ? $menu['items'] : [];
+    $linkCount = count_menu_items_recursive($items);
+    $totalLinks += $linkCount;
+
+    $depth = menu_max_depth($items);
+    $deepestLevel = max($deepestLevel, $depth);
+
+    if (menu_has_nested_children($items)) {
+        $menusWithNested++;
+    }
+}
+
+$singleLevelMenus = max(0, $totalMenus - $menusWithNested);
+$averageLinks = $totalMenus > 0 ? round($totalLinks / $totalMenus, 1) : 0;
+$lastUpdated = date('M j, Y g:i A');
+
+$filterCounts = [
+    'all' => $totalMenus,
+    'nested' => $menusWithNested,
+    'single' => $singleLevelMenus,
+];
+?>
+<div class="content-section" id="menus">
+    <div class="menu-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdated, ENT_QUOTES); ?>">
+        <header class="menu-hero">
+            <div class="menu-hero-content">
+                <div>
+                    <h2 class="menu-hero-title">Navigation Menus</h2>
+                    <p class="menu-hero-subtitle">Craft intuitive navigation experiences and keep every menu in sync with your site's structure.</p>
                 </div>
+                <div class="menu-hero-actions">
+                    <button type="button" class="menu-btn menu-btn--primary" id="newMenuBtn">
+                        <i class="fas fa-plus" aria-hidden="true"></i>
+                        <span>New Menu</span>
+                    </button>
+                    <button type="button" class="menu-btn menu-btn--icon" id="refreshMenusBtn" aria-label="Refresh menus">
+                        <i class="fas fa-rotate" aria-hidden="true"></i>
+                    </button>
+                </div>
+            </div>
+            <span class="menu-hero-meta">
+                <i class="fas fa-clock" aria-hidden="true"></i>
+                Last updated: <?php echo htmlspecialchars($lastUpdated); ?>
+            </span>
+        </header>
 
+        <div class="menu-overview-grid">
+            <div class="menu-overview-card">
+                <div class="menu-overview-value" id="menuStatTotal"><?php echo $totalMenus; ?></div>
+                <div class="menu-overview-label">Total Menus</div>
+            </div>
+            <div class="menu-overview-card">
+                <div class="menu-overview-value" id="menuStatLinks"><?php echo $totalLinks; ?></div>
+                <div class="menu-overview-label">Total Links</div>
+            </div>
+            <div class="menu-overview-card">
+                <div class="menu-overview-value" id="menuStatNested"><?php echo $menusWithNested; ?></div>
+                <div class="menu-overview-label">Menus with Submenus</div>
+            </div>
+            <div class="menu-overview-card">
+                <div class="menu-overview-value" id="menuStatAverage"><?php echo $averageLinks; ?></div>
+                <div class="menu-overview-label">Average Links per Menu</div>
+            </div>
+        </div>
+
+        <div class="menu-controls">
+            <label class="menu-search" for="menuSearchInput">
+                <i class="fas fa-search" aria-hidden="true"></i>
+                <input type="search" id="menuSearchInput" placeholder="Search menus by name or link" aria-label="Search menus">
+            </label>
+            <div class="menu-filter-group" role="group" aria-label="Menu filters">
+                <button type="button" class="menu-filter-btn active" data-menu-filter="all">All Menus <span class="menu-filter-count" data-count="all"><?php echo $filterCounts['all']; ?></span></button>
+                <button type="button" class="menu-filter-btn" data-menu-filter="nested">With submenus <span class="menu-filter-count" data-count="nested"><?php echo $filterCounts['nested']; ?></span></button>
+                <button type="button" class="menu-filter-btn" data-menu-filter="single">Single level <span class="menu-filter-count" data-count="single"><?php echo $filterCounts['single']; ?></span></button>
+            </div>
+        </div>
+
+        <div class="menu-table" id="menuTable" aria-live="polite">
+            <div class="menu-table-header">
+                <div>Name</div>
+                <div>Links</div>
+                <div>Structure</div>
+                <div>Actions</div>
+            </div>
+            <div class="menu-table-body" id="menuTableBody"></div>
+        </div>
+
+        <div class="menu-empty-search" id="menuNoResults" hidden>
+            <i class="fas fa-filter" aria-hidden="true"></i>
+            <h3>No menus match your filters</h3>
+            <p>Try adjusting the search or switching to a different filter.</p>
+        </div>
+
+        <div class="menu-empty-state" id="menuEmptyState" <?php echo $totalMenus > 0 ? 'hidden' : ''; ?>>
+            <i class="fas fa-sitemap" aria-hidden="true"></i>
+            <h3>No menus yet</h3>
+            <p>Create your first navigation menu to help visitors find key pages.</p>
+            <button type="button" class="menu-btn menu-btn--primary" id="emptyStateCreateMenu">
+                <i class="fas fa-plus" aria-hidden="true"></i>
+                <span>Create Menu</span>
+            </button>
+        </div>
+    </div>
+
+    <div class="menu-editor-card" id="menuFormCard" aria-hidden="true">
+        <header class="menu-editor-header">
+            <div>
+                <h3 id="menuFormTitle">Add Menu</h3>
+                <p class="menu-editor-subtitle">Drag and drop to arrange links and nest submenus.</p>
+            </div>
+            <button type="button" class="menu-editor-close" id="closeMenuEditor" aria-label="Close menu editor">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
+        </header>
+        <form id="menuForm">
+            <input type="hidden" name="id" id="menuId">
+            <div class="form-group">
+                <label class="form-label" for="menuName">Menu Name</label>
+                <input type="text" class="form-input" name="name" id="menuName" required>
+            </div>
+            <div class="form-group">
+                <label class="form-label">Menu Items</label>
+                <p class="menu-editor-hint">Choose a page or custom URL, then drag handles to reorder or nest items.</p>
+                <ul id="menuItems" class="menu-list"></ul>
+                <button type="button" class="menu-btn menu-btn--secondary menu-btn--sm" id="addMenuItem">
+                    <i class="fas fa-plus" aria-hidden="true"></i>
+                    <span>Add Item</span>
+                </button>
+            </div>
+            <div class="menu-form-actions">
+                <button type="submit" class="menu-btn menu-btn--primary">Save Menu</button>
+                <button type="button" class="menu-btn menu-btn--ghost" id="cancelMenuEdit">Cancel</button>
+            </div>
+        </form>
+    </div>
+</div>
+<script>
+window.menuDashboardInitialData = <?php echo json_encode($menus, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
+</script>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2201,37 +2201,552 @@
             margin-bottom: 20px;
         }
 
-        .menu-item {
+        /* Menu management dashboard */
+        .menu-dashboard {
             display: flex;
-            align-items: center;
-            gap: 5px;
-            margin-bottom: 5px;
+            flex-direction: column;
+            gap: 24px;
         }
 
-        .drag-handle {
-            cursor: move;
-            padding: 0 5px;
+        .menu-hero {
+            position: relative;
+            background: linear-gradient(135deg, #0f172a, #2563eb);
+            color: #fff;
+            padding: 32px;
+            border-radius: 18px;
+            overflow: hidden;
+            box-shadow: 0 20px 46px rgba(37, 99, 235, 0.28);
+        }
+
+        .menu-hero::before {
+            content: '';
+            position: absolute;
+            top: -90px;
+            right: -90px;
+            width: 260px;
+            height: 260px;
+            background: rgba(255, 255, 255, 0.12);
+            border-radius: 50%;
+            filter: blur(0.5px);
+        }
+
+        .menu-hero-content {
+            position: relative;
+            display: flex;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: 24px;
+        }
+
+        .menu-hero-title {
+            font-size: 30px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .menu-hero-subtitle {
+            font-size: 15px;
+            max-width: 520px;
+            color: rgba(255, 255, 255, 0.86);
+        }
+
+        .menu-hero-actions {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        .menu-hero-meta {
+            margin-top: 18px;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 18px;
+            border-radius: 999px;
+            background: rgba(15, 23, 42, 0.28);
+            font-size: 13px;
+        }
+
+        .menu-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            padding: 10px 18px;
+            border-radius: 999px;
+            border: 1px solid transparent;
+            font-weight: 600;
+            font-size: 14px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            text-decoration: none;
+            background: #f1f5f9;
+            color: #1f2937;
+        }
+
+        .menu-btn i {
+            font-size: 14px;
+        }
+
+        .menu-btn:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+        }
+
+        .menu-btn--primary {
+            background: linear-gradient(135deg, #2563eb, #0ea5e9);
+            color: #fff;
+            box-shadow: 0 14px 28px rgba(37, 99, 235, 0.25);
+        }
+
+        .menu-btn--primary:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 18px 32px rgba(37, 99, 235, 0.35);
+        }
+
+        .menu-btn--secondary {
+            background: #e0f2fe;
+            color: #1d4ed8;
+        }
+
+        .menu-btn--secondary:hover {
+            background: #bae6fd;
+        }
+
+        .menu-btn--ghost {
+            background: transparent;
+            color: #1e293b;
+            border-color: #cbd5f5;
+        }
+
+        .menu-btn--ghost:hover {
+            background: #e2e8f0;
+        }
+
+        .menu-btn--danger {
+            background: #fee2e2;
+            color: #b91c1c;
+        }
+
+        .menu-btn--danger:hover {
+            background: #fecaca;
+        }
+
+        .menu-btn--icon {
+            padding: 8px 14px;
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.18);
+            color: #fff;
+        }
+
+        .menu-btn--icon:hover {
+            transform: translateY(-1px);
+        }
+
+        .menu-btn--sm {
+            padding: 8px 16px;
+            font-size: 13px;
+        }
+
+        .menu-btn.is-loading {
+            opacity: 0.65;
+            cursor: wait;
+        }
+
+        .menu-overview-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            gap: 18px;
+        }
+
+        .menu-overview-card {
+            background: rgba(255, 255, 255, 0.14);
+            border-radius: 16px;
+            padding: 18px 20px;
+            backdrop-filter: blur(6px);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+        }
+
+        .menu-overview-value {
+            font-size: 28px;
+            font-weight: 600;
+        }
+
+        .menu-overview-label {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+            opacity: 0.85;
+        }
+
+        .menu-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .menu-search {
+            position: relative;
+            flex: 1;
+            min-width: 240px;
+            max-width: 420px;
+            display: flex;
+            align-items: center;
+            background: #fff;
+            border: 1px solid #e2e8f0;
+            border-radius: 12px;
+            padding: 10px 14px;
+            gap: 10px;
+            color: #64748b;
+        }
+
+        .menu-search i {
+            font-size: 15px;
+        }
+
+        .menu-search input {
+            border: none;
+            outline: none;
+            flex: 1;
+            font-size: 14px;
+            color: #1f2937;
+        }
+
+        .menu-filter-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .menu-filter-btn {
+            border: 1px solid #cbd5f5;
+            background: #f5f7ff;
+            color: #334155;
+            padding: 8px 16px;
+            border-radius: 999px;
+            font-size: 13px;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .menu-filter-btn .menu-filter-count {
+            background: #e0e7ff;
+            border-radius: 999px;
+            padding: 2px 10px;
+            font-size: 12px;
+        }
+
+        .menu-filter-btn:hover,
+        .menu-filter-btn.active {
+            background: linear-gradient(135deg, #4338ca, #2563eb);
+            color: #fff;
+            border-color: transparent;
+        }
+
+        .menu-filter-btn:hover .menu-filter-count,
+        .menu-filter-btn.active .menu-filter-count {
+            background: rgba(255, 255, 255, 0.2);
+        }
+
+        .menu-table {
+            background: #fff;
+            border-radius: 18px;
+            box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+            border: 1px solid #e2e8f0;
+            overflow: hidden;
+        }
+
+        .menu-table-header {
+            display: grid;
+            grid-template-columns: minmax(260px, 2fr) 120px 180px 200px;
+            gap: 16px;
+            padding: 18px 24px;
+            background: #f8fafc;
+            font-size: 12px;
+            font-weight: 600;
+            color: #475569;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+        }
+
+        .menu-table-body {
+            display: flex;
+            flex-direction: column;
+        }
+
+        .menu-table-row {
+            display: grid;
+            grid-template-columns: minmax(260px, 2fr) 120px 180px 200px;
+            gap: 16px;
+            padding: 20px 24px;
+            border-top: 1px solid #f1f5f9;
+            align-items: center;
+            transition: background 0.2s ease;
+        }
+
+        .menu-table-row:hover {
+            background: #f8fafc;
+        }
+
+        .menu-table-cell {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .menu-table-cell--links {
+            align-items: center;
+        }
+
+        .menu-table-cell--structure {
+            align-items: flex-start;
+        }
+
+        .menu-table-actions {
+            flex-direction: row;
+            align-items: center;
+            justify-content: flex-end;
+            gap: 10px;
+        }
+
+        .menu-name {
             font-size: 16px;
+            font-weight: 600;
+            color: #0f172a;
+        }
+
+        .menu-preview {
+            font-size: 13px;
+            color: #64748b;
+        }
+
+        .menu-count {
+            font-size: 26px;
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        .menu-count-label {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: #94a3b8;
+        }
+
+        .menu-structure-badge {
+            display: inline-flex;
+            align-items: center;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: #e0f2fe;
+            color: #1d4ed8;
+            font-weight: 600;
+            font-size: 12px;
+        }
+
+        .menu-structure-meta {
+            font-size: 12px;
+            color: #64748b;
+        }
+
+        .menu-empty-state,
+        .menu-empty-search {
+            background: #fff;
+            border-radius: 16px;
+            border: 1px dashed #cbd5f5;
+            padding: 60px 20px;
+            text-align: center;
+            color: #475569;
+        }
+
+        .menu-empty-state i,
+        .menu-empty-search i {
+            font-size: 36px;
+            margin-bottom: 16px;
+            color: #2563eb;
+        }
+
+        .menu-empty-state h3,
+        .menu-empty-search h3 {
+            font-size: 20px;
+            margin-bottom: 8px;
+        }
+
+        .menu-empty-state p,
+        .menu-empty-search p {
+            margin-bottom: 16px;
+            color: #64748b;
+        }
+
+        .menu-editor-card {
+            display: none;
+            background: #fff;
+            border-radius: 18px;
+            padding: 28px;
+            box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+            border: 1px solid #e2e8f0;
+        }
+
+        .menu-editor-card.is-visible {
+            display: block;
+        }
+
+        .menu-editor-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            margin-bottom: 20px;
+        }
+
+        .menu-editor-subtitle {
+            margin-top: 6px;
+            color: #475569;
+            font-size: 14px;
+        }
+
+        .menu-editor-close {
+            background: #f1f5f9;
+            border: none;
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            color: #475569;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .menu-editor-close:hover {
+            background: #e2e8f0;
+        }
+
+        .menu-editor-hint {
+            margin: 8px 0 12px;
+            color: #64748b;
+            font-size: 13px;
+        }
+
+        .menu-form-actions {
+            display: flex;
+            gap: 10px;
+            margin-top: 24px;
         }
 
         .menu-list,
         .menu-list ul {
             list-style: none;
             padding-left: 0;
-        }
-
-        .menu-list li {
-            margin-bottom: 5px;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
         }
 
         .menu-list ul {
-            margin-left: 20px;
+            margin-left: 28px;
+        }
+
+        .menu-item {
+            display: flex;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: 12px;
+            padding: 12px;
+            background: #fff;
+            border: 1px solid #e2e8f0;
+            border-radius: 12px;
+            box-shadow: 0 6px 16px rgba(15, 23, 42, 0.05);
+        }
+
+        .menu-item .form-select,
+        .menu-item .form-input {
+            width: auto;
+        }
+
+        .menu-item .type-select {
+            flex: 0 0 160px;
+        }
+
+        .menu-item .page-select {
+            flex: 1 1 220px;
+        }
+
+        .menu-item .link-input {
+            flex: 1 1 220px;
+        }
+
+        .menu-item .label-input {
+            flex: 1 1 160px;
+        }
+
+        .menu-item-checkbox {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            color: #475569;
+            font-size: 13px;
+            margin-left: auto;
+        }
+
+        .menu-item-checkbox input {
+            margin: 0;
+        }
+
+        .menu-chip-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: #e0f2fe;
+            color: #1d4ed8;
+            border: none;
+            font-size: 12px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+
+        .menu-chip-btn:hover {
+            background: #bae6fd;
+        }
+
+        .menu-chip-btn--danger {
+            background: #fee2e2;
+            color: #b91c1c;
+        }
+
+        .menu-chip-btn--danger:hover {
+            background: #fecaca;
+        }
+
+        .drag-handle {
+            cursor: move;
+            font-size: 18px;
+            color: #94a3b8;
+            display: inline-flex;
+            align-items: center;
+            padding: 0 6px;
+        }
+
+        .drag-handle:hover {
+            color: #2563eb;
         }
 
         .menu-placeholder {
-            border: 1px dashed #ccc;
-            height: 38px;
-            margin-bottom: 5px;
+            border: 1px dashed #94a3b8;
+            border-radius: 12px;
+            height: 46px;
+            margin: 6px 0;
         }
 
         .form-label {


### PR DESCRIPTION
## Summary
- replace the menus module view with a dashboard-style layout that mirrors the accessibility module, including hero stats, filters, and refreshed editor controls
- update menus.js to hydrate data, render the new layout, support searching/filtering, and streamline editor interactions
- extend spark-cms.css with dedicated styling for the new menus dashboard, table, and drag-and-drop item controls

## Testing
- php -l CMS/modules/menus/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d72689734883318bf2066d37bbc26e