### PR TITLE
Restyle page settings modal to match accessibility design

### DIFF
--- a/CMS/modules/pages/pages.js
+++ b/CMS/modules/pages/pages.js
@@ -8,6 +8,7 @@ $(function(){
         const $emptyState = $('#pagesEmptyState');
         const $visibleCount = $('#pagesVisibleCount');
         let activeFilter = 'all';
+        $('#cancelEdit').hide();
 
         function openPageModal() {
             openModal('pageModal');
@@ -177,6 +178,7 @@ $(function(){
             $('#published').prop('checked', false);
             $('#content').val('');
             $('#pageTabs').tabs('option', 'active', 0);
+            $('#cancelEdit').hide();
             openPageModal();
             slugEdited = false;
         });

--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -186,82 +186,96 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
         </div>
     </div>
 
-    <div id="pageModal" class="modal">
+    <div id="pageModal" class="modal page-settings-modal" role="dialog" aria-modal="true" aria-labelledby="formTitle" aria-describedby="pageModalDescription">
         <div class="modal-content">
-            <button class="close-btn" id="closePageModal" aria-label="Close"><i class="fa-solid fa-xmark" aria-hidden="true"></i></button>
-            <div class="modal-header">
-                <div class="modal-title" id="formTitle">Add New Page</div>
+            <div class="page-modal-surface">
+                <button type="button" class="page-modal-close" id="closePageModal" aria-label="Close page settings">
+                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                </button>
+                <header class="page-modal-header">
+                    <span class="page-modal-subtitle">Page settings</span>
+                    <h2 class="page-modal-title" id="formTitle">Add New Page</h2>
+                    <p class="page-modal-description" id="pageModalDescription">Configure publishing, templates, and metadata before publishing your page.</p>
+                </header>
+                <form id="pageForm" class="page-modal-form">
+                    <input type="hidden" name="id" id="pageId">
+                    <input type="hidden" name="content" id="content">
+                    <div class="page-modal-body">
+                        <div id="pageTabs" class="page-modal-tabs">
+                            <ul>
+                                <li><a href="#tab-settings">Page Settings</a></li>
+                                <li><a href="#tab-seo">SEO Options</a></li>
+                                <li><a href="#tab-og">Social Open Graph</a></li>
+                            </ul>
+                            <div id="tab-settings" class="page-modal-panel">
+                                <div class="page-modal-grid">
+                                    <div class="form-group">
+                                        <label class="form-label" for="title">Title</label>
+                                        <input type="text" class="form-input" name="title" id="title" required>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="slug">Slug</label>
+                                        <input type="text" class="form-input" name="slug" id="slug" required>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="template">Template</label>
+                                        <select class="form-select" name="template" id="template">
+                                            <option value="page.php">page.php</option>
+                                            <?php foreach ($templates as $t): ?>
+                                            <?php if ($t !== 'page.php'): ?>
+                                            <option value="<?php echo htmlspecialchars($t); ?>"><?php echo htmlspecialchars($t); ?></option>
+                                            <?php endif; ?>
+                                            <?php endforeach; ?>
+                                        </select>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="access">Access</label>
+                                        <select class="form-select" name="access" id="access">
+                                            <option value="public">Public</option>
+                                            <option value="private">Private</option>
+                                        </select>
+                                    </div>
+                                    <div class="form-group page-modal-checkbox">
+                                        <label class="form-label" for="published">Publishing</label>
+                                        <label class="page-modal-toggle">
+                                            <input type="checkbox" name="published" id="published">
+                                            <span>Published</span>
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="tab-seo" class="page-modal-panel">
+                                <div class="form-group">
+                                    <label class="form-label" for="meta_title">Meta Title</label>
+                                    <input type="text" class="form-input" name="meta_title" id="meta_title">
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="meta_description">Meta Description</label>
+                                    <textarea class="form-textarea" name="meta_description" id="meta_description" rows="3"></textarea>
+                                </div>
+                            </div>
+                            <div id="tab-og" class="page-modal-panel">
+                                <div class="form-group">
+                                    <label class="form-label" for="og_title">OG Title</label>
+                                    <input type="text" class="form-input" name="og_title" id="og_title">
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="og_description">OG Description</label>
+                                    <textarea class="form-textarea" name="og_description" id="og_description" rows="3"></textarea>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="og_image">OG Image URL</label>
+                                    <input type="text" class="form-input" name="og_image" id="og_image">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <footer class="page-modal-footer">
+                        <button type="button" class="page-modal-button page-modal-button--secondary" id="cancelEdit">Cancel</button>
+                        <button type="submit" class="page-modal-button page-modal-button--primary">Save Page</button>
+                    </footer>
+                </form>
             </div>
-            <form id="pageForm">
-                <input type="hidden" name="id" id="pageId">
-                <input type="hidden" name="content" id="content">
-                <div id="pageTabs">
-                    <ul>
-                        <li><a href="#tab-settings">Page Settings</a></li>
-                        <li><a href="#tab-seo">SEO Options</a></li>
-                        <li><a href="#tab-og">Social Open Graph</a></li>
-                    </ul>
-                    <div id="tab-settings">
-                        <div class="form-group">
-                            <label class="form-label">Title</label>
-                            <input type="text" class="form-input" name="title" id="title" required>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Slug</label>
-                            <input type="text" class="form-input" name="slug" id="slug" required>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label"><input type="checkbox" name="published" id="published"> Published</label>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Template</label>
-                            <select class="form-select" name="template" id="template">
-                                <option value="page.php">page.php</option>
-                                <?php foreach ($templates as $t): ?>
-                                <?php if ($t !== 'page.php'): ?>
-                                <option value="<?php echo htmlspecialchars($t); ?>"><?php echo htmlspecialchars($t); ?></option>
-                                <?php endif; ?>
-                                <?php endforeach; ?>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Access</label>
-                            <select class="form-select" name="access" id="access">
-                                <option value="public">Public</option>
-                                <option value="private">Private</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div id="tab-seo">
-                        <div class="form-group">
-                            <label class="form-label">Meta Title</label>
-                            <input type="text" class="form-input" name="meta_title" id="meta_title">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">Meta Description</label>
-                            <textarea class="form-textarea" name="meta_description" id="meta_description" rows="3"></textarea>
-                        </div>
-                    </div>
-                    <div id="tab-og">
-                        <div class="form-group">
-                            <label class="form-label">OG Title</label>
-                            <input type="text" class="form-input" name="og_title" id="og_title">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">OG Description</label>
-                            <textarea class="form-textarea" name="og_description" id="og_description" rows="3"></textarea>
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label">OG Image URL</label>
-                            <input type="text" class="form-input" name="og_image" id="og_image">
-                        </div>
-                    </div>
-                </div>
-                <div style="display:flex; gap:10px; margin-top:15px;">
-                    <button type="submit" class="btn btn-primary">Save Page</button>
-                    <button type="button" class="btn btn-secondary" id="cancelEdit">Cancel</button>
-                </div>
-            </form>
         </div>
     </div>
 

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -5098,8 +5098,227 @@
 }
 
 #pageModal .modal-content {
-    min-width: 900px;
+    background: none;
+    padding: 0;
+    border-radius: 0;
     max-width: none;
+    width: auto;
+    max-height: none;
+    overflow: visible;
+}
+
+.page-modal-surface {
+    background: #ffffff;
+    border-radius: 18px;
+    width: min(720px, 92vw);
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+    padding: 32px 32px 28px;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+}
+
+.page-modal-close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    background: none;
+    border: none;
+    color: #64748b;
+    font-size: 22px;
+    cursor: pointer;
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.page-modal-close:hover,
+.page-modal-close:focus-visible {
+    background: #f1f5f9;
+    color: #1e293b;
+    outline: none;
+}
+
+.page-modal-header {
+    margin-bottom: 24px;
+}
+
+.page-modal-subtitle {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: #e0f2fe;
+    color: #0369a1;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 14px;
+}
+
+.page-modal-title {
+    margin: 0;
+    font-size: 26px;
+    line-height: 1.2;
+    color: #1e293b;
+    font-weight: 700;
+}
+
+.page-modal-description {
+    margin: 12px 0 0;
+    color: #475569;
+    font-size: 15px;
+}
+
+.page-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.page-modal-tabs .ui-tabs-nav {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin: 0;
+    padding: 0;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.page-modal-tabs .ui-tabs-nav li {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.page-modal-tabs .ui-tabs-nav li a {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 999px 999px 0 0;
+    text-decoration: none;
+    font-weight: 600;
+    color: #475569;
+    background: transparent;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.page-modal-tabs .ui-tabs-nav li a:hover {
+    background: #e2e8f0;
+}
+
+.page-modal-tabs .ui-tabs-nav li.ui-state-active a,
+.page-modal-tabs .ui-tabs-nav li.ui-tabs-active a {
+    background: #1d4ed8;
+    color: #ffffff;
+}
+
+.page-modal-panel {
+    padding-top: 20px;
+}
+
+.page-modal-panel .form-group {
+    margin-bottom: 0;
+}
+
+.page-modal-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.page-modal-checkbox {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.page-modal-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-radius: 12px;
+    border: 1px solid #e2e8f0;
+    background: #f8fafc;
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.page-modal-toggle input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+}
+
+.page-modal-footer {
+    margin-top: 28px;
+    padding-top: 20px;
+    border-top: 1px solid #e2e8f0;
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+}
+
+.page-modal-button {
+    border: none;
+    border-radius: 999px;
+    padding: 10px 22px;
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 15px;
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.page-modal-button:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: 2px;
+}
+
+.page-modal-button--secondary {
+    background: #e2e8f0;
+    color: #1e293b;
+}
+
+.page-modal-button--secondary:hover {
+    background: #cbd5f5;
+}
+
+.page-modal-button--primary {
+    background: linear-gradient(135deg, #2563eb, #1d4ed8);
+    color: #ffffff;
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+.page-modal-button--primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 16px 32px rgba(37, 99, 235, 0.28);
+}
+
+.page-modal-button--primary:active {
+    transform: translateY(0);
+    box-shadow: 0 8px 20px rgba(37, 99, 235, 0.24);
+}
+
+@media (max-width: 640px) {
+    .page-modal-surface {
+        padding: 24px 20px 20px;
+        border-radius: 16px;
+    }
+
+    .page-modal-title {
+        font-size: 22px;
+    }
+
+    .page-modal-grid {
+        grid-template-columns: 1fr;
+        gap: 16px;
+    }
 }
 
 .crop-sidebar {


### PR DESCRIPTION
## Summary
- redesign the Pages module settings modal with a header, description, and dialog semantics similar to the Accessibility modal
- apply new modal styling, responsive grid layout, and updated buttons to align the visual design with the Accessibility experience
- hide the cancel action by default and when adding a new page to keep the modal state consistent for new entries

## Testing
- php -l CMS/modules/pages/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d72aa1ae288331996cb2734ced2847