### PR TITLE
Ensure form submission activity shows submission time

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -116,13 +116,36 @@ $(function(){
 
     function formatSubmissionDate(value){
         if(!value) return 'Unknown';
+
+        function formatDate(date){
+            if(Number.isNaN(date.getTime())){
+                return null;
+            }
+            try {
+                return date.toLocaleString(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit'
+                });
+            } catch (err) {
+                return date.toString();
+            }
+        }
+
         const numeric = Number(value);
         if(!Number.isNaN(numeric) && numeric > 0){
-            return new Date(numeric * (numeric < 1e12 ? 1000 : 1)).toLocaleString();
+            const date = new Date(numeric * (numeric < 1e12 ? 1000 : 1));
+            const formatted = formatDate(date);
+            if(formatted){
+                return formatted;
+            }
         }
         const date = new Date(value);
-        if(!Number.isNaN(date.getTime())){
-            return date.toLocaleString();
+        const formatted = formatDate(date);
+        if(formatted){
+            return formatted;
         }
         return String(value);
     }


### PR DESCRIPTION
## Summary
- format submission timestamps with an explicit date/time pattern so activity lists include the time component

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d72e8873e083318ca25f5bd51836ff