### PR TITLE
Enhance activity logging details and backend events

### DIFF
--- a/CMS/modules/logs/list_logs.php
+++ b/CMS/modules/logs/list_logs.php
@@ -30,12 +30,28 @@ function slugify_action_label(string $label): string {
 foreach ($historyData as $pid => $entries) {
     foreach ($entries as $entry) {
         $actionLabel = normalize_action_label($entry['action'] ?? '');
+        $context = $entry['context'] ?? (is_numeric($pid) ? 'page' : 'system');
+        $details = $entry['details'] ?? [];
+        if (!is_array($details)) {
+            $details = $details !== '' ? [$details] : [];
+        }
+        $pageTitle = $entry['page_title'] ?? null;
+        if ($pageTitle === null) {
+            if ($context === 'system') {
+                $pageTitle = 'System activity';
+            } else {
+                $pageTitle = $pageLookup[$pid] ?? 'Unknown';
+            }
+        }
         $logs[] = [
             'time' => (int)($entry['time'] ?? 0),
             'user' => $entry['user'] ?? '',
-            'page_title' => $pageLookup[$pid] ?? 'Unknown',
+            'page_title' => $pageTitle,
             'action' => $actionLabel,
             'action_slug' => slugify_action_label($actionLabel),
+            'details' => $details,
+            'context' => $context,
+            'meta' => $entry['meta'] ?? new stdClass(),
         ];
     }
 }

--- a/CMS/modules/logs/logs.js
+++ b/CMS/modules/logs/logs.js
@@ -178,9 +178,14 @@ $(function(){
         const exact = timestamp ? new Date(timestamp * 1000).toISOString() : '';
         const absolute = formatAbsolute(timestamp);
         const relative = relativeTime(timestamp);
-        const pageTitle = log.page_title || 'Unknown';
+        const context = log.context || 'page';
+        const pageTitle = log.page_title || (context === 'system' ? 'System activity' : 'Unknown');
         const user = log.user && log.user !== '' ? log.user : 'System';
-        const searchText = (user + ' ' + pageTitle + ' ' + label).toLowerCase();
+        const details = Array.isArray(log.details) ? log.details : (log.details ? [log.details] : []);
+        const detailsHtml = details.length ? '<ul class="logs-activity-details">' + details.map(function(detail){
+            return '<li>' + escapeHtml(detail) + '</li>';
+        }).join('') + '</ul>' : '';
+        const searchText = (user + ' ' + pageTitle + ' ' + label + ' ' + details.join(' ')).toLowerCase();
 
         return (
             '<article class="logs-activity-card" data-search="' + escapeHtml(searchText) + '" data-action="' + escapeHtml(slug) + '">' +
@@ -196,6 +201,7 @@ $(function(){
                     '<span class="logs-activity-divider" aria-hidden="true">•</span>' +
                     '<span class="logs-activity-action">' + escapeHtml(label) + '</span>' +
                 '</p>' +
+                detailsHtml +
             '</article>'
         );
     }

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -521,6 +521,19 @@
             font-size: 14px;
         }
 
+        .logs-activity-details {
+            margin: 12px 0 0 18px;
+            padding: 0;
+            list-style: disc;
+            color: #475569;
+            font-size: 14px;
+        }
+
+        .logs-activity-details li {
+            margin: 4px 0;
+            line-height: 1.4;
+        }
+
         .logs-activity-user {
             font-weight: 600;
             color: #1e293b;
@@ -591,6 +604,11 @@
                 flex-direction: column;
                 align-items: flex-start;
                 gap: 4px;
+            }
+
+            .logs-activity-details {
+                margin-left: 16px;
+                font-size: 13px;
             }
 
             .logs-hero-title {

--- a/liveed/save-content.php
+++ b/liveed/save-content.php
@@ -9,6 +9,7 @@ $pages = read_json_file($pagesFile);
 
 $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
 $content = $_POST['content'] ?? '';
+$previousContent = '';
 
 if (!$id) {
     http_response_code(400);
@@ -18,6 +19,7 @@ if (!$id) {
 
 foreach ($pages as &$p) {
     if ((int)$p['id'] === $id) {
+        $previousContent = $p['content'] ?? '';
         $p['content'] = $content;
         $p['last_modified'] = time();
         $timestamp = $p['last_modified'];
@@ -27,13 +29,47 @@ foreach ($pages as &$p) {
 unset($p);
 
 $action = 'updated content';
+$oldWordCount = str_word_count(strip_tags($previousContent));
+$newWordCount = str_word_count(strip_tags($content));
+$wordDiff = $newWordCount - $oldWordCount;
+$details = [
+    'Word count: ' . $oldWordCount . ' → ' . $newWordCount . ($wordDiff === 0 ? '' : ($wordDiff > 0 ? ' (+' . $wordDiff . ')' : ' (' . $wordDiff . ')')),
+];
+$details[] = 'Characters: ' . strlen(strip_tags($previousContent)) . ' → ' . strlen(strip_tags($content));
 
 $historyFile = __DIR__ . '/../CMS/data/page_history.json';
 $historyData = read_json_file($historyFile);
 if (!isset($historyData[$id])) $historyData[$id] = [];
 $user = $_SESSION['user']['username'] ?? 'Unknown';
-$historyData[$id][] = ['time' => $timestamp, 'user' => $user, 'action' => $action];
+$historyData[$id][] = [
+    'time' => $timestamp,
+    'user' => $user,
+    'action' => $action,
+    'details' => $details,
+    'context' => 'page',
+    'page_id' => $id,
+];
 $historyData[$id] = array_slice($historyData[$id], -20);
+
+if (!isset($historyData['__system__'])) {
+    $historyData['__system__'] = [];
+}
+$historyData['__system__'][] = [
+    'time' => time(),
+    'user' => '',
+    'action' => 'Regenerated sitemap',
+    'details' => [
+        'Automatic sitemap refresh after editing content for page ID ' . $id,
+    ],
+    'context' => 'system',
+    'meta' => [
+        'trigger' => 'sitemap_regeneration',
+        'page_id' => $id,
+    ],
+    'page_title' => 'CMS Backend',
+];
+$historyData['__system__'] = array_slice($historyData['__system__'], -50);
+
 file_put_contents($historyFile, json_encode($historyData, JSON_PRETTY_PRINT));
 
 file_put_contents($pagesFile, json_encode($pages, JSON_PRETTY_PRINT));


### PR DESCRIPTION
## Summary
- enrich page history entries with field-level details for create, update, and delete actions
- surface detailed change lists in the activity timeline UI and styling updates
- record automatic sitemap refreshes as backend system activity in the logs

## Testing
- php -l CMS/modules/pages/save_page.php
- php -l liveed/save-content.php
- php -l CMS/modules/pages/delete_page.php

------
https://chatgpt.com/codex/tasks/task_e_68d732787dcc8331b03d639d414801ab