### PR TITLE
Add calendar module with recurring event management

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -58,6 +58,10 @@ $settings = get_cached_json($settingsFile);
                         <div class="nav-icon"><i class="fas fa-blog"></i></div>
                         <div class="nav-text">Blogs</div>
                     </div>
+                    <div class="nav-item" data-section="calendar">
+                        <div class="nav-icon"><i class="fas fa-calendar-days"></i></div>
+                        <div class="nav-text">Calendar</div>
+                    </div>
                 </div>
 
                 <div class="nav-section">

--- a/CMS/data/calendar_data.json
+++ b/CMS/data/calendar_data.json
@@ -1,0 +1,4 @@
+{
+    "events": [],
+    "categories": []
+}

--- a/CMS/modules/calendar/calendar.js
+++ b/CMS/modules/calendar/calendar.js
@@ -1,0 +1,534 @@
+(function ($) {
+    const container = $('#calendar');
+    if (!container.length) {
+        return;
+    }
+
+    const endpoints = {
+        manage: 'modules/calendar/manage_data.php',
+        month: 'modules/calendar/calendar_backend.php'
+    };
+
+    const timezone = 'America/Los_Angeles';
+    let dayjsLib = null;
+
+    const state = {
+        today: null,
+        currentMonth: null,
+        events: [],
+        upcoming: [],
+        categories: [],
+        rawEvents: [],
+        filters: {
+            search: '',
+            category: ''
+        }
+    };
+
+    function bootstrap() {
+        if (!window.dayjs) {
+            setTimeout(bootstrap, 50);
+            return;
+        }
+        dayjsLib = window.dayjs;
+        state.today = dayjsLib.tz ? dayjsLib().tz(timezone) : dayjsLib();
+        state.currentMonth = state.today.startOf('month');
+        bindEvents();
+        fetchData().then(function () {
+            updateMonthLabel();
+            refreshMonth();
+        });
+    }
+
+    function bindEvents() {
+        $('#calendarPrevMonth').on('click', function () {
+            state.currentMonth = state.currentMonth.subtract(1, 'month');
+            refreshMonth();
+        });
+        $('#calendarNextMonth').on('click', function () {
+            state.currentMonth = state.currentMonth.add(1, 'month');
+            refreshMonth();
+        });
+        $('.calendar-toggle-btn').on('click', function () {
+            const view = $(this).data('view');
+            $('.calendar-toggle-btn').removeClass('active');
+            $(this).addClass('active');
+            if (view === 'list') {
+                $('#calendarGridView').attr('hidden', true);
+                $('#calendarListView').removeAttr('hidden');
+            } else {
+                $('#calendarListView').attr('hidden', true);
+                $('#calendarGridView').removeAttr('hidden');
+            }
+        });
+        $('#calendarSearch').on('input', debounce(function () {
+            state.filters.search = $(this).val().trim();
+            refreshMonth();
+        }, 250));
+        $('#calendarCategoryFilter').on('change', function () {
+            state.filters.category = $(this).val();
+            refreshMonth();
+        });
+        $('#calendarNewEventBtn').on('click', function () {
+            openEventForm();
+        });
+        $('#calendarManageCategoriesBtn').on('click', function () {
+            openCategoryModal();
+        });
+        $('body').on('click', '[data-calendar-close]', function () {
+            closeModal($(this).closest('.calendar-modal'));
+        });
+        $('.calendar-modal').on('click', function (e) {
+            if ($(e.target).is('.calendar-modal')) {
+                closeModal($(this));
+            }
+        });
+        $('#calendarEventForm').on('submit', handleEventSave);
+        $('#calendarDeleteEventBtn').on('click', handleEventDelete);
+        $('#calendarCategoryForm').on('submit', handleCategorySave);
+    }
+
+    function fetchData() {
+        return $.getJSON(endpoints.manage, { action: 'fetch' })
+            .done(function (response) {
+                if (!response || response.status !== 'success') {
+                    console.error(response && response.message ? response.message : 'Unable to load calendar data');
+                    return;
+                }
+                state.categories = response.categories || [];
+                state.rawEvents = response.events || [];
+                populateCategoryOptions();
+                renderCategorySidebar();
+                updateMetrics();
+            })
+            .fail(function () {
+                console.error('Failed to load calendar data');
+            });
+    }
+
+    function refreshMonth() {
+        updateMonthLabel();
+        const params = {
+            month: state.currentMonth.month() + 1,
+            year: state.currentMonth.year()
+        };
+        if (state.filters.search) {
+            params.search = state.filters.search;
+        }
+        if (state.filters.category) {
+            params.category = state.filters.category;
+        }
+        $.getJSON(endpoints.month, params)
+            .done(function (response) {
+                if (response.status !== 'success') {
+                    console.error(response.message || 'Unable to load events');
+                    return;
+                }
+                state.events = response.events || [];
+                state.upcoming = response.upcoming || buildUpcoming(state.events);
+                renderCalendar();
+                renderList();
+                renderUpcoming();
+                updateMetrics(response.meta);
+            })
+            .fail(function () {
+                console.error('Unable to fetch month events');
+            });
+    }
+
+    function updateMonthLabel() {
+        $('#calendarCurrentMonth').text(state.currentMonth.format('MMMM YYYY'));
+    }
+
+    function renderCalendar() {
+        const grid = $('#calendarGrid');
+        grid.empty();
+        const firstDayOfMonth = state.currentMonth.startOf('month');
+        const daysInMonth = state.currentMonth.daysInMonth();
+        const startWeekday = firstDayOfMonth.day();
+        const today = state.today.startOf('day');
+
+        for (let i = 0; i < startWeekday; i++) {
+            grid.append('<div class="calendar-cell calendar-cell--empty" role="presentation"></div>');
+        }
+
+        for (let day = 1; day <= daysInMonth; day++) {
+            const date = firstDayOfMonth.date(day);
+            const cell = $('<div>', {
+                class: 'calendar-cell',
+                role: 'gridcell',
+                'data-date': date.format('YYYY-MM-DD')
+            });
+            const header = $('<div>', { class: 'calendar-cell__header' });
+            const label = $('<span>', { text: day, class: 'calendar-cell__day' });
+            if (date.isSame(today, 'day')) {
+                cell.addClass('calendar-cell--today');
+                label.attr('aria-label', 'Today');
+            }
+            header.append(label);
+            cell.append(header);
+
+            const eventsForDay = state.events.filter(function (event) {
+                return dayjsLib(event.start).isSame(date, 'day');
+            });
+
+            const eventList = $('<div>', { class: 'calendar-cell__events' });
+            eventsForDay.forEach(function (event) {
+                const eventItem = $('<button>', {
+                    type: 'button',
+                    class: 'calendar-event-chip',
+                    text: event.title,
+                    css: {
+                        backgroundColor: event.category && event.category.color ? event.category.color : '#2563eb'
+                    }
+                }).on('click', function () {
+                    openEventDetail(event);
+                });
+                eventList.append(eventItem);
+            });
+
+            cell.append(eventList);
+            grid.append(cell);
+        }
+    }
+
+    function renderList() {
+        const list = $('#calendarList');
+        list.empty();
+        if (!state.events.length) {
+            list.append('<p class="calendar-empty">No events scheduled for this period.</p>');
+            return;
+        }
+        const sorted = state.events.slice().sort(function (a, b) {
+            return dayjsLib(a.start).diff(dayjsLib(b.start));
+        });
+        sorted.forEach(function (event) {
+            const item = $('<article>', { class: 'calendar-list__item' });
+            const header = $('<header>', { class: 'calendar-list__item-header' });
+            const title = $('<h4>', { text: event.title });
+            if (event.category) {
+                const badge = $('<span>', {
+                    class: 'calendar-category-badge',
+                    text: event.category.name || 'Category'
+                }).css('background-color', event.category.color || '#2563eb');
+                header.append(badge);
+            }
+            header.append(title);
+            item.append(header);
+            const meta = $('<p>', {
+                class: 'calendar-event__meta',
+                text: formatEventRange(event)
+            });
+            item.append(meta);
+            if (event.description) {
+                item.append($('<p>', { text: event.description }));
+            }
+            const actions = $('<div>', { class: 'calendar-list__actions' });
+            $('<button>', {
+                type: 'button',
+                class: 'calendar-btn calendar-btn--ghost',
+                text: 'View details'
+            }).on('click', function () {
+                openEventDetail(event);
+            }).appendTo(actions);
+            $('<button>', {
+                type: 'button',
+                class: 'calendar-btn calendar-btn--ghost',
+                text: 'Edit'
+            }).on('click', function () {
+                openEventForm(event.sourceId);
+            }).appendTo(actions);
+            item.append(actions);
+            list.append(item);
+        });
+    }
+
+    function renderUpcoming() {
+        const container = $('#calendarUpcomingList');
+        container.empty();
+        if (!state.upcoming.length) {
+            container.append('<li class="calendar-empty">No upcoming events</li>');
+            return;
+        }
+        state.upcoming.slice(0, 6).forEach(function (event) {
+            const item = $('<li>');
+            const title = $('<div>', { class: 'calendar-upcoming__title', text: event.title });
+            const date = $('<div>', { class: 'calendar-upcoming__date', text: formatEventRange(event) });
+            if (event.category) {
+                const dot = $('<span>', { class: 'calendar-upcoming__dot' }).css('background-color', event.category.color || '#2563eb');
+                title.prepend(dot);
+            }
+            item.append(title, date);
+            item.on('click', function () {
+                openEventDetail(event);
+            });
+            container.append(item);
+        });
+    }
+
+    function renderCategorySidebar() {
+        const list = $('#calendarCategoryList');
+        list.empty();
+        if (!state.categories.length) {
+            list.append('<li class="calendar-empty">No categories yet</li>');
+            return;
+        }
+        state.categories.forEach(function (category) {
+            const item = $('<li>');
+            const marker = $('<span>', { class: 'calendar-category__marker' }).css('background-color', category.color || '#2563eb');
+            item.append(marker).append($('<span>', { text: category.name }));
+            list.append(item);
+        });
+    }
+
+    function populateCategoryOptions() {
+        const selectFilter = $('#calendarCategoryFilter');
+        const selectForm = $('#calendarEventCategory');
+        selectFilter.find('option:not(:first)').remove();
+        selectForm.find('option:not(:first)').remove();
+        state.categories.forEach(function (category) {
+            const option = $('<option>', { value: category.id, text: category.name });
+            selectFilter.append(option.clone());
+            selectForm.append(option.clone());
+        });
+    }
+
+    function formatEventRange(event) {
+        const start = dayjsLib(event.start);
+        const end = dayjsLib(event.end);
+        if (event.allDay) {
+            if (start.isSame(end, 'day')) {
+                return start.format('dddd, MMMM D');
+            }
+            return start.format('MMM D') + ' – ' + end.format('MMM D');
+        }
+        if (start.isSame(end, 'day')) {
+            return start.format('MMM D, h:mm A') + ' – ' + end.format('h:mm A');
+        }
+        return start.format('MMM D, h:mm A') + ' – ' + end.format('MMM D, h:mm A');
+    }
+
+    function openEventDetail(event) {
+        $('#calendarEventDetailTitle').text(event.title);
+        $('#calendarEventDetailDescription').text(event.description || '');
+        $('#calendarEventDetailTime').text(formatEventRange(event));
+        if (event.category) {
+            const category = $('<span>', {
+                class: 'calendar-category-badge',
+                text: event.category.name
+            }).css('background-color', event.category.color || '#2563eb');
+            $('#calendarEventDetailCategory').empty().append(category);
+        } else {
+            $('#calendarEventDetailCategory').text('No category');
+        }
+        $('#calendarEventDetailGoogle').attr('href', buildGoogleCalendarLink(event));
+        openModal($('#calendarEventDetailModal'));
+    }
+
+    function openEventForm(eventId) {
+        const formElement = $('#calendarEventForm')[0];
+        formElement.reset();
+        $('#calendarEventId').val('');
+        $('#calendarEventRecurrenceInterval').val('1');
+        $('#calendarDeleteEventBtn').prop('hidden', true).removeData('eventId');
+        $('#calendarEventFormTitle').text(eventId ? 'Edit event' : 'New event');
+
+        if (eventId) {
+            const event = state.rawEvents.find(function (item) { return item.id === eventId; });
+            if (event) {
+                $('#calendarEventId').val(event.id);
+                $('#calendarEventTitle').val(event.title);
+                $('#calendarEventDescription').val(event.description || '');
+                $('#calendarEventStartDate').val(event.start_date);
+                $('#calendarEventStartTime').val(event.start_time || '');
+                $('#calendarEventEndDate').val(event.end_date);
+                $('#calendarEventEndTime').val(event.end_time || '');
+                $('#calendarEventAllDay').prop('checked', !!event.all_day);
+                $('#calendarEventCategory').val(event.category_id || '');
+                $('#calendarEventRecurrenceType').val(event.recurrence && event.recurrence.type ? event.recurrence.type : 'none');
+                $('#calendarEventRecurrenceInterval').val(event.recurrence && event.recurrence.interval ? event.recurrence.interval : 1);
+                $('#calendarEventRecurrenceEnd').val(event.recurrence && event.recurrence.end_date ? event.recurrence.end_date : '');
+                $('#calendarDeleteEventBtn').prop('hidden', false).data('eventId', event.id);
+            }
+        }
+        openModal($('#calendarEventFormModal'));
+    }
+
+    function handleEventSave(e) {
+        e.preventDefault();
+        const form = $(this);
+        const data = form.serialize();
+        $.ajax({
+            url: endpoints.manage,
+            method: 'POST',
+            data: data,
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.status !== 'success') {
+                alert(response.message || 'Unable to save event');
+                return;
+            }
+            closeModal($('#calendarEventFormModal'));
+            fetchData().then(refreshMonth);
+        }).fail(function () {
+            alert('Unable to save event.');
+        });
+    }
+
+    function handleEventDelete() {
+        const eventId = $(this).data('eventId');
+        if (!eventId) {
+            return;
+        }
+        if (!confirm('Delete this event?')) {
+            return;
+        }
+        $.ajax({
+            url: endpoints.manage,
+            method: 'POST',
+            data: { action: 'delete_event', id: eventId },
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.status !== 'success') {
+                alert(response.message || 'Unable to delete event');
+                return;
+            }
+            closeModal($('#calendarEventFormModal'));
+            fetchData().then(refreshMonth);
+        }).fail(function () {
+            alert('Unable to delete event.');
+        });
+    }
+
+    function openCategoryModal() {
+        $('#calendarCategoryForm')[0].reset();
+        $('#calendarCategoryId').val('');
+        renderCategoryManager();
+        openModal($('#calendarCategoryModal'));
+    }
+
+    function renderCategoryManager() {
+        const list = $('#calendarCategoryManagerList');
+        list.empty();
+        if (!state.categories.length) {
+            list.append('<li class="calendar-empty">No categories created yet.</li>');
+            return;
+        }
+        state.categories.forEach(function (category) {
+            const item = $('<li>', { class: 'calendar-category-manager__item' });
+            $('<span>', { class: 'calendar-category__marker' }).css('background-color', category.color || '#2563eb').appendTo(item);
+            $('<span>', { class: 'calendar-category-manager__name', text: category.name }).appendTo(item);
+            const actions = $('<div>', { class: 'calendar-category-manager__actions' });
+            $('<button>', { type: 'button', text: 'Edit', class: 'calendar-btn calendar-btn--ghost' })
+                .on('click', function () {
+                    $('#calendarCategoryId').val(category.id);
+                    $('#calendarCategoryName').val(category.name);
+                    $('#calendarCategoryColor').val(category.color || '#2563eb');
+                }).appendTo(actions);
+            $('<button>', { type: 'button', text: 'Delete', class: 'calendar-btn calendar-btn--ghost' })
+                .on('click', function () {
+                    if (!confirm('Delete this category? Events will keep their color but lose this label.')) {
+                        return;
+                    }
+                    $.ajax({
+                        url: endpoints.manage,
+                        method: 'POST',
+                        data: { action: 'delete_category', id: category.id },
+                        dataType: 'json'
+                    }).done(function (response) {
+                        if (response.status !== 'success') {
+                            alert(response.message || 'Unable to delete category');
+                            return;
+                        }
+                        fetchData().then(function () {
+                            renderCategoryManager();
+                            refreshMonth();
+                        });
+                    }).fail(function () {
+                        alert('Unable to delete category.');
+                    });
+                }).appendTo(actions);
+            item.append(actions);
+            list.append(item);
+        });
+    }
+
+    function handleCategorySave(e) {
+        e.preventDefault();
+        const data = $(this).serialize();
+        $.ajax({
+            url: endpoints.manage,
+            method: 'POST',
+            data: data,
+            dataType: 'json'
+        }).done(function (response) {
+            if (response.status !== 'success') {
+                alert(response.message || 'Unable to save category');
+                return;
+            }
+            $('#calendarCategoryId').val('');
+            $('#calendarCategoryName').val('');
+            fetchData().then(function () {
+                renderCategoryManager();
+                refreshMonth();
+            });
+        }).fail(function () {
+            alert('Unable to save category.');
+        });
+    }
+
+    function buildUpcoming(events) {
+        const today = state.today.startOf('day');
+        return events.filter(function (event) {
+            const start = dayjsLib(event.start);
+            return start.isAfter(today) || start.isSame(today, 'day');
+        }).sort(function (a, b) {
+            return dayjsLib(a.start).diff(dayjsLib(b.start));
+        });
+    }
+
+    function openModal(modal) {
+        modal.attr('aria-hidden', 'false').addClass('open');
+    }
+
+    function closeModal(modal) {
+        modal.attr('aria-hidden', 'true').removeClass('open');
+    }
+
+    function updateMetrics(meta) {
+        if (meta) {
+            $('#calendarMetricMonth').text(meta.eventsThisMonth || 0);
+            $('#calendarMetricCampaigns').text(meta.recurringSeries || 0);
+            $('#calendarMetricCategories').text(meta.categories ?? state.categories.length ?? 0);
+            $('#calendarMetricUpdated').text(meta.lastUpdated || dayjsLib().format('MMM D, YYYY h:mm A'));
+        } else {
+            $('#calendarMetricCategories').text(state.categories.length);
+        }
+    }
+
+    function buildGoogleCalendarLink(event) {
+        const format = 'YYYYMMDD[T]HHmmss';
+        const start = event.allDay
+            ? dayjsLib(event.start).format('YYYYMMDD')
+            : dayjsLib(event.start).tz ? dayjsLib(event.start).tz(timezone).format(format) : dayjsLib(event.start).format(format);
+        const end = event.allDay
+            ? dayjsLib(event.end).add(1, 'day').format('YYYYMMDD')
+            : dayjsLib(event.end).tz ? dayjsLib(event.end).tz(timezone).format(format) : dayjsLib(event.end).format(format);
+        const text = encodeURIComponent(event.title || 'Event');
+        const details = encodeURIComponent(event.description || '');
+        return `https://calendar.google.com/calendar/r/eventedit?text=${text}&details=${details}&dates=${start}/${end}&ctz=${encodeURIComponent(timezone)}`;
+    }
+
+    function debounce(fn, wait) {
+        let timeout;
+        return function () {
+            const args = arguments;
+            clearTimeout(timeout);
+            timeout = setTimeout(function () {
+                fn.apply(null, args);
+            }, wait);
+        };
+    }
+
+    bootstrap();
+})(jQuery);

--- a/CMS/modules/calendar/calendar_backend.php
+++ b/CMS/modules/calendar/calendar_backend.php
@@ -1,0 +1,248 @@
+<?php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
+
+date_default_timezone_set('America/Los_Angeles');
+
+$dataFile = __DIR__ . '/../../data/calendar_data.json';
+$data = read_json_file($dataFile);
+$events = isset($data['events']) && is_array($data['events']) ? $data['events'] : [];
+$categories = isset($data['categories']) && is_array($data['categories']) ? $data['categories'] : [];
+
+$month = isset($_GET['month']) ? (int) $_GET['month'] : (int) date('n');
+$year = isset($_GET['year']) ? (int) $_GET['year'] : (int) date('Y');
+$search = isset($_GET['search']) ? trim((string) $_GET['search']) : '';
+$categoryFilter = isset($_GET['category']) ? trim((string) $_GET['category']) : '';
+
+if ($month < 1 || $month > 12) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid month.']);
+    exit;
+}
+
+if ($year < 1970 || $year > 2100) {
+    http_response_code(400);
+    echo json_encode(['status' => 'error', 'message' => 'Invalid year.']);
+    exit;
+}
+
+$monthStart = new DateTimeImmutable(sprintf('%04d-%02d-01 00:00:00', $year, $month));
+$monthEnd = $monthStart->modify('first day of next month');
+$upcomingStart = (new DateTimeImmutable('now'))->setTime(0, 0, 0);
+$upcomingEnd = $upcomingStart->modify('+30 days');
+
+$categoryMap = [];
+foreach ($categories as $category) {
+    if (!is_array($category) || empty($category['id'])) {
+        continue;
+    }
+    $categoryMap[$category['id']] = [
+        'id' => $category['id'],
+        'name' => $category['name'] ?? 'Category',
+        'color' => $category['color'] ?? '#2563eb'
+    ];
+}
+
+$searchLower = $search !== '' ? mb_strtolower($search) : '';
+$results = [];
+$upcoming = [];
+$recurringSeries = 0;
+
+foreach ($events as $event) {
+    if (!is_array($event) || empty($event['id']) || empty($event['title'])) {
+        continue;
+    }
+    $recurrenceType = normalize_recurrence_type($event['recurrence']['type'] ?? ($event['recurrence_type'] ?? 'none'));
+    if ($recurrenceType !== 'none') {
+        $recurringSeries++;
+    }
+
+    if ($categoryFilter !== '' && (!isset($event['category_id']) || $event['category_id'] !== $categoryFilter)) {
+        continue;
+    }
+
+    if ($searchLower !== '') {
+        $haystack = mb_strtolower(($event['title'] ?? '') . ' ' . ($event['description'] ?? ''));
+        if (strpos($haystack, $searchLower) === false) {
+            continue;
+        }
+    }
+
+    $category = null;
+    if (!empty($event['category_id']) && isset($categoryMap[$event['category_id']])) {
+        $category = $categoryMap[$event['category_id']];
+    }
+
+    $occurrences = generate_occurrences($event, $monthStart, $monthEnd, $category, $recurrenceType);
+    $results = array_merge($results, $occurrences);
+
+    // Build upcoming list regardless of filter window but still respecting filters
+    $upcomingOccurrences = generate_occurrences($event, $upcomingStart, $upcomingEnd, $category, $recurrenceType);
+    if ($upcomingOccurrences) {
+        $upcoming = array_merge($upcoming, $upcomingOccurrences);
+    }
+}
+
+usort($results, static function ($a, $b) {
+    return strcmp($a['start'], $b['start']);
+});
+
+usort($upcoming, static function ($a, $b) {
+    return strcmp($a['start'], $b['start']);
+});
+
+$meta = [
+    'eventsThisMonth' => count($results),
+    'recurringSeries' => $recurringSeries,
+    'categories' => count($categoryMap),
+    'lastUpdated' => date('M j, Y g:i A')
+];
+
+echo json_encode([
+    'status' => 'success',
+    'events' => $results,
+    'upcoming' => array_slice($upcoming, 0, 10),
+    'meta' => $meta
+]);
+exit;
+
+function generate_occurrences(array $event, DateTimeImmutable $rangeStart, DateTimeImmutable $rangeEnd, ?array $category, string $recurrenceType): array
+{
+    $base = normalize_event_dates($event);
+    if (!$base) {
+        return [];
+    }
+    [$start, $end, $allDay] = $base;
+    $duration = max(60, $end->getTimestamp() - $start->getTimestamp());
+
+    $occurrences = [];
+    $interval = max(1, (int) ($event['recurrence']['interval'] ?? 1));
+    $recurrenceEnd = !empty($event['recurrence']['end_date'])
+        ? DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $event['recurrence']['end_date'] . ' 23:59:59')
+        : null;
+
+    $id = $event['id'];
+    $title = $event['title'];
+    $description = $event['description'] ?? '';
+
+    $limit = min_date($rangeEnd, $recurrenceEnd);
+
+    if ($recurrenceType === 'none') {
+        if (date_ranges_overlap($start, $end, $rangeStart, $rangeEnd)) {
+            $occurrences[] = format_occurrence($id, $start, $end, $title, $description, $category, $allDay, $event, $recurrenceType, $interval, $recurrenceEnd);
+        }
+        return $occurrences;
+    }
+
+    $intervalSpec = build_interval_spec($recurrenceType, $interval);
+    if (!$intervalSpec) {
+        return $occurrences;
+    }
+    $periodInterval = new DateInterval($intervalSpec);
+    $periodEnd = ($limit ?? $rangeEnd)->modify('+1 day');
+    $period = new DatePeriod($start, $periodInterval, $periodEnd);
+    $count = 0;
+    foreach ($period as $occurrenceStart) {
+        if ($recurrenceEnd && $occurrenceStart > $recurrenceEnd) {
+            break;
+        }
+        $occurrenceEnd = $occurrenceStart->modify('+' . $duration . ' seconds');
+        if (!date_ranges_overlap($occurrenceStart, $occurrenceEnd, $rangeStart, $rangeEnd)) {
+            if ($occurrenceEnd <= $rangeStart) {
+                continue;
+            }
+            if ($occurrenceStart >= $rangeEnd) {
+                break;
+            }
+        }
+        $occurrences[] = format_occurrence($id, $occurrenceStart, $occurrenceEnd, $title, $description, $category, $allDay, $event, $recurrenceType, $interval, $recurrenceEnd);
+        $count++;
+        if ($count >= 500) {
+            break;
+        }
+    }
+
+    return $occurrences;
+}
+
+function normalize_event_dates(array $event): ?array
+{
+    $allDay = !empty($event['all_day']);
+    $startDate = $event['start_date'] ?? '';
+    $endDate = $event['end_date'] ?? $startDate;
+    $startTime = $allDay ? '00:00' : ($event['start_time'] ?? '00:00');
+    $endTime = $allDay ? '23:59' : ($event['end_time'] ?? $startTime);
+
+    $start = DateTimeImmutable::createFromFormat('Y-m-d H:i', $startDate . ' ' . $startTime);
+    $end = DateTimeImmutable::createFromFormat('Y-m-d H:i', $endDate . ' ' . $endTime);
+
+    if (!$start) {
+        return null;
+    }
+    if (!$end || $end < $start) {
+        $end = $start->modify('+1 hour');
+    }
+
+    if ($allDay) {
+        $start = $start->setTime(0, 0, 0);
+        $end = $end->setTime(23, 59, 59);
+    }
+
+    return [$start, $end, $allDay];
+}
+
+function format_occurrence(string $id, DateTimeImmutable $start, DateTimeImmutable $end, string $title, string $description, ?array $category, bool $allDay, array $event, string $recurrenceType, int $interval, ?DateTimeImmutable $recurrenceEnd): array
+{
+    $occurrenceId = $id . '_' . $start->format('YmdHis');
+    return [
+        'id' => $occurrenceId,
+        'sourceId' => $id,
+        'title' => $title,
+        'description' => $description,
+        'start' => $start->format(DateTime::ATOM),
+        'end' => $end->format(DateTime::ATOM),
+        'allDay' => $allDay,
+        'category' => $category,
+        'recurrence' => [
+            'type' => $recurrenceType,
+            'interval' => $interval,
+            'endDate' => $recurrenceEnd ? $recurrenceEnd->format('Y-m-d') : null
+        ]
+    ];
+}
+
+function build_interval_spec(string $type, int $interval): ?string
+{
+    switch ($type) {
+        case 'daily':
+            return 'P' . $interval . 'D';
+        case 'weekly':
+            return 'P' . ($interval * 7) . 'D';
+        case 'monthly':
+            return 'P' . $interval . 'M';
+        case 'yearly':
+            return 'P' . $interval . 'Y';
+        default:
+            return null;
+    }
+}
+
+function min_date(DateTimeImmutable $a, ?DateTimeImmutable $b): DateTimeImmutable
+{
+    if (!$b) {
+        return $a;
+    }
+    return $a < $b ? $a : $b;
+}
+
+function date_ranges_overlap(DateTimeImmutable $startA, DateTimeImmutable $endA, DateTimeImmutable $startB, DateTimeImmutable $endB): bool
+{
+    return $startA < $endB && $endA > $startB;
+}
+
+function normalize_recurrence_type(string $type): string
+{
+    $type = strtolower(trim($type));
+    return in_array($type, ['daily', 'weekly', 'monthly', 'yearly'], true) ? $type : 'none';
+}

--- a/CMS/modules/calendar/manage_data.php
+++ b/CMS/modules/calendar/manage_data.php
@@ -1,0 +1,297 @@
+<?php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
+require_login();
+
+date_default_timezone_set('America/Los_Angeles');
+
+$dataFile = __DIR__ . '/../../data/calendar_data.json';
+$data = read_json_file($dataFile);
+if (!isset($data['events']) || !is_array($data['events'])) {
+    $data['events'] = [];
+}
+if (!isset($data['categories']) || !is_array($data['categories'])) {
+    $data['categories'] = [];
+}
+
+$action = $_REQUEST['action'] ?? 'fetch';
+
+switch ($action) {
+    case 'fetch':
+        respond_success([
+            'events' => array_values(array_map('format_event_for_response', $data['events'])),
+            'categories' => array_values(array_map('format_category_for_response', $data['categories']))
+        ]);
+        break;
+
+    case 'save_event':
+        $result = save_event($data);
+        if ($result['status'] === 'success') {
+            write_calendar_data($dataFile, $data);
+        }
+        respond_json($result);
+        break;
+
+    case 'delete_event':
+        $result = delete_event($data);
+        if ($result['status'] === 'success') {
+            write_calendar_data($dataFile, $data);
+        }
+        respond_json($result);
+        break;
+
+    case 'save_category':
+        $result = save_category($data);
+        if ($result['status'] === 'success') {
+            write_calendar_data($dataFile, $data);
+        }
+        respond_json($result);
+        break;
+
+    case 'delete_category':
+        $result = delete_category($data);
+        if ($result['status'] === 'success') {
+            write_calendar_data($dataFile, $data);
+        }
+        respond_json($result);
+        break;
+
+    default:
+        respond_error('Unsupported action.');
+}
+
+function save_event(array &$data): array
+{
+    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
+    $title = sanitize_text($_POST['title'] ?? '');
+    $description = trim((string) ($_POST['description'] ?? ''));
+    $startDate = trim((string) ($_POST['start_date'] ?? ''));
+    $endDate = trim((string) ($_POST['end_date'] ?? ''));
+    $startTime = trim((string) ($_POST['start_time'] ?? ''));
+    $endTime = trim((string) ($_POST['end_time'] ?? ''));
+    $allDay = !empty($_POST['all_day']);
+    $categoryId = sanitize_text($_POST['category_id'] ?? '');
+    $recurrenceType = sanitize_text($_POST['recurrence_type'] ?? 'none');
+    $recurrenceInterval = isset($_POST['recurrence_interval']) ? (int) $_POST['recurrence_interval'] : 1;
+    $recurrenceEndDate = trim((string) ($_POST['recurrence_end_date'] ?? ''));
+
+    if ($title === '') {
+        return ['status' => 'error', 'message' => 'Title is required.'];
+    }
+    if ($startDate === '' || $endDate === '') {
+        return ['status' => 'error', 'message' => 'Start and end dates are required.'];
+    }
+
+    $allowedRecurrence = ['none', 'daily', 'weekly', 'monthly', 'yearly'];
+    if (!in_array($recurrenceType, $allowedRecurrence, true)) {
+        $recurrenceType = 'none';
+    }
+    if ($recurrenceType === 'none') {
+        $recurrenceInterval = 1;
+        $recurrenceEndDate = '';
+    } else {
+        $recurrenceInterval = max(1, $recurrenceInterval);
+    }
+
+    if ($allDay) {
+        $startTime = '00:00';
+        $endTime = '23:59';
+    } else {
+        if ($startTime === '') {
+            $startTime = '00:00';
+        }
+        if ($endTime === '') {
+            $endTime = $startTime;
+        }
+    }
+
+    $start = DateTimeImmutable::createFromFormat('Y-m-d H:i', $startDate . ' ' . $startTime);
+    $end = DateTimeImmutable::createFromFormat('Y-m-d H:i', $endDate . ' ' . $endTime);
+    if (!$start || !$end) {
+        return ['status' => 'error', 'message' => 'Invalid dates provided.'];
+    }
+    if ($end < $start) {
+        $end = $start->modify('+1 hour');
+        $endDate = $end->format('Y-m-d');
+        $endTime = $allDay ? '23:59' : $end->format('H:i');
+    }
+
+    $eventData = [
+        'id' => $id !== '' ? $id : uniqid('evt_', true),
+        'title' => $title,
+        'description' => $description,
+        'start_date' => $startDate,
+        'start_time' => $allDay ? null : $startTime,
+        'end_date' => $endDate,
+        'end_time' => $allDay ? null : $endTime,
+        'all_day' => $allDay,
+        'category_id' => $categoryId !== '' ? $categoryId : null,
+        'recurrence' => [
+            'type' => $recurrenceType,
+            'interval' => $recurrenceInterval,
+            'end_date' => $recurrenceEndDate !== '' ? $recurrenceEndDate : null
+        ],
+        'updated_at' => date(DateTime::ATOM)
+    ];
+
+    $found = false;
+    foreach ($data['events'] as &$event) {
+        if (isset($event['id']) && $event['id'] === $eventData['id']) {
+            $event = $eventData;
+            $found = true;
+            break;
+        }
+    }
+    unset($event);
+
+    if (!$found) {
+        $data['events'][] = $eventData;
+    }
+
+    return ['status' => 'success', 'event' => format_event_for_response($eventData)];
+}
+
+function delete_event(array &$data): array
+{
+    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
+    if ($id === '') {
+        return ['status' => 'error', 'message' => 'Missing event id.'];
+    }
+
+    $initialCount = count($data['events']);
+    $data['events'] = array_values(array_filter($data['events'], static function ($event) use ($id) {
+        return !is_array($event) || ($event['id'] ?? null) !== $id;
+    }));
+
+    if (count($data['events']) === $initialCount) {
+        return ['status' => 'error', 'message' => 'Event not found.'];
+    }
+
+    return ['status' => 'success'];
+}
+
+function save_category(array &$data): array
+{
+    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
+    $name = sanitize_text($_POST['name'] ?? '');
+    $color = trim((string) ($_POST['color'] ?? ''));
+
+    if ($name === '') {
+        return ['status' => 'error', 'message' => 'Category name is required.'];
+    }
+
+    if ($color === '' || !preg_match('/^#([0-9a-fA-F]{6})$/', $color)) {
+        $color = '#2563eb';
+    }
+
+    $categoryData = [
+        'id' => $id !== '' ? $id : uniqid('cat_', true),
+        'name' => $name,
+        'color' => $color,
+        'updated_at' => date(DateTime::ATOM)
+    ];
+
+    $found = false;
+    foreach ($data['categories'] as &$category) {
+        if (isset($category['id']) && $category['id'] === $categoryData['id']) {
+            $category = $categoryData;
+            $found = true;
+            break;
+        }
+    }
+    unset($category);
+
+    if (!$found) {
+        $data['categories'][] = $categoryData;
+    }
+
+    return ['status' => 'success', 'category' => format_category_for_response($categoryData)];
+}
+
+function delete_category(array &$data): array
+{
+    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
+    if ($id === '') {
+        return ['status' => 'error', 'message' => 'Missing category id.'];
+    }
+
+    $initialCount = count($data['categories']);
+    $data['categories'] = array_values(array_filter($data['categories'], static function ($category) use ($id) {
+        return !is_array($category) || ($category['id'] ?? null) !== $id;
+    }));
+
+    if (count($data['categories']) === $initialCount) {
+        return ['status' => 'error', 'message' => 'Category not found.'];
+    }
+
+    foreach ($data['events'] as &$event) {
+        if (isset($event['category_id']) && $event['category_id'] === $id) {
+            $event['category_id'] = null;
+        }
+    }
+    unset($event);
+
+    return ['status' => 'success'];
+}
+
+function write_calendar_data(string $file, array $data): void
+{
+    write_json_file($file, [
+        'events' => array_values($data['events']),
+        'categories' => array_values($data['categories'])
+    ]);
+}
+
+function format_event_for_response($event): array
+{
+    if (!is_array($event)) {
+        return [];
+    }
+    return [
+        'id' => $event['id'] ?? '',
+        'title' => $event['title'] ?? '',
+        'description' => $event['description'] ?? '',
+        'start_date' => $event['start_date'] ?? '',
+        'start_time' => $event['start_time'] ?? '',
+        'end_date' => $event['end_date'] ?? '',
+        'end_time' => $event['end_time'] ?? '',
+        'all_day' => !empty($event['all_day']),
+        'category_id' => $event['category_id'] ?? '',
+        'recurrence' => [
+            'type' => $event['recurrence']['type'] ?? 'none',
+            'interval' => $event['recurrence']['interval'] ?? 1,
+            'end_date' => $event['recurrence']['end_date'] ?? null
+        ],
+        'updated_at' => $event['updated_at'] ?? null
+    ];
+}
+
+function format_category_for_response($category): array
+{
+    if (!is_array($category)) {
+        return [];
+    }
+    return [
+        'id' => $category['id'] ?? '',
+        'name' => $category['name'] ?? '',
+        'color' => $category['color'] ?? '#2563eb',
+        'updated_at' => $category['updated_at'] ?? null
+    ];
+}
+
+function respond_success(array $payload = []): void
+{
+    respond_json(['status' => 'success'] + $payload);
+}
+
+function respond_error(string $message): void
+{
+    respond_json(['status' => 'error', 'message' => $message]);
+}
+
+function respond_json(array $payload): void
+{
+    header('Content-Type: application/json');
+    echo json_encode($payload);
+}

--- a/CMS/modules/calendar/view.php
+++ b/CMS/modules/calendar/view.php
@@ -1,0 +1,261 @@
+<?php
+require_once __DIR__ . '/../../includes/auth.php';
+require_login();
+
+date_default_timezone_set('America/Los_Angeles');
+?>
+<div class="content-section" id="calendar">
+    <div class="calendar-dashboard" data-timezone="America/Los_Angeles">
+        <header class="calendar-hero">
+            <div class="calendar-hero__content">
+                <div>
+                    <h2 class="calendar-hero__title">Events &amp; Campaign Calendar</h2>
+                    <p class="calendar-hero__subtitle">Plan launches, keep teams aligned, and give stakeholders a single source of truth for every upcoming milestone.</p>
+                </div>
+                <div class="calendar-hero__actions">
+                    <button type="button" class="calendar-btn calendar-btn--ghost" id="calendarManageCategoriesBtn">
+                        <i class="fa-solid fa-palette" aria-hidden="true"></i>
+                        <span>Manage categories</span>
+                    </button>
+                    <button type="button" class="calendar-btn calendar-btn--primary" id="calendarNewEventBtn">
+                        <i class="fa-solid fa-plus" aria-hidden="true"></i>
+                        <span>New event</span>
+                    </button>
+                </div>
+            </div>
+            <dl class="calendar-hero__metrics">
+                <div>
+                    <dt>Events this month</dt>
+                    <dd id="calendarMetricMonth">0</dd>
+                </div>
+                <div>
+                    <dt>Scheduled campaigns</dt>
+                    <dd id="calendarMetricCampaigns">0</dd>
+                </div>
+                <div>
+                    <dt>Categories</dt>
+                    <dd id="calendarMetricCategories">0</dd>
+                </div>
+                <div>
+                    <dt>Last updated</dt>
+                    <dd id="calendarMetricUpdated">Just now</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="calendar-controls" aria-label="Calendar controls">
+            <div class="calendar-controls__primary">
+                <div class="calendar-month-nav" role="group" aria-label="Month navigation">
+                    <button type="button" id="calendarPrevMonth" class="calendar-icon-btn" aria-label="Previous month">
+                        <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
+                    </button>
+                    <div class="calendar-month-label" id="calendarCurrentMonth">Month YYYY</div>
+                    <button type="button" id="calendarNextMonth" class="calendar-icon-btn" aria-label="Next month">
+                        <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+                    </button>
+                </div>
+                <div class="calendar-view-toggle" role="group" aria-label="View mode">
+                    <button type="button" class="calendar-toggle-btn active" data-view="grid">Calendar</button>
+                    <button type="button" class="calendar-toggle-btn" data-view="list">List</button>
+                </div>
+            </div>
+            <div class="calendar-controls__filters">
+                <label class="calendar-search" for="calendarSearch">
+                    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                    <input type="search" id="calendarSearch" placeholder="Search events, launches, campaigns" aria-label="Search events">
+                </label>
+                <label class="calendar-filter">
+                    <span>Category</span>
+                    <select id="calendarCategoryFilter">
+                        <option value="">All categories</option>
+                    </select>
+                </label>
+            </div>
+        </section>
+
+        <div class="calendar-layout">
+            <section class="calendar-view" id="calendarGridView" aria-label="Calendar view">
+                <div class="calendar-weekdays" role="row">
+                    <span role="columnheader">Sun</span>
+                    <span role="columnheader">Mon</span>
+                    <span role="columnheader">Tue</span>
+                    <span role="columnheader">Wed</span>
+                    <span role="columnheader">Thu</span>
+                    <span role="columnheader">Fri</span>
+                    <span role="columnheader">Sat</span>
+                </div>
+                <div class="calendar-grid" id="calendarGrid" role="grid" aria-live="polite"></div>
+            </section>
+
+            <section class="calendar-list" id="calendarListView" aria-label="List view" hidden>
+                <header class="calendar-list__header">
+                    <h3>Timeline</h3>
+                    <p>Every event across categories in chronological order.</p>
+                </header>
+                <div class="calendar-list__container" id="calendarList"></div>
+            </section>
+        </div>
+
+        <aside class="calendar-sidebar">
+            <section class="calendar-upcoming">
+                <header>
+                    <h3>Next up</h3>
+                    <p>Upcoming milestones over the next 30 days.</p>
+                </header>
+                <ul id="calendarUpcomingList" class="calendar-upcoming__list"></ul>
+            </section>
+            <section class="calendar-categories">
+                <header>
+                    <h3>Categories</h3>
+                    <p>Color-coded tags applied to calendar entries.</p>
+                </header>
+                <ul id="calendarCategoryList"></ul>
+            </section>
+        </aside>
+    </div>
+</div>
+
+<div class="calendar-modal" id="calendarEventDetailModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="calendar-modal__content">
+        <header class="calendar-modal__header">
+            <h2 id="calendarEventDetailTitle">Event</h2>
+            <button type="button" class="calendar-modal__close" data-calendar-close>
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
+        </header>
+        <div class="calendar-modal__body">
+            <p class="calendar-event__meta" id="calendarEventDetailTime"></p>
+            <p class="calendar-event__category" id="calendarEventDetailCategory"></p>
+            <p id="calendarEventDetailDescription"></p>
+            <a href="#" target="_blank" rel="noopener" id="calendarEventDetailGoogle" class="calendar-btn calendar-btn--ghost">
+                <i class="fa-brands fa-google" aria-hidden="true"></i>
+                <span>Add to Google Calendar</span>
+            </a>
+        </div>
+    </div>
+</div>
+
+<div class="calendar-modal" id="calendarEventFormModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="calendar-modal__content">
+        <header class="calendar-modal__header">
+            <h2 id="calendarEventFormTitle">New event</h2>
+            <button type="button" class="calendar-modal__close" data-calendar-close>
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
+        </header>
+        <form id="calendarEventForm" class="calendar-form">
+            <input type="hidden" name="action" value="save_event">
+            <input type="hidden" name="id" id="calendarEventId">
+            <div class="calendar-form__group">
+                <label for="calendarEventTitle">Title *</label>
+                <input type="text" id="calendarEventTitle" name="title" required>
+            </div>
+            <div class="calendar-form__group">
+                <label for="calendarEventDescription">Description</label>
+                <textarea id="calendarEventDescription" name="description" rows="4"></textarea>
+            </div>
+            <div class="calendar-form__row">
+                <div class="calendar-form__group">
+                    <label for="calendarEventStartDate">Start date *</label>
+                    <input type="date" id="calendarEventStartDate" name="start_date" required>
+                </div>
+                <div class="calendar-form__group">
+                    <label for="calendarEventStartTime">Start time</label>
+                    <input type="time" id="calendarEventStartTime" name="start_time">
+                </div>
+            </div>
+            <div class="calendar-form__row">
+                <div class="calendar-form__group">
+                    <label for="calendarEventEndDate">End date *</label>
+                    <input type="date" id="calendarEventEndDate" name="end_date" required>
+                </div>
+                <div class="calendar-form__group">
+                    <label for="calendarEventEndTime">End time</label>
+                    <input type="time" id="calendarEventEndTime" name="end_time">
+                </div>
+            </div>
+            <div class="calendar-form__group calendar-form__checkbox">
+                <input type="checkbox" id="calendarEventAllDay" name="all_day" value="1">
+                <label for="calendarEventAllDay">All day event</label>
+            </div>
+            <div class="calendar-form__group">
+                <label for="calendarEventCategory">Category</label>
+                <select id="calendarEventCategory" name="category_id">
+                    <option value="">No category</option>
+                </select>
+            </div>
+            <fieldset class="calendar-form__fieldset">
+                <legend>Recurrence</legend>
+                <div class="calendar-form__row">
+                    <div class="calendar-form__group">
+                        <label for="calendarEventRecurrenceType">Pattern</label>
+                        <select id="calendarEventRecurrenceType" name="recurrence_type">
+                            <option value="none">Does not repeat</option>
+                            <option value="daily">Daily</option>
+                            <option value="weekly">Weekly</option>
+                            <option value="monthly">Monthly</option>
+                            <option value="yearly">Yearly</option>
+                        </select>
+                    </div>
+                    <div class="calendar-form__group">
+                        <label for="calendarEventRecurrenceInterval">Interval</label>
+                        <input type="number" min="1" value="1" id="calendarEventRecurrenceInterval" name="recurrence_interval">
+                    </div>
+                </div>
+                <div class="calendar-form__group">
+                    <label for="calendarEventRecurrenceEnd">Ends</label>
+                    <input type="date" id="calendarEventRecurrenceEnd" name="recurrence_end_date">
+                    <p class="calendar-form__help">Leave blank for no end date.</p>
+                </div>
+            </fieldset>
+            <div class="calendar-form__actions">
+                <button type="button" class="calendar-btn calendar-btn--danger" id="calendarDeleteEventBtn" hidden>Delete</button>
+                <button type="button" class="calendar-btn calendar-btn--ghost" data-calendar-close>Cancel</button>
+                <button type="submit" class="calendar-btn calendar-btn--primary">Save event</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="calendar-modal" id="calendarCategoryModal" role="dialog" aria-modal="true" aria-hidden="true">
+    <div class="calendar-modal__content">
+        <header class="calendar-modal__header">
+            <h2>Manage categories</h2>
+            <button type="button" class="calendar-modal__close" data-calendar-close>
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
+        </header>
+        <div class="calendar-modal__body">
+            <form id="calendarCategoryForm" class="calendar-form calendar-form--compact">
+                <input type="hidden" name="action" value="save_category">
+                <input type="hidden" name="id" id="calendarCategoryId">
+                <div class="calendar-form__row">
+                    <div class="calendar-form__group">
+                        <label for="calendarCategoryName">Name *</label>
+                        <input type="text" id="calendarCategoryName" name="name" required>
+                    </div>
+                    <div class="calendar-form__group">
+                        <label for="calendarCategoryColor">Color</label>
+                        <input type="color" id="calendarCategoryColor" name="color" value="#2563eb">
+                    </div>
+                </div>
+                <div class="calendar-form__actions">
+                    <button type="submit" class="calendar-btn calendar-btn--primary">Save category</button>
+                </div>
+            </form>
+            <ul id="calendarCategoryManagerList" class="calendar-category-manager"></ul>
+        </div>
+    </div>
+</div>
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flatpickr/4.6.13/flatpickr.min.css" integrity="sha512-5mP4QjPRqCMgfHdCqkfNNpJBWlAbIYW/W2PASi6DPd7OJbRRqtD9h5pz50jdK5Zk90unfG0KBPXn1HULICwhfA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.10/dayjs.min.js" integrity="sha512-6wZveHFkNjEcNWef39MF4R2tQeM+c/fi91tIbp/BK+f5pFwchAuC8W9jAq56k97X3CJidb8sRP/6IDdnh3oX2w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.10/plugin/utc.min.js" integrity="sha512-7DcKJ2YMBX1IzBgE4c3OJbGdv8ImZ/Sc7VcRbP5t6dv3Vv4Y20N6l0e6QF6UVx/FuWRzE7dDzIvmhjYQdkWXug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dayjs/1.11.10/plugin/timezone.min.js" integrity="sha512-rP0iDL49myyQeF1P0uohsEiL41Z8nfdXbra+XUl3Bd6mVTRu6YQPGVE3d2rYZRk5v0zzakDx4zY/boYYGr2susg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+if (window.dayjs) {
+    dayjs.extend(window.dayjs_plugin_utc);
+    dayjs.extend(window.dayjs_plugin_timezone);
+    dayjs.tz.setDefault('America/Los_Angeles');
+}
+</script>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -6448,3 +6448,544 @@
     text-align: center;
     padding: 20px;
 }
+
+/* Calendar module */
+#calendar .calendar-dashboard {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 32px;
+    align-items: start;
+}
+
+#calendar .calendar-hero {
+    background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
+    color: #fff;
+    padding: 32px;
+    border-radius: 24px;
+    margin-bottom: 32px;
+    box-shadow: 0 24px 40px -24px rgba(37, 99, 235, 0.6);
+}
+
+#calendar .calendar-hero__content {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+}
+
+#calendar .calendar-hero__title {
+    font-size: 28px;
+    font-weight: 700;
+}
+
+#calendar .calendar-hero__subtitle {
+    margin-top: 8px;
+    max-width: 520px;
+    font-size: 16px;
+    opacity: 0.9;
+}
+
+#calendar .calendar-hero__actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+#calendar .calendar-hero__metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 16px;
+    margin-top: 28px;
+}
+
+#calendar .calendar-hero__metrics dt {
+    font-size: 13px;
+    text-transform: uppercase;
+    opacity: 0.75;
+}
+
+#calendar .calendar-hero__metrics dd {
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.calendar-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    font-weight: 600;
+    padding: 10px 18px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.calendar-btn i {
+    font-size: 14px;
+}
+
+.calendar-btn--primary {
+    background: #fff;
+    color: #1d4ed8;
+    box-shadow: 0 14px 24px -18px rgba(255, 255, 255, 0.9);
+}
+
+.calendar-btn--ghost {
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.25);
+}
+
+.calendar-btn--danger {
+    background: #fee2e2;
+    color: #b91c1c;
+    border-color: #fecaca;
+}
+
+.calendar-btn:hover {
+    transform: translateY(-1px);
+}
+
+.calendar-controls {
+    background: #fff;
+    border-radius: 20px;
+    padding: 24px;
+    margin-bottom: 24px;
+    box-shadow: 0 18px 34px -28px rgba(15, 23, 42, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.calendar-controls__primary,
+.calendar-controls__filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+}
+
+.calendar-month-nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    border-radius: 12px;
+    padding: 6px 12px;
+    background: #f1f5f9;
+}
+
+.calendar-icon-btn {
+    background: transparent;
+    border: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #1d4ed8;
+    cursor: pointer;
+}
+
+.calendar-month-label {
+    font-weight: 600;
+    font-size: 16px;
+}
+
+.calendar-view-toggle {
+    display: inline-flex;
+    border-radius: 999px;
+    background: #eff6ff;
+    padding: 4px;
+}
+
+.calendar-toggle-btn {
+    border: none;
+    background: transparent;
+    border-radius: 999px;
+    padding: 8px 16px;
+    font-weight: 600;
+    color: #1e293b;
+    cursor: pointer;
+}
+
+.calendar-toggle-btn.active {
+    background: #1d4ed8;
+    color: #fff;
+    box-shadow: 0 10px 20px -16px rgba(37, 99, 235, 0.6);
+}
+
+.calendar-search {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    background: #f8fafc;
+    border-radius: 14px;
+    border: 1px solid #e2e8f0;
+}
+
+.calendar-search input {
+    border: none;
+    background: transparent;
+    min-width: 220px;
+    outline: none;
+}
+
+.calendar-filter {
+    display: flex;
+    flex-direction: column;
+    font-size: 13px;
+    font-weight: 600;
+    color: #475569;
+}
+
+.calendar-filter select {
+    margin-top: 4px;
+    padding: 8px 12px;
+    border-radius: 10px;
+    border: 1px solid #dbeafe;
+    background: #fff;
+}
+
+.calendar-layout {
+    background: #fff;
+    border-radius: 24px;
+    padding: 24px;
+    box-shadow: 0 18px 32px -28px rgba(15, 23, 42, 0.35);
+}
+
+.calendar-weekdays,
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.calendar-weekdays span {
+    text-align: center;
+    font-weight: 600;
+    color: #64748b;
+    padding: 8px 0;
+}
+
+.calendar-grid {
+    gap: 6px;
+    margin-top: 12px;
+}
+
+.calendar-cell {
+    background: #f8fafc;
+    border-radius: 16px;
+    min-height: 120px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid transparent;
+}
+
+.calendar-cell--empty {
+    background: transparent;
+    border: none;
+}
+
+.calendar-cell--today {
+    border-color: #2563eb;
+    background: #eff6ff;
+}
+
+.calendar-cell__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.calendar-cell__day {
+    font-weight: 700;
+}
+
+.calendar-cell__events {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.calendar-event-chip {
+    border: none;
+    border-radius: 10px;
+    padding: 6px 10px;
+    color: #fff;
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.calendar-list {
+    margin-top: 24px;
+}
+
+.calendar-list__header {
+    border-bottom: 1px solid #e2e8f0;
+    padding-bottom: 12px;
+    margin-bottom: 16px;
+}
+
+.calendar-list__container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.calendar-list__item {
+    background: #f8fafc;
+    border-radius: 16px;
+    padding: 16px;
+    border: 1px solid #e2e8f0;
+}
+
+.calendar-list__item-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.calendar-category-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    color: #fff;
+    font-weight: 600;
+}
+
+.calendar-list__actions {
+    margin-top: 12px;
+    display: flex;
+    gap: 8px;
+}
+
+.calendar-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.calendar-upcoming,
+.calendar-categories {
+    background: #fff;
+    border-radius: 20px;
+    padding: 20px;
+    box-shadow: 0 18px 28px -28px rgba(15, 23, 42, 0.3);
+}
+
+.calendar-upcoming__list,
+.calendar-category-list,
+.calendar-category-manager {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.calendar-upcoming__list li {
+    padding: 12px 0;
+    border-bottom: 1px solid #e2e8f0;
+    cursor: pointer;
+}
+
+.calendar-upcoming__list li:last-child {
+    border-bottom: none;
+}
+
+.calendar-upcoming__title {
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.calendar-upcoming__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.calendar-category__marker {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 10px;
+}
+
+.calendar-empty {
+    color: #94a3b8;
+    font-size: 14px;
+    padding: 12px 0;
+}
+
+.calendar-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 2000;
+}
+
+.calendar-modal.open {
+    display: flex;
+}
+
+.calendar-modal__content {
+    background: #fff;
+    border-radius: 20px;
+    width: min(640px, 100%);
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: 0 28px 48px -28px rgba(15, 23, 42, 0.45);
+}
+
+.calendar-modal__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.calendar-modal__body {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.calendar-modal__close {
+    border: none;
+    background: transparent;
+    font-size: 20px;
+    cursor: pointer;
+    color: #475569;
+}
+
+.calendar-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.calendar-form__row {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.calendar-form__group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+}
+
+.calendar-form__group input,
+.calendar-form__group textarea,
+.calendar-form__group select {
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid #dbeafe;
+    font-size: 14px;
+}
+
+.calendar-form__checkbox {
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+}
+
+.calendar-form__fieldset {
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    padding: 16px;
+}
+
+.calendar-form__help {
+    font-size: 12px;
+    color: #64748b;
+}
+
+.calendar-form__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.calendar-form--compact .calendar-form__row {
+    flex-direction: column;
+}
+
+.calendar-category-manager {
+    margin-top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.calendar-category-manager__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #f8fafc;
+    border-radius: 12px;
+    padding: 12px 16px;
+    border: 1px solid #e2e8f0;
+}
+
+.calendar-category-manager__actions {
+    display: flex;
+    gap: 8px;
+}
+
+@media (max-width: 1200px) {
+    #calendar .calendar-dashboard {
+        grid-template-columns: 1fr;
+    }
+
+    .calendar-sidebar {
+        order: -1;
+        flex-direction: row;
+        gap: 16px;
+        flex-wrap: wrap;
+    }
+
+    .calendar-sidebar > section {
+        flex: 1 1 240px;
+    }
+}
+
+@media (max-width: 768px) {
+    .calendar-controls__primary,
+    .calendar-controls__filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .calendar-layout {
+        padding: 16px;
+    }
+
+    .calendar-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .calendar-weekdays {
+        display: none;
+    }
+}


### PR DESCRIPTION
## Summary
- add a calendar navigation entry and create an empty data store for events and categories
- implement a fully featured calendar admin module with calendar/list views, event modals, and category management UI
- build PHP back-end endpoints to persist events, categories, and generate recurring instances, plus module-specific styling

## Testing
- php -l CMS/modules/calendar/calendar_backend.php
- php -l CMS/modules/calendar/manage_data.php

------
https://chatgpt.com/codex/tasks/task_e_68d73426657883318ee07e952a2ab8c9