### PR TITLE
Add front-end calendar block and public feed

### DIFF
--- a/CMS/modules/calendar/calendar_helpers.php
+++ b/CMS/modules/calendar/calendar_helpers.php
@@ -1,0 +1,146 @@
+<?php
+// Shared helper functions for calendar data processing.
+// Extracted to support both administrative and front-end calendar endpoints.
+
+declare(strict_types=1);
+
+function generate_occurrences(array $event, DateTimeImmutable $rangeStart, DateTimeImmutable $rangeEnd, ?array $category, string $recurrenceType): array
+{
+    $base = normalize_event_dates($event);
+    if (!$base) {
+        return [];
+    }
+    [$start, $end, $allDay] = $base;
+    $duration = max(60, $end->getTimestamp() - $start->getTimestamp());
+
+    $occurrences = [];
+    $interval = max(1, (int) ($event['recurrence']['interval'] ?? 1));
+    $recurrenceEnd = !empty($event['recurrence']['end_date'])
+        ? DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $event['recurrence']['end_date'] . ' 23:59:59')
+        : null;
+
+    $id = $event['id'];
+    $title = $event['title'];
+    $description = $event['description'] ?? '';
+
+    $limit = min_date($rangeEnd, $recurrenceEnd);
+
+    if ($recurrenceType === 'none') {
+        if (date_ranges_overlap($start, $end, $rangeStart, $rangeEnd)) {
+            $occurrences[] = format_occurrence($id, $start, $end, $title, $description, $category, $allDay, $event, $recurrenceType, $interval, $recurrenceEnd);
+        }
+        return $occurrences;
+    }
+
+    $intervalSpec = build_interval_spec($recurrenceType, $interval);
+    if (!$intervalSpec) {
+        return $occurrences;
+    }
+
+    $periodInterval = new DateInterval($intervalSpec);
+    $periodEnd = ($limit ?? $rangeEnd)->modify('+1 day');
+    $period = new DatePeriod($start, $periodInterval, $periodEnd);
+    $count = 0;
+    foreach ($period as $occurrenceStart) {
+        if ($recurrenceEnd && $occurrenceStart > $recurrenceEnd) {
+            break;
+        }
+        $occurrenceEnd = $occurrenceStart->modify('+' . $duration . ' seconds');
+        if (!date_ranges_overlap($occurrenceStart, $occurrenceEnd, $rangeStart, $rangeEnd)) {
+            if ($occurrenceEnd <= $rangeStart) {
+                continue;
+            }
+            if ($occurrenceStart >= $rangeEnd) {
+                break;
+            }
+        }
+        $occurrences[] = format_occurrence($id, $occurrenceStart, $occurrenceEnd, $title, $description, $category, $allDay, $event, $recurrenceType, $interval, $recurrenceEnd);
+        $count++;
+        if ($count >= 500) {
+            break;
+        }
+    }
+
+    return $occurrences;
+}
+
+function normalize_event_dates(array $event): ?array
+{
+    $allDay = !empty($event['all_day']);
+    $startDate = $event['start_date'] ?? '';
+    $endDate = $event['end_date'] ?? $startDate;
+    $startTime = $allDay ? '00:00' : ($event['start_time'] ?? '00:00');
+    $endTime = $allDay ? '23:59' : ($event['end_time'] ?? $startTime);
+
+    $start = DateTimeImmutable::createFromFormat('Y-m-d H:i', $startDate . ' ' . $startTime);
+    $end = DateTimeImmutable::createFromFormat('Y-m-d H:i', $endDate . ' ' . $endTime);
+
+    if (!$start) {
+        return null;
+    }
+    if (!$end || $end < $start) {
+        $end = $start->modify('+1 hour');
+    }
+
+    if ($allDay) {
+        $start = $start->setTime(0, 0, 0);
+        $end = $end->setTime(23, 59, 59);
+    }
+
+    return [$start, $end, $allDay];
+}
+
+function format_occurrence(string $id, DateTimeImmutable $start, DateTimeImmutable $end, string $title, string $description, ?array $category, bool $allDay, array $event, string $recurrenceType, int $interval, ?DateTimeImmutable $recurrenceEnd): array
+{
+    $occurrenceId = $id . '_' . $start->format('YmdHis');
+    return [
+        'id' => $occurrenceId,
+        'sourceId' => $id,
+        'title' => $title,
+        'description' => $description,
+        'start' => $start->format(DateTime::ATOM),
+        'end' => $end->format(DateTime::ATOM),
+        'allDay' => $allDay,
+        'category' => $category,
+        'recurrence' => [
+            'type' => $recurrenceType,
+            'interval' => $interval,
+            'endDate' => $recurrenceEnd ? $recurrenceEnd->format('Y-m-d') : null,
+        ],
+    ];
+}
+
+function build_interval_spec(string $type, int $interval): ?string
+{
+    switch ($type) {
+        case 'daily':
+            return 'P' . $interval . 'D';
+        case 'weekly':
+            return 'P' . ($interval * 7) . 'D';
+        case 'monthly':
+            return 'P' . $interval . 'M';
+        case 'yearly':
+            return 'P' . $interval . 'Y';
+        default:
+            return null;
+    }
+}
+
+function min_date(DateTimeImmutable $a, ?DateTimeImmutable $b): DateTimeImmutable
+{
+    if (!$b) {
+        return $a;
+    }
+    return $a < $b ? $a : $b;
+}
+
+function date_ranges_overlap(DateTimeImmutable $startA, DateTimeImmutable $endA, DateTimeImmutable $startB, DateTimeImmutable $endB): bool
+{
+    return $startA < $endB && $endA > $startB;
+}
+
+function normalize_recurrence_type(string $type): string
+{
+    $type = strtolower(trim($type));
+    return in_array($type, ['daily', 'weekly', 'monthly', 'yearly'], true) ? $type : 'none';
+}

--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -1204,3 +1204,478 @@ section.container-fluid {
 .spark-form-status {
     min-height: 1.5rem;
 }
+
+/* Calendar Widget Styles */
+.calendar-block {
+    position: relative;
+    margin: 60px 0;
+}
+
+.calendar-widget {
+    background: transparent;
+}
+
+.calendar-widget .calendar-dashboard {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 32px;
+    align-items: start;
+}
+
+.calendar-widget .calendar-hero {
+    background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
+    color: #fff;
+    padding: 32px;
+    border-radius: 24px;
+    margin-bottom: 32px;
+    box-shadow: 0 24px 40px -24px rgba(37, 99, 235, 0.6);
+}
+
+.calendar-widget .calendar-hero__content {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+}
+
+.calendar-widget .calendar-hero__eyebrow {
+    letter-spacing: 0.08em;
+    font-size: 13px;
+    font-weight: 600;
+    opacity: 0.9;
+}
+
+.calendar-widget .calendar-hero__title {
+    font-size: 28px;
+    font-weight: 700;
+}
+
+.calendar-widget .calendar-hero__subtitle {
+    margin-top: 8px;
+    max-width: 520px;
+    font-size: 16px;
+    opacity: 0.9;
+}
+
+.calendar-widget .calendar-hero__metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 16px;
+    margin-top: 28px;
+}
+
+.calendar-widget .calendar-hero__metrics dt {
+    font-size: 13px;
+    text-transform: uppercase;
+    opacity: 0.75;
+}
+
+.calendar-widget .calendar-hero__metrics dd {
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.calendar-controls {
+    background: #fff;
+    border-radius: 20px;
+    padding: 24px;
+    margin-bottom: 24px;
+    box-shadow: 0 18px 34px -28px rgba(15, 23, 42, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.calendar-controls__primary,
+.calendar-controls__filters {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+}
+
+.calendar-month-nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    border-radius: 12px;
+    padding: 6px 12px;
+    background: #f1f5f9;
+}
+
+.calendar-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    border: none;
+    background: #2563eb;
+    color: #fff;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-icon-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px -12px rgba(37, 99, 235, 0.6);
+}
+
+.calendar-month-label {
+    font-weight: 600;
+    font-size: 18px;
+}
+
+.calendar-view-toggle {
+    display: inline-flex;
+    background: #f8fafc;
+    border-radius: 12px;
+    padding: 4px;
+    gap: 6px;
+}
+
+.calendar-toggle-btn {
+    border: none;
+    background: transparent;
+    padding: 8px 14px;
+    border-radius: 10px;
+    font-weight: 600;
+    color: #475569;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.calendar-toggle-btn.active,
+.calendar-toggle-btn:hover {
+    background: #2563eb;
+    color: #fff;
+    transform: translateY(-1px);
+}
+
+.calendar-search,
+.calendar-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: #f8fafc;
+    padding: 10px 14px;
+    border-radius: 12px;
+    border: 1px solid #e2e8f0;
+    min-width: 220px;
+}
+
+.calendar-search input,
+.calendar-filter select {
+    border: none;
+    background: transparent;
+    outline: none;
+    width: 100%;
+    font-size: 14px;
+}
+
+.calendar-layout {
+    background: #fff;
+    border-radius: 24px;
+    box-shadow: 0 28px 48px -32px rgba(15, 23, 42, 0.35);
+    padding: 24px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 24px;
+}
+
+.calendar-weekdays,
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 8px;
+}
+
+.calendar-weekdays span {
+    font-size: 13px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #94a3b8;
+    text-align: center;
+}
+
+.calendar-grid {
+    margin-top: 12px;
+}
+
+.calendar-cell {
+    background: #f8fafc;
+    border-radius: 16px;
+    padding: 12px;
+    min-height: 120px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border: 1px solid transparent;
+    transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-cell--empty {
+    background: transparent;
+    border: none;
+    min-height: auto;
+}
+
+.calendar-cell--today {
+    border-color: #2563eb;
+    box-shadow: 0 16px 28px -24px rgba(37, 99, 235, 0.6);
+}
+
+.calendar-cell__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.calendar-cell__events {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: auto;
+}
+
+.calendar-event-chip {
+    border: none;
+    border-radius: 10px;
+    padding: 6px 10px;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+    background: #2563eb;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-event-chip:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 20px -16px rgba(37, 99, 235, 0.5);
+}
+
+.calendar-list {
+    background: #f8fafc;
+    border-radius: 18px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.calendar-list__header h3 {
+    font-size: 18px;
+    margin-bottom: 6px;
+}
+
+.calendar-list__header p {
+    color: #64748b;
+    margin: 0;
+}
+
+.calendar-list__container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.calendar-list__item {
+    background: #fff;
+    border-radius: 14px;
+    padding: 16px;
+    border: 1px solid #e2e8f0;
+    display: grid;
+    gap: 12px;
+}
+
+.calendar-list__item-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.calendar-category-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(37, 99, 235, 0.08);
+    color: #1d4ed8;
+}
+
+.calendar-category-badge::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+}
+
+.calendar-list__actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.calendar-sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.calendar-sidebar > section {
+    background: #f8fafc;
+    border-radius: 18px;
+    padding: 24px;
+    border: 1px solid #e2e8f0;
+}
+
+.calendar-sidebar h3 {
+    font-size: 18px;
+    margin-bottom: 4px;
+}
+
+.calendar-sidebar p {
+    color: #64748b;
+    margin-bottom: 16px;
+}
+
+.calendar-upcoming__list,
+.calendar-category-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.calendar-upcoming__list li {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    font-size: 14px;
+    color: #1f2937;
+}
+
+.calendar-upcoming__title {
+    font-weight: 600;
+}
+
+.calendar-upcoming__dot,
+.calendar-category__marker {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-top: 4px;
+}
+
+.calendar-category__marker {
+    display: inline-block;
+    margin-right: 8px;
+}
+
+.calendar-empty {
+    font-size: 15px;
+    color: #64748b;
+}
+
+.calendar-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 1050;
+}
+
+.calendar-modal.open {
+    display: flex;
+}
+
+.calendar-modal__content {
+    background: #fff;
+    border-radius: 20px;
+    max-width: 520px;
+    width: 100%;
+    box-shadow: 0 40px 70px -40px rgba(15, 23, 42, 0.55);
+    overflow: hidden;
+}
+
+.calendar-modal__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 24px;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.calendar-modal__body {
+    padding: 24px;
+    display: grid;
+    gap: 12px;
+    font-size: 15px;
+    color: #1f2937;
+}
+
+.calendar-modal__close {
+    border: none;
+    background: transparent;
+    font-size: 20px;
+    cursor: pointer;
+    color: #475569;
+}
+
+@media (max-width: 1200px) {
+    .calendar-widget .calendar-dashboard {
+        grid-template-columns: 1fr;
+    }
+
+    .calendar-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .calendar-sidebar {
+        flex-direction: row;
+        gap: 16px;
+        flex-wrap: wrap;
+    }
+
+    .calendar-sidebar > section {
+        flex: 1 1 240px;
+    }
+}
+
+@media (max-width: 768px) {
+    .calendar-controls__primary,
+    .calendar-controls__filters {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .calendar-layout {
+        padding: 16px;
+    }
+
+    .calendar-weekdays {
+        display: none;
+    }
+
+    .calendar-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}

--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -707,6 +707,694 @@
     });
   }
 
+  var calendarStates = new WeakMap();
+
+  function debounce(fn, wait) {
+    var timeoutId;
+    return function () {
+      var context = this;
+      var args = arguments;
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(function () {
+        fn.apply(context, args);
+      }, wait);
+    };
+  }
+
+  function resolvedTimeZone() {
+    try {
+      var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      return typeof tz === 'string' && tz ? tz : 'UTC';
+    } catch (err) {
+      return 'UTC';
+    }
+  }
+
+  function normalizeTimezone(value) {
+    if (typeof value !== 'string') {
+      return resolvedTimeZone();
+    }
+    var trimmed = value.trim();
+    if (!trimmed) {
+      return resolvedTimeZone();
+    }
+    try {
+      new Intl.DateTimeFormat(undefined, { timeZone: trimmed });
+      return trimmed;
+    } catch (err) {
+      return resolvedTimeZone();
+    }
+  }
+
+  function startOfDay(date) {
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  function startOfMonth(date) {
+    return new Date(date.getFullYear(), date.getMonth(), 1);
+  }
+
+  function addMonths(date, amount) {
+    return new Date(date.getFullYear(), date.getMonth() + amount, 1);
+  }
+
+  function dateKey(date) {
+    var year = date.getFullYear();
+    var month = String(date.getMonth() + 1).padStart(2, '0');
+    var day = String(date.getDate()).padStart(2, '0');
+    return year + '-' + month + '-' + day;
+  }
+
+  function formatMonthLabel(date, timezone) {
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        month: 'long',
+        year: 'numeric',
+        timeZone: timezone,
+      }).format(date);
+    } catch (err) {
+      return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+    }
+  }
+
+  function normalizeEvents(list) {
+    if (!Array.isArray(list)) {
+      return [];
+    }
+    return list
+      .map(function (item) {
+        if (!item || !item.start) {
+          return null;
+        }
+        var start = new Date(item.start);
+        if (isNaN(start.getTime())) {
+          return null;
+        }
+        var end = item.end ? new Date(item.end) : new Date(start.getTime());
+        if (isNaN(end.getTime())) {
+          end = new Date(start.getTime());
+        }
+        var category = null;
+        if (item.category && typeof item.category === 'object') {
+          category = {
+            id: item.category.id ? String(item.category.id) : '',
+            name: item.category.name || '',
+            color: item.category.color || '',
+          };
+        }
+        var occurrence = {
+          id: item.id || item.sourceId || String(start.getTime()),
+          title: item.title || 'Untitled event',
+          description: item.description || '',
+          start: start,
+          end: end,
+          allDay: !!item.allDay,
+          category: category,
+          raw: item,
+        };
+        occurrence.dateKey = dateKey(start);
+        return occurrence;
+      })
+      .filter(function (item) {
+        return !!item;
+      })
+      .sort(function (a, b) {
+        return a.start.getTime() - b.start.getTime();
+      });
+  }
+
+  function formatEventTimeRange(event, timezone) {
+    var dateOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+    var timeOptions = { hour: 'numeric', minute: '2-digit' };
+    try {
+      if (timezone) {
+        dateOptions.timeZone = timezone;
+        timeOptions.timeZone = timezone;
+      }
+      var dateFormatter = new Intl.DateTimeFormat(undefined, dateOptions);
+      var timeFormatter = new Intl.DateTimeFormat(undefined, timeOptions);
+      var startDate = event.start;
+      var endDate = event.end;
+      var sameDay = dateKey(startDate) === dateKey(endDate);
+      if (event.allDay) {
+        if (sameDay) {
+          return dateFormatter.format(startDate) + ' · All day';
+        }
+        return dateFormatter.format(startDate) + ' – ' + dateFormatter.format(endDate) + ' · All day';
+      }
+      if (sameDay) {
+        return (
+          dateFormatter.format(startDate) +
+          ' · ' +
+          timeFormatter.format(startDate) +
+          ' – ' +
+          timeFormatter.format(endDate)
+        );
+      }
+      return (
+        dateFormatter.format(startDate) +
+        ' ' +
+        timeFormatter.format(startDate) +
+        ' – ' +
+        dateFormatter.format(endDate) +
+        ' ' +
+        timeFormatter.format(endDate)
+      );
+    } catch (err) {
+      return event.start.toString();
+    }
+  }
+
+  function setCurrentView(widget, state, view) {
+    state.view = view === 'list' ? 'list' : 'grid';
+    var panels = widget.querySelectorAll('[data-calendar-view-panel]');
+    panels.forEach(function (panel) {
+      var panelView = panel.getAttribute('data-calendar-view-panel');
+      panel.hidden = panelView !== state.view;
+    });
+    var buttons = widget.querySelectorAll('[data-calendar-view]');
+    buttons.forEach(function (button) {
+      var matches = button.getAttribute('data-calendar-view') === state.view;
+      button.classList.toggle('active', matches);
+      button.setAttribute('aria-pressed', matches ? 'true' : 'false');
+    });
+  }
+
+  function updateMonthLabel(widget, state) {
+    if (!state.elements.monthLabel) {
+      return;
+    }
+    state.elements.monthLabel.textContent = formatMonthLabel(state.currentMonth, state.timezone);
+  }
+
+  function updateCategoryFilter(widget, state) {
+    if (!state.elements.categoryFilter) {
+      return;
+    }
+    var select = state.elements.categoryFilter;
+    while (select.firstChild) {
+      select.removeChild(select.firstChild);
+    }
+    var allOption = document.createElement('option');
+    allOption.value = '';
+    allOption.textContent = 'All categories';
+    select.appendChild(allOption);
+    var current = state.filters.category;
+    var found = false;
+    state.categories.forEach(function (category) {
+      var option = document.createElement('option');
+      var value = category.id != null ? String(category.id) : '';
+      option.value = value;
+      option.textContent = category.name || 'Category';
+      if (value === current) {
+        found = true;
+      }
+      select.appendChild(option);
+    });
+    if (current && !found) {
+      state.filters.category = '';
+    }
+    select.value = state.filters.category;
+  }
+
+  function renderCalendar(widget, state) {
+    var grid = state.elements.grid;
+    if (!grid) {
+      return;
+    }
+    grid.innerHTML = '';
+    var monthStart = startOfMonth(state.currentMonth);
+    var daysInMonth = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 0).getDate();
+    var firstWeekday = monthStart.getDay();
+    for (var offset = 0; offset < firstWeekday; offset++) {
+      var spacer = document.createElement('div');
+      spacer.className = 'calendar-cell calendar-cell--empty';
+      spacer.setAttribute('role', 'presentation');
+      grid.appendChild(spacer);
+    }
+    var todayKey = dateKey(state.today);
+    for (var day = 1; day <= daysInMonth; day++) {
+      var date = new Date(monthStart.getFullYear(), monthStart.getMonth(), day);
+      var cell = document.createElement('div');
+      cell.className = 'calendar-cell';
+      cell.setAttribute('data-date', dateKey(date));
+      cell.setAttribute('role', 'gridcell');
+      if (dateKey(date) === todayKey) {
+        cell.classList.add('calendar-cell--today');
+      }
+      var header = document.createElement('div');
+      header.className = 'calendar-cell__header';
+      header.textContent = String(day);
+      cell.appendChild(header);
+      var eventsForDay = state.events.filter(function (event) {
+        return event.dateKey === dateKey(date);
+      });
+      if (eventsForDay.length) {
+        var list = document.createElement('div');
+        list.className = 'calendar-cell__events';
+        eventsForDay.forEach(function (event) {
+          var button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'calendar-event-chip';
+          button.textContent = event.title;
+          if (event.category && event.category.color) {
+            button.style.backgroundColor = event.category.color;
+          }
+          button.addEventListener('click', function () {
+            openCalendarModal(state, event);
+          });
+          list.appendChild(button);
+        });
+        cell.appendChild(list);
+      }
+      grid.appendChild(cell);
+    }
+  }
+
+  function renderList(widget, state) {
+    var list = state.elements.list;
+    if (!list) {
+      return;
+    }
+    list.innerHTML = '';
+    if (state.elements.listEmpty) {
+      state.elements.listEmpty.classList.add('d-none');
+    }
+    if (!state.events.length) {
+      if (state.elements.listEmpty) {
+        state.elements.listEmpty.textContent = state.emptyMessage;
+        state.elements.listEmpty.classList.remove('d-none');
+      }
+      return;
+    }
+    state.events.forEach(function (event) {
+      var item = document.createElement('article');
+      item.className = 'calendar-list__item';
+      item.setAttribute('tabindex', '0');
+      item.setAttribute('role', 'button');
+      var header = document.createElement('div');
+      header.className = 'calendar-list__item-header';
+      var title = document.createElement('h4');
+      title.textContent = event.title;
+      header.appendChild(title);
+      if (event.category && (event.category.name || event.category.color)) {
+        var badge = document.createElement('span');
+        badge.className = 'calendar-category-badge';
+        if (event.category.color) {
+          badge.style.backgroundColor = event.category.color;
+          badge.style.color = '#fff';
+        }
+        badge.textContent = event.category.name || 'Category';
+        header.appendChild(badge);
+      }
+      item.appendChild(header);
+      var meta = document.createElement('p');
+      meta.textContent = formatEventTimeRange(event, state.timezone);
+      item.appendChild(meta);
+      if (event.description) {
+        var description = document.createElement('p');
+        description.textContent = event.description;
+        item.appendChild(description);
+      }
+      item.addEventListener('click', function (evt) {
+        if (evt.target && (evt.target.closest('button') || evt.target.closest('a'))) {
+          return;
+        }
+        openCalendarModal(state, event);
+      });
+      item.addEventListener('keydown', function (evt) {
+        if (evt.key === 'Enter' || evt.key === ' ') {
+          evt.preventDefault();
+          openCalendarModal(state, event);
+        }
+      });
+      list.appendChild(item);
+    });
+  }
+
+  function renderUpcoming(widget, state) {
+    if (!state.elements.upcoming) {
+      return;
+    }
+    var list = state.elements.upcoming;
+    list.innerHTML = '';
+    if (!state.upcoming.length) {
+      var empty = document.createElement('li');
+      empty.className = 'calendar-empty';
+      empty.textContent = 'No upcoming events in the next 30 days.';
+      list.appendChild(empty);
+      return;
+    }
+    state.upcoming.forEach(function (event) {
+      var item = document.createElement('li');
+      var marker = document.createElement('span');
+      marker.className = 'calendar-upcoming__dot';
+      marker.style.backgroundColor = event.category && event.category.color ? event.category.color : '#2563eb';
+      item.appendChild(marker);
+      var content = document.createElement('div');
+      var title = document.createElement('span');
+      title.className = 'calendar-upcoming__title';
+      title.textContent = event.title;
+      var time = document.createElement('span');
+      time.className = 'd-block';
+      time.textContent = formatEventTimeRange(event, state.timezone);
+      content.appendChild(title);
+      content.appendChild(time);
+      item.appendChild(content);
+      item.addEventListener('click', function () {
+        openCalendarModal(state, event);
+      });
+      list.appendChild(item);
+    });
+  }
+
+  function renderCategories(widget, state) {
+    if (!state.elements.categories) {
+      return;
+    }
+    var list = state.elements.categories;
+    list.innerHTML = '';
+    if (!state.categories.length) {
+      var empty = document.createElement('li');
+      empty.className = 'calendar-empty';
+      empty.textContent = 'No categories defined yet.';
+      list.appendChild(empty);
+      return;
+    }
+    state.categories.forEach(function (category) {
+      var item = document.createElement('li');
+      var marker = document.createElement('span');
+      marker.className = 'calendar-category__marker';
+      marker.style.backgroundColor = category.color || '#2563eb';
+      item.appendChild(marker);
+      var name = document.createElement('span');
+      name.textContent = category.name || 'Category';
+      item.appendChild(name);
+      list.appendChild(item);
+    });
+  }
+
+  function updateMetrics(widget, meta, state) {
+    if (!state.elements.metrics) {
+      return;
+    }
+    var metrics = state.elements.metrics;
+    metrics.month.textContent = meta && typeof meta.eventsThisMonth === 'number' ? meta.eventsThisMonth : state.events.length;
+    metrics.recurring.textContent = meta && typeof meta.recurringSeries === 'number' ? meta.recurringSeries : '0';
+    metrics.categories.textContent = meta && typeof meta.categories === 'number' ? meta.categories : state.categories.length;
+    metrics.updated.textContent = meta && meta.lastUpdated ? meta.lastUpdated : 'Just now';
+  }
+
+  function showLoading(widget, state) {
+    if (state.elements.grid) {
+      state.elements.grid.innerHTML = '<p class="calendar-empty">Loading events…</p>';
+    }
+    if (state.elements.list) {
+      state.elements.list.innerHTML = '';
+    }
+    if (state.elements.listEmpty) {
+      state.elements.listEmpty.textContent = 'Loading events…';
+      state.elements.listEmpty.classList.remove('d-none');
+    }
+    if (state.elements.upcoming) {
+      state.elements.upcoming.innerHTML = '';
+      var loadingUpcoming = document.createElement('li');
+      loadingUpcoming.className = 'calendar-empty';
+      loadingUpcoming.textContent = 'Loading upcoming events…';
+      state.elements.upcoming.appendChild(loadingUpcoming);
+    }
+    if (state.elements.categories) {
+      state.elements.categories.innerHTML = '';
+      var loadingCategories = document.createElement('li');
+      loadingCategories.className = 'calendar-empty';
+      loadingCategories.textContent = 'Loading categories…';
+      state.elements.categories.appendChild(loadingCategories);
+    }
+  }
+
+  function showError(widget, state, message) {
+    var text = message || 'We were unable to load events right now.';
+    if (state.elements.grid) {
+      state.elements.grid.innerHTML = '<p class="calendar-empty">' + text + '</p>';
+    }
+    if (state.elements.list) {
+      state.elements.list.innerHTML = '';
+    }
+    if (state.elements.listEmpty) {
+      state.elements.listEmpty.textContent = text;
+      state.elements.listEmpty.classList.remove('d-none');
+    }
+    if (state.elements.upcoming) {
+      state.elements.upcoming.innerHTML = '';
+      var li = document.createElement('li');
+      li.className = 'calendar-empty';
+      li.textContent = text;
+      state.elements.upcoming.appendChild(li);
+    }
+    if (state.elements.categories) {
+      state.elements.categories.innerHTML = '';
+      var catLi = document.createElement('li');
+      catLi.className = 'calendar-empty';
+      catLi.textContent = text;
+      state.elements.categories.appendChild(catLi);
+    }
+  }
+
+  function closeCalendarModal(state) {
+    if (!state.modal) {
+      return;
+    }
+    state.modal.classList.remove('open');
+    state.modal.setAttribute('aria-hidden', 'true');
+    if (state.modalElements && state.modalElements.content) {
+      state.modalElements.content.blur();
+    }
+    if (state.modalKeyHandler) {
+      document.removeEventListener('keydown', state.modalKeyHandler, true);
+      state.modalKeyHandler = null;
+    }
+  }
+
+  function openCalendarModal(state, event) {
+    if (!state.modal) {
+      return;
+    }
+    if (state.modalElements && state.modalElements.title) {
+      state.modalElements.title.textContent = event.title;
+    }
+    if (state.modalElements && state.modalElements.time) {
+      state.modalElements.time.textContent = formatEventTimeRange(event, state.timezone);
+    }
+    if (state.modalElements && state.modalElements.category) {
+      if (event.category && (event.category.name || event.category.color)) {
+        state.modalElements.category.textContent = event.category.name || 'Category';
+        state.modalElements.category.style.display = '';
+        state.modalElements.category.style.color = event.category.color || '';
+      } else {
+        state.modalElements.category.textContent = '';
+        state.modalElements.category.style.display = 'none';
+      }
+    }
+    if (state.modalElements && state.modalElements.description) {
+      if (event.description) {
+        state.modalElements.description.textContent = event.description;
+        state.modalElements.description.style.display = '';
+      } else {
+        state.modalElements.description.textContent = '';
+        state.modalElements.description.style.display = 'none';
+      }
+    }
+    state.modal.classList.add('open');
+    state.modal.setAttribute('aria-hidden', 'false');
+    if (state.modalElements && state.modalElements.content) {
+      state.modalElements.content.focus({ preventScroll: true });
+    }
+    state.modalKeyHandler = function (evt) {
+      if (evt.key === 'Escape') {
+        evt.preventDefault();
+        closeCalendarModal(state);
+      }
+    };
+    document.addEventListener('keydown', state.modalKeyHandler, true);
+  }
+
+  function setupCalendarWidget(widget, state) {
+    state.elements = {
+      monthLabel: widget.querySelector('[data-calendar-month-label]'),
+      grid: widget.querySelector('[data-calendar-grid]'),
+      list: widget.querySelector('[data-calendar-list]'),
+      listEmpty: widget.querySelector('[data-calendar-list-empty]'),
+      upcoming: widget.querySelector('[data-calendar-upcoming]'),
+      categories: widget.querySelector('[data-calendar-category-list]'),
+      categoryFilter: widget.querySelector('[data-calendar-category-filter]'),
+      metrics: {
+        month: widget.querySelector('[data-calendar-metric="month"]') || document.createElement('span'),
+        recurring: widget.querySelector('[data-calendar-metric="recurring"]') || document.createElement('span'),
+        categories: widget.querySelector('[data-calendar-metric="categories"]') || document.createElement('span'),
+        updated: widget.querySelector('[data-calendar-metric="updated"]') || document.createElement('span'),
+      },
+    };
+    var container = widget.closest('.calendar-block') || widget;
+    state.modal = container.querySelector('[data-calendar-modal="detail"]');
+    if (state.modal) {
+      state.modalElements = {
+        container: state.modal,
+        content: state.modal.querySelector('.calendar-modal__content'),
+        title: state.modal.querySelector('[data-calendar-modal-title]'),
+        time: state.modal.querySelector('[data-calendar-modal-time]'),
+        category: state.modal.querySelector('[data-calendar-modal-category]'),
+        description: state.modal.querySelector('[data-calendar-modal-description]'),
+      };
+      state.modal.setAttribute('aria-hidden', 'true');
+      state.modal.addEventListener('click', function (evt) {
+        if (evt.target === state.modal) {
+          closeCalendarModal(state);
+        }
+      });
+      var closeButton = state.modal.querySelector('[data-calendar-modal-close]');
+      if (closeButton) {
+        closeButton.addEventListener('click', function () {
+          closeCalendarModal(state);
+        });
+      }
+    }
+    var viewButtons = widget.querySelectorAll('[data-calendar-view]');
+    viewButtons.forEach(function (button) {
+      button.addEventListener('click', function () {
+        setCurrentView(widget, state, button.getAttribute('data-calendar-view'));
+      });
+    });
+    var prev = widget.querySelector('[data-calendar-nav="prev"]');
+    if (prev) {
+      prev.addEventListener('click', function () {
+        state.currentMonth = addMonths(state.currentMonth, -1);
+        refreshCalendarWidget(widget, state);
+      });
+    }
+    var next = widget.querySelector('[data-calendar-nav="next"]');
+    if (next) {
+      next.addEventListener('click', function () {
+        state.currentMonth = addMonths(state.currentMonth, 1);
+        refreshCalendarWidget(widget, state);
+      });
+    }
+    if (state.elements.categoryFilter) {
+      state.elements.categoryFilter.addEventListener('change', function (evt) {
+        state.filters.category = evt.target.value || '';
+        refreshCalendarWidget(widget, state);
+      });
+    }
+    var searchInput = widget.querySelector('[data-calendar-search]');
+    if (searchInput) {
+      var handleSearch = debounce(function (evt) {
+        state.filters.search = evt.target.value.trim();
+        refreshCalendarWidget(widget, state);
+      }, 250);
+      searchInput.addEventListener('input', handleSearch);
+    }
+    setCurrentView(widget, state, state.view);
+    updateMonthLabel(widget, state);
+  }
+
+  function fetchCalendarData(widget, state) {
+    if (state.abortController) {
+      state.abortController.abort();
+    }
+    var controller = new AbortController();
+    state.abortController = controller;
+    var base = basePath();
+    var endpoint = (base || '') + '/CMS/modules/calendar/public_feed.php';
+    var params = new URLSearchParams();
+    params.set('month', String(state.currentMonth.getMonth() + 1));
+    params.set('year', String(state.currentMonth.getFullYear()));
+    if (state.filters.search) {
+      params.set('search', state.filters.search);
+    }
+    if (state.filters.category) {
+      params.set('category', state.filters.category);
+    }
+    if (state.timezone) {
+      params.set('timezone', state.timezone);
+    }
+    var url = endpoint + '?' + params.toString();
+    var request = fetch(url, { credentials: 'same-origin', signal: controller.signal })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Failed to load events');
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        if (!data || data.status !== 'success') {
+          throw new Error((data && data.message) || 'Unable to load events');
+        }
+        return data;
+      });
+    return request.finally(function () {
+      if (state.abortController === controller) {
+        state.abortController = null;
+      }
+    });
+  }
+
+  function refreshCalendarWidget(widget, state) {
+    state.today = startOfDay(new Date());
+    updateMonthLabel(widget, state);
+    updateCategoryFilter(widget, state);
+    showLoading(widget, state);
+    fetchCalendarData(widget, state)
+      .then(function (data) {
+        state.events = normalizeEvents(data.events);
+        state.upcoming = normalizeEvents(data.upcoming);
+        state.categories = Array.isArray(data.categories)
+          ? data.categories.map(function (category) {
+              return {
+                id: category.id != null ? String(category.id) : '',
+                name: category.name || 'Category',
+                color: category.color || '',
+              };
+            })
+          : [];
+        updateCategoryFilter(widget, state);
+        renderCalendar(widget, state);
+        renderList(widget, state);
+        renderUpcoming(widget, state);
+        renderCategories(widget, state);
+        updateMetrics(widget, data.meta || null, state);
+      })
+      .catch(function (error) {
+        if (error && error.name === 'AbortError') {
+          return;
+        }
+        var message = error && error.message ? error.message : null;
+        showError(widget, state, message);
+      });
+  }
+
+  function initCalendarWidgets() {
+    var widgets = document.querySelectorAll('[data-calendar-widget]');
+    widgets.forEach(function (widget) {
+      if (calendarStates.has(widget)) {
+        return;
+      }
+      var state = {
+        timezone: normalizeTimezone(widget.getAttribute('data-calendar-timezone')),
+        currentMonth: startOfMonth(new Date()),
+        today: startOfDay(new Date()),
+        events: [],
+        upcoming: [],
+        categories: [],
+        filters: { search: '', category: '' },
+        view: widget.getAttribute('data-calendar-initial-view') === 'list' ? 'list' : 'grid',
+        emptyMessage: widget.getAttribute('data-calendar-empty') || 'No events scheduled for this period.',
+        abortController: null,
+      };
+      calendarStates.set(widget, state);
+      setupCalendarWidget(widget, state);
+      refreshCalendarWidget(widget, state);
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
     var toggle = document.querySelector('.nav-toggle');
     var nav = document.getElementById('main-nav');
@@ -746,14 +1434,21 @@
     initializeSparkForms();
     document.addEventListener('canvasUpdated', initializeSparkForms);
 
+    initCalendarWidgets();
+    document.addEventListener('canvasUpdated', initCalendarWidgets);
+
     if (window.MutationObserver) {
       var observer = new MutationObserver(function (mutations) {
         var needsRefresh = false;
+        var needsCalendarInit = false;
         mutations.forEach(function (mutation) {
           if (mutation.type === 'attributes' && mutation.attributeName === 'data-form-id') {
             var target = mutation.target;
             if (target && target.classList && target.classList.contains('spark-form-embed')) {
               needsRefresh = true;
+            }
+            if (target && target.hasAttribute && target.hasAttribute('data-calendar-widget')) {
+              needsCalendarInit = true;
             }
           }
           if (mutation.type === 'childList') {
@@ -764,18 +1459,32 @@
               } else if (node.querySelector && node.querySelector('.spark-form-embed')) {
                 needsRefresh = true;
               }
+              if (node.hasAttribute && node.hasAttribute('data-calendar-widget')) {
+                needsCalendarInit = true;
+              } else if (node.querySelector && node.querySelector('[data-calendar-widget]')) {
+                needsCalendarInit = true;
+              }
             });
           }
         });
         if (needsRefresh) {
           initializeSparkForms();
         }
+        if (needsCalendarInit) {
+          initCalendarWidgets();
+        }
       });
       observer.observe(document.body, {
         childList: true,
         subtree: true,
         attributes: true,
-        attributeFilter: ['data-form-id'],
+        attributeFilter: [
+          'data-form-id',
+          'data-calendar-widget',
+          'data-calendar-timezone',
+          'data-calendar-initial-view',
+          'data-calendar-empty',
+        ],
       });
     }
   });

--- a/theme/templates/blocks/interactive.calendar.php
+++ b/theme/templates/blocks/interactive.calendar.php
@@ -1,0 +1,184 @@
+<!-- File: interactive.calendar.php -->
+<!-- Template: interactive.calendar -->
+<?php $calendarId = uniqid('calendar-'); ?>
+<templateSetting caption="Calendar Settings" order="1">
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Eyebrow</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_eyebrow" value="Marketing Calendar">
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Headline</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_title" value="Events &amp; Campaign Calendar">
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Subheadline</dt>
+        <dd>
+            <textarea class="form-control" name="custom_subtitle" rows="3">Plan launches, keep teams aligned, and share upcoming milestones with your audience.</textarea>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Default Timezone</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_timezone" value="America/Los_Angeles">
+            <small class="form-text text-muted">Used for formatting event dates on the front end.</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Initial View</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_initial_view" value="grid" checked> Calendar</label>
+            <label><input type="radio" name="custom_initial_view" value="list"> List</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Search &amp; Filter?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_filters" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_filters" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Upcoming List?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_upcoming" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_upcoming" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Categories?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_categories" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_categories" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Empty State Message</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_empty" value="No events scheduled for this period.">
+        </dd>
+    </dl>
+</templateSetting>
+<section id="<?= $calendarId ?>" class="calendar-block" data-tpl-tooltip="Calendar">
+    <div class="calendar-widget" data-calendar-widget data-calendar-timezone="{custom_timezone}" data-calendar-initial-view="{custom_initial_view}" data-calendar-empty="{custom_empty}">
+        <div class="calendar-dashboard">
+            <header class="calendar-hero">
+                <div class="calendar-hero__content">
+                    <p class="calendar-hero__eyebrow text-uppercase" data-editable>{custom_eyebrow}</p>
+                    <h2 class="calendar-hero__title" data-editable>{custom_title}</h2>
+                    <p class="calendar-hero__subtitle" data-editable>{custom_subtitle}</p>
+                </div>
+                <dl class="calendar-hero__metrics">
+                    <div>
+                        <dt>Events this month</dt>
+                        <dd data-calendar-metric="month">0</dd>
+                    </div>
+                    <div>
+                        <dt>Recurring series</dt>
+                        <dd data-calendar-metric="recurring">0</dd>
+                    </div>
+                    <div>
+                        <dt>Categories</dt>
+                        <dd data-calendar-metric="categories">0</dd>
+                    </div>
+                    <div>
+                        <dt>Last updated</dt>
+                        <dd data-calendar-metric="updated">Just now</dd>
+                    </div>
+                </dl>
+            </header>
+            <div class="calendar-controls" aria-label="Calendar controls">
+                <div class="calendar-controls__primary">
+                    <div class="calendar-month-nav" role="group" aria-label="Month navigation">
+                        <button type="button" class="calendar-icon-btn" data-calendar-nav="prev" aria-label="Previous month">
+                            <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
+                        </button>
+                        <div class="calendar-month-label" data-calendar-month-label>Month YYYY</div>
+                        <button type="button" class="calendar-icon-btn" data-calendar-nav="next" aria-label="Next month">
+                            <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                    <div class="calendar-view-toggle" role="group" aria-label="View mode">
+                        <button type="button" class="calendar-toggle-btn" data-calendar-view="grid">Calendar</button>
+                        <button type="button" class="calendar-toggle-btn" data-calendar-view="list">List</button>
+                    </div>
+                </div>
+                <toggle rel="custom_show_filters" value="yes">
+                    <div class="calendar-controls__filters">
+                        <label class="calendar-search" for="<?= $calendarId ?>-search">
+                            <span class="visually-hidden">Search events</span>
+                            <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                            <input type="search" id="<?= $calendarId ?>-search" placeholder="Search events, launches, campaigns" aria-label="Search events" data-calendar-search>
+                        </label>
+                        <label class="calendar-filter" for="<?= $calendarId ?>-filter">
+                            <span class="visually-hidden">Filter by category</span>
+                            <select id="<?= $calendarId ?>-filter" data-calendar-category-filter>
+                                <option value="">All categories</option>
+                            </select>
+                        </label>
+                    </div>
+                </toggle>
+            </div>
+            <div class="calendar-layout">
+                <section class="calendar-view" data-calendar-view-panel="grid" aria-label="Calendar view">
+                    <div class="calendar-weekdays" aria-hidden="true">
+                        <span>Sun</span>
+                        <span>Mon</span>
+                        <span>Tue</span>
+                        <span>Wed</span>
+                        <span>Thu</span>
+                        <span>Fri</span>
+                        <span>Sat</span>
+                    </div>
+                    <div class="calendar-grid" data-calendar-grid role="grid" aria-live="polite"></div>
+                </section>
+                <section class="calendar-list" data-calendar-view-panel="list" aria-label="List view" hidden>
+                    <header class="calendar-list__header">
+                        <h3>Timeline</h3>
+                        <p>Every event across categories in chronological order.</p>
+                    </header>
+                    <div class="calendar-list__container" data-calendar-list></div>
+                    <div class="calendar-empty d-none" data-calendar-list-empty>{custom_empty}</div>
+                </section>
+                <aside class="calendar-sidebar">
+                    <toggle rel="custom_show_upcoming" value="yes">
+                        <section class="calendar-upcoming" data-calendar-upcoming-section>
+                            <header>
+                                <h3>Next up</h3>
+                                <p>Upcoming milestones over the next 30 days.</p>
+                            </header>
+                            <ul class="calendar-upcoming__list" data-calendar-upcoming></ul>
+                        </section>
+                    </toggle>
+                    <toggle rel="custom_show_categories" value="yes">
+                        <section class="calendar-categories" data-calendar-categories-section>
+                            <header>
+                                <h3>Categories</h3>
+                                <p>Color-coded tags applied to calendar entries.</p>
+                            </header>
+                            <ul class="calendar-category-list" data-calendar-category-list></ul>
+                        </section>
+                    </toggle>
+                </aside>
+            </div>
+        </div>
+    </div>
+    <div class="calendar-modal" data-calendar-modal="detail" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="<?= $calendarId ?>-modal-title">
+        <div class="calendar-modal__content" role="document" tabindex="-1">
+            <header class="calendar-modal__header">
+                <h2 id="<?= $calendarId ?>-modal-title" data-calendar-modal-title>Event</h2>
+                <button type="button" class="calendar-modal__close" data-calendar-modal-close>
+                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                </button>
+            </header>
+            <div class="calendar-modal__body">
+                <p class="calendar-event__meta" data-calendar-modal-time></p>
+                <p class="calendar-event__category" data-calendar-modal-category></p>
+                <p data-calendar-modal-description></p>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- extract reusable calendar helpers and expose a read-only public feed for front-end consumption
- add a configurable front-end calendar block template with markup and styling
- wire up calendar rendering, filters, and modal interactions in the front-end JS bundles

## Testing
- php -l CMS/modules/calendar/public_feed.php
- php -l CMS/modules/calendar/calendar_helpers.php
- php -l CMS/modules/calendar/calendar_backend.php

------
https://chatgpt.com/codex/tasks/task_e_68d738c3a0748331956b683fb92bcb96