### PR TITLE
Add admin user aibotbob

### DIFF
--- a/CMS/data/users.json
+++ b/CMS/data/users.json
@@ -43,5 +43,14 @@
         "status": "active",
         "created_at": 0,
         "last_login": null
+    },
+    {
+        "id": 6,
+        "username": "aibotbob",
+        "password": "$2y$12$eZr9T/Ok9bnxoRm8b0ZUxeSLF7mVXMHXg6N5pFecjgL60tCTNwpoC",
+        "role": "admin",
+        "status": "active",
+        "created_at": 0,
+        "last_login": null
     }
 ]


### PR DESCRIPTION
## Summary
- add the admin user `aibotbob` with a bcrypt-hashed password to the CMS data store

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7447f23888331a362f1ca594e6a34