### PR TITLE
Fix hidden empty-state indicator showing during page search

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -5,6 +5,10 @@
             box-sizing: border-box;
         }
 
+        [hidden] {
+            display: none !important;
+        }
+
         body {
             font-family: 'Poppins', sans-serif;
             background: #f8fafc;


### PR DESCRIPTION
## Summary
- add a global CSS rule to respect the `hidden` attribute so empty states stay out of view when results are present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d747785b008331b9b1718ffbf67bcd