### PR TITLE
Remove CSV export option from analytics dashboard

### DIFF
--- a/CMS/modules/analytics/analytics.js
+++ b/CMS/modules/analytics/analytics.js
@@ -27,7 +27,6 @@ $(function(){
     const $viewButtons = $('[data-analytics-view]');
     const $counts = $('[data-analytics-count]');
     const $refreshBtn = $('[data-analytics-action="refresh"]');
-    const $exportBtn = $('[data-analytics-action="export"]');
     const $totalViews = $('#analyticsTotalViews');
     const $averageViews = $('#analyticsAverageViews');
     const $totalPages = $('#analyticsTotalPages');
@@ -383,28 +382,6 @@ $(function(){
             });
     }
 
-    function exportCsv(){
-        if (!state.entries.length) {
-            window.alert('No analytics data to export yet.');
-            return;
-        }
-        const rows = ['"Title","Slug","Views"'];
-        state.entries.forEach(function(item){
-            const title = '"' + String(item.title).replace(/"/g, '""') + '"';
-            const slug = '"' + String(item.slug).replace(/"/g, '""') + '"';
-            rows.push([title, slug, item.views].join(','));
-        });
-        const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' });
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = 'analytics-export.csv';
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-        URL.revokeObjectURL(url);
-    }
-
     const initialEntries = window.analyticsInitialEntries || [];
     const initialMeta = window.analyticsInitialMeta || {};
     setData(initialEntries);
@@ -434,9 +411,4 @@ $(function(){
         });
     }
 
-    if ($exportBtn.length) {
-        $exportBtn.on('click', function(){
-            exportCsv();
-        });
-    }
 });

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -58,10 +58,6 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
                         <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                         <span class="analytics-btn__text">Refresh data</span>
                     </button>
-                    <button type="button" class="analytics-btn analytics-btn--ghost" data-analytics-action="export">
-                        <i class="fa-solid fa-file-export" aria-hidden="true"></i>
-                        <span class="analytics-btn__text">Export CSV</span>
-                    </button>
                     <span class="analytics-hero-meta" id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
                         <?php echo $lastUpdatedDisplay
                             ? 'Data refreshed ' . htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES)


### PR DESCRIPTION
## Summary
- remove the analytics dashboard CSV export button from the UI
- drop the unused JavaScript logic that generated the CSV export

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d747c65ae48331a39b3d0ca85d54a4