### PR TITLE
Add server-side validation for settings image uploads

### DIFF
--- a/CMS/modules/settings/settings.js
+++ b/CMS/modules/settings/settings.js
@@ -149,14 +149,32 @@ $(function(){
                 $saveButton.removeClass('is-loading').prop('disabled', false);
             },
             success: function(response){
-                alertModal('Settings saved');
-                if(response && response.last_updated){
-                    updateHeroMeta(response.last_updated);
+                if(response && response.status === 'ok'){
+                    alertModal('Settings saved');
+                    if(response.last_updated){
+                        updateHeroMeta(response.last_updated);
+                    }
+                    loadSettings();
+                } else {
+                    const message = (response && response.message) ? response.message : 'Unable to save settings';
+                    alertModal(message);
                 }
-                loadSettings();
             },
-            error: function(){
-                alertModal('Unable to save settings');
+            error: function(xhr){
+                let message = 'Unable to save settings';
+                if(xhr && xhr.responseJSON && xhr.responseJSON.message){
+                    message = xhr.responseJSON.message;
+                } else if(xhr && xhr.responseText){
+                    try {
+                        const parsed = JSON.parse(xhr.responseText);
+                        if(parsed && parsed.message){
+                            message = parsed.message;
+                        }
+                    } catch (e) {
+                        // ignore JSON parse errors
+                    }
+                }
+                alertModal(message);
             }
         });
     });


### PR DESCRIPTION
## Summary
- validate logo and Open Graph uploads using MIME allowlist, a size cap, and descriptive JSON errors
- prevent invalid uploads from updating stored image paths when validation fails
- surface server-side validation messages in the settings UI

## Testing
- php -l CMS/modules/settings/save_settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d74afb3e688331b4a9818efe895009