### PR TITLE
Enhance media upload progress and error handling

### DIFF
--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -210,25 +210,78 @@ $(function(){
         }, mime, quality);
     }
 
+    function updateUploadProgress(percent){
+        const value = Math.max(0, Math.min(100, Math.round(percent || 0)));
+        $('#uploadProgressFill').css('width', value + '%');
+        $('#uploadProgressPercent').text(value + '%');
+    }
+
+    function startUploadUI(){
+        updateUploadProgress(0);
+        $('#uploadStatusMessage').text('Uploading files…');
+        $('#uploadLoader').show();
+    }
+
+    function resetUploadUI(){
+        $('#fileInput').val('');
+        $('#uploadLoader').hide();
+        updateUploadProgress(0);
+        $('#uploadStatusMessage').text('');
+    }
+
     function uploadFiles(files){
         if(!currentFolder || !files.length) return;
         const fd = new FormData();
         Array.from(files).forEach(f => fd.append('files[]', f));
         fd.append('folder', currentFolder);
         fd.append('tags','');
-        $('#uploadLoader').show();
+        startUploadUI();
         $.ajax({
             url: 'modules/media/upload_media.php',
             method: 'POST',
             data: fd,
             processData: false,
-            contentType: false
-        }).done(function(){
-            $('#fileInput').val('');
-            loadImages();
-            loadFolders();
+            contentType: false,
+            dataType: 'json',
+            xhr: function(){
+                const xhr = new window.XMLHttpRequest();
+                xhr.upload.addEventListener('progress', function(e){
+                    if(e.lengthComputable){
+                        const percent = (e.loaded / e.total) * 100;
+                        updateUploadProgress(percent);
+                    }
+                });
+                return xhr;
+            }
+        }).done(function(res){
+            const response = res || {};
+            if(response.status === 'success'){
+                updateUploadProgress(100);
+                loadImages();
+                loadFolders();
+            }
+            const errors = Array.isArray(response.errors) ? response.errors : [];
+            if(errors.length){
+                alertModal(errors.join('\n'));
+            } else if(response.status !== 'success'){
+                const message = response.message || 'Error uploading files.';
+                alertModal(message);
+            }
+        }).fail(function(jqXHR){
+            let message = 'Error uploading files.';
+            if(jqXHR.responseJSON){
+                const json = jqXHR.responseJSON;
+                if(Array.isArray(json.errors) && json.errors.length){
+                    message = json.errors.join('\n');
+                }else if(json.message){
+                    message = json.message;
+                }
+            }else if(jqXHR.responseText){
+                message = jqXHR.responseText;
+            }
+            alertModal(message);
         }).always(function(){
-            $('#uploadLoader').hide();
+            resetUploadUI();
         });
     }
 

--- a/CMS/modules/media/upload_media.php
+++ b/CMS/modules/media/upload_media.php
@@ -32,19 +32,52 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     $order = $maxOrder + 1;
 
+    header('Content-Type: application/json');
+
+    if (!isset($_FILES['files'])) {
+        echo json_encode([
+            'status' => 'error',
+            'message' => 'No files uploaded.'
+        ]);
+        exit;
+    }
+
+    $errors = [];
+    $newEntries = [];
+
     foreach ($_FILES['files']['name'] as $i => $name) {
+        $originalName = $name;
+        $displayName = sanitize_text($originalName) ?: $originalName;
+        $errorCode = $_FILES['files']['error'][$i] ?? UPLOAD_ERR_NO_FILE;
+
+        if ($errorCode !== UPLOAD_ERR_OK) {
+            $errors[] = upload_error_message($displayName, $errorCode);
+            continue;
+        }
+
         $tmp = $_FILES['files']['tmp_name'][$i];
         $size = $_FILES['files']['size'][$i];
-        $ext = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+        $ext = strtolower(pathinfo($originalName, PATHINFO_EXTENSION));
         $category = null;
         foreach ($allowed as $cat => $exts) {
             if (in_array($ext, $exts)) { $category = $cat; break; }
         }
-        if (!$category) continue;
+        if (!$category) {
+            $errors[] = $displayName . ' is not a supported file type.';
+            continue;
+        }
 
-        $safe = uniqid() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $name);
+        if (!is_uploaded_file($tmp)) {
+            $errors[] = 'Could not validate the upload for ' . $displayName . '.';
+            continue;
+        }
+
+        $safe = uniqid() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $originalName);
         $dest = $baseDir . '/' . $safe;
-        if (!move_uploaded_file($tmp, $dest)) continue;
+        if (!move_uploaded_file($tmp, $dest)) {
+            $errors[] = 'Failed to save ' . $displayName . '.';
+            continue;
+        }
 
         $thumbPath = null;
         if ($category === 'images') {
@@ -52,12 +85,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!is_dir($thumbDir)) mkdir($thumbDir, 0777, true);
             $thumbPath = $thumbDir . '/' . $safe;
             create_thumbnail($dest, $thumbPath, 200);
-            $thumbPath = str_replace($root . '/', '', $thumbPath);
+            if (file_exists($thumbPath)) {
+                $thumbPath = str_replace($root . '/', '', $thumbPath);
+            } else {
+                $thumbPath = null;
+            }
         }
 
-        $media[] = [
+        $newEntries[] = [
             'id' => uniqid(),
-            'name' => $name,
+            'name' => $originalName,
             'file' => str_replace($root . '/', '', $dest),
             'folder' => $folder,
             'size' => $size,
@@ -69,8 +106,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         ];
     }
 
-    file_put_contents($mediaFile, json_encode($media, JSON_PRETTY_PRINT));
-    echo json_encode(['status' => 'success']);
+    if (!empty($newEntries)) {
+        $media = array_merge($media, $newEntries);
+        file_put_contents($mediaFile, json_encode($media, JSON_PRETTY_PRINT));
+    }
+
+    $response = [
+        'status' => !empty($newEntries) ? 'success' : 'error',
+        'uploaded' => count($newEntries)
+    ];
+
+    if (!empty($errors)) {
+        $response['errors'] = $errors;
+        if (!empty($newEntries)) {
+            $response['partial'] = true;
+            $response['message'] = 'Some files could not be uploaded.';
+        } else {
+            $response['message'] = 'No files were uploaded.';
+        }
+    } elseif (empty($newEntries)) {
+        $response['message'] = 'No files to upload.';
+    }
+
+    echo json_encode($response);
     exit;
 }
 
@@ -99,4 +157,66 @@ function create_thumbnail($src, $dest, $maxWidth) {
     }
     imagedestroy($img);
     imagedestroy($thumb);
+}
+
+function upload_error_message(string $name, int $code): string {
+    $limit = get_php_upload_limit();
+    switch ($code) {
+        case UPLOAD_ERR_INI_SIZE:
+        case UPLOAD_ERR_FORM_SIZE:
+            $limitText = $limit ? format_bytes($limit) : 'the server limit';
+            return $name . ' exceeds the maximum upload size of ' . $limitText . '.';
+        case UPLOAD_ERR_PARTIAL:
+            return $name . ' was only partially uploaded. Please try again.';
+        case UPLOAD_ERR_NO_FILE:
+            return 'No file was uploaded for ' . $name . '.';
+        case UPLOAD_ERR_NO_TMP_DIR:
+            return 'Missing a temporary folder for ' . $name . '. Contact support.';
+        case UPLOAD_ERR_CANT_WRITE:
+            return 'The server could not write ' . $name . ' to disk.';
+        case UPLOAD_ERR_EXTENSION:
+            return 'A server extension stopped the upload of ' . $name . '.';
+        default:
+            return 'An unknown error occurred while uploading ' . $name . '.';
+    }
+}
+
+function get_php_upload_limit(): ?int {
+    $limits = [ini_get('upload_max_filesize'), ini_get('post_max_size')];
+    $bytes = array_filter(array_map('convert_shorthand_to_bytes', $limits));
+    if (empty($bytes)) {
+        return null;
+    }
+    return (int) min($bytes);
+}
+
+function convert_shorthand_to_bytes($value): ?int {
+    if (!$value) return null;
+    $value = trim($value);
+    if ($value === '') return null;
+    $last = strtolower(substr($value, -1));
+    $number = (float) $value;
+    switch ($last) {
+        case 'g':
+            $number *= 1024;
+            // no break
+        case 'm':
+            $number *= 1024;
+            // no break
+        case 'k':
+            $number *= 1024;
+            break;
+    }
+    return (int) round($number);
+}
+
+function format_bytes(int $bytes): string {
+    if ($bytes <= 0) {
+        return '0 B';
+    }
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $i = (int) floor(log($bytes, 1024));
+    $i = min($i, count($units) - 1);
+    $value = $bytes / pow(1024, $i);
+    return number_format($value, $value >= 10 ? 0 : 1) . ' ' . $units[$i];
 }

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -244,6 +244,15 @@
                     <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.12/cropper.min.js"></script>
                     <input type="file" id="fileInput" class="upload-input" multiple accept="image/*">
                     <div id="uploadLoader" class="upload-loader" style="display:none;">
-                        <div class="loading"></div>
+                        <div class="upload-loader-content" role="status" aria-live="polite">
+                            <div class="loading" aria-hidden="true"></div>
+                            <div class="upload-progress">
+                                <div class="upload-progress-bar" aria-hidden="true">
+                                    <div id="uploadProgressFill" class="upload-progress-fill"></div>
+                                </div>
+                                <div id="uploadProgressPercent" class="upload-progress-percent">0%</div>
+                                <div id="uploadStatusMessage" class="upload-status-message"></div>
+                            </div>
+                        </div>
                     </div>
                 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -6096,10 +6096,56 @@
     z-index: 3000;
 }
 
+#uploadLoader .upload-loader-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding: 28px 32px;
+    background: #ffffff;
+    border-radius: 16px;
+    box-shadow: 0 20px 45px rgba(15, 23, 42, 0.18);
+}
+
 #uploadLoader .loading {
     width: 40px;
     height: 40px;
     border-width: 5px;
+}
+
+#uploadLoader .upload-progress {
+    width: 280px;
+    max-width: 80vw;
+}
+
+#uploadLoader .upload-progress-bar {
+    width: 100%;
+    height: 12px;
+    background: #e2e8f0;
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+#uploadLoader .upload-progress-fill {
+    width: 0%;
+    height: 100%;
+    background: linear-gradient(90deg, #38bdf8 0%, #6366f1 100%);
+    transition: width 0.2s ease;
+}
+
+#uploadLoader .upload-progress-percent {
+    margin-top: 10px;
+    font-size: 16px;
+    font-weight: 600;
+    text-align: center;
+    color: #1e293b;
+}
+
+#uploadStatusMessage {
+    margin-top: 4px;
+    font-size: 14px;
+    text-align: center;
+    color: #334155;
 }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
## Summary
- add upload progress tracking, failure handling, and UI reset logic to the media uploader
- return structured validation feedback from upload_media.php for unsupported or oversized files
- style the media upload loader with a progress bar to reflect in-flight uploads

## Testing
- php -l CMS/modules/media/upload_media.php

------
https://chatgpt.com/codex/tasks/task_e_68d74ab9fadc8331ac5576eb18be9802