### PR TITLE
Add editable media titles to gallery

### DIFF
--- a/CMS/index.php
+++ b/CMS/index.php
@@ -67,8 +67,13 @@ if ($slug === 'search') {
     }
     foreach ($mediaItems as $m) {
         $tags = isset($m['tags']) && is_array($m['tags']) ? implode(',', $m['tags']) : '';
-        if ($q === '' || stripos($m['name'], $lower) !== false || stripos($m['file'], $lower) !== false || stripos($tags, $lower) !== false) {
-            $results[] = ['title' => $m['name'], 'slug' => ltrim($m['file'], '/')];
+        $mediaTitle = $m['title'] ?? '';
+        if ($q === ''
+            || stripos($m['name'], $lower) !== false
+            || stripos($mediaTitle, $lower) !== false
+            || stripos($m['file'], $lower) !== false
+            || stripos($tags, $lower) !== false) {
+            $results[] = ['title' => $mediaTitle ?: $m['name'], 'slug' => ltrim($m['file'], '/')];
         }
     }
     $content = '<div class="search-results"><h1>Search Results';

--- a/CMS/modules/media/list_media.php
+++ b/CMS/modules/media/list_media.php
@@ -7,6 +7,12 @@ require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
 $media = read_json_file($mediaFile);
+foreach ($media as &$entry) {
+    $entry['title'] = isset($entry['title']) && $entry['title'] !== ''
+        ? $entry['title']
+        : sanitize_text(pathinfo($entry['name'] ?? '', PATHINFO_FILENAME));
+}
+unset($entry);
 $query = strtolower(sanitize_text($_GET['q'] ?? ''));
 $folder = sanitize_text($_GET['folder'] ?? '');
 
@@ -16,7 +22,8 @@ usort($media, function($a,$b){
 
 $results = array_filter($media, function($item) use ($query, $folder) {
     if ($folder !== '' && $item['folder'] !== $folder) return false;
-    if ($query && stripos($item['name'], $query) === false &&
+    if ($query && stripos($item['name'] ?? '', $query) === false &&
+        stripos($item['title'] ?? '', $query) === false &&
         (!isset($item['tags']) || stripos(implode(',', $item['tags']), $query) === false)) return false;
     return true;
 });

--- a/CMS/modules/media/rename_media.php
+++ b/CMS/modules/media/rename_media.php
@@ -18,6 +18,7 @@ $root = dirname(__DIR__, 2);
 $found = false;
 foreach ($media as &$item) {
     if ($item['id'] === $id) {
+        $existingName = $item['name'];
         $oldPath = $root . '/' . $item['file'];
         $ext = pathinfo($oldPath, PATHINFO_EXTENSION);
         $safe = preg_replace('/[^A-Za-z0-9._-]/', '_', pathinfo($newName, PATHINFO_FILENAME)) . '.' . $ext;
@@ -46,8 +47,14 @@ foreach ($media as &$item) {
             @touch($thumbNew);
             $item['thumbnail'] = $thumbNewRel;
         }
+        $previousTitle = $item['title'] ?? '';
         $item['name'] = $safe;
         $item['file'] = $newRel;
+        if ($previousTitle === '' || $previousTitle === sanitize_text(pathinfo($existingName, PATHINFO_FILENAME))) {
+            $item['title'] = sanitize_text(pathinfo($safe, PATHINFO_FILENAME));
+        } else {
+            $item['title'] = $previousTitle;
+        }
         $found = true;
         break;
     }

--- a/CMS/modules/media/update_title.php
+++ b/CMS/modules/media/update_title.php
@@ -1,0 +1,36 @@
+<?php
+// File: update_title.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
+require_login();
+
+$mediaFile = __DIR__ . '/../../data/media.json';
+$media = read_json_file($mediaFile);
+
+$id = sanitize_text($_POST['id'] ?? '');
+$title = sanitize_text($_POST['title'] ?? '');
+
+if ($id === '') {
+    echo json_encode(['status' => 'error', 'message' => 'Invalid request']);
+    exit;
+}
+
+$found = false;
+foreach ($media as &$item) {
+    if (($item['id'] ?? '') === $id) {
+        $item['title'] = $title;
+        $found = true;
+        break;
+    }
+}
+unset($item);
+
+if (!$found) {
+    echo json_encode(['status' => 'error', 'message' => 'File not found']);
+    exit;
+}
+
+write_json_file($mediaFile, $media);
+
+echo json_encode(['status' => 'success', 'title' => $title]);

--- a/CMS/modules/media/upload_media.php
+++ b/CMS/modules/media/upload_media.php
@@ -58,6 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $media[] = [
             'id' => uniqid(),
             'name' => $name,
+            'title' => sanitize_text(pathinfo($name, PATHINFO_FILENAME)),
             'file' => str_replace($root . '/', '', $dest),
             'folder' => $folder,
             'size' => $size,

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -172,7 +172,7 @@
                                         <p><strong>Folder:</strong> <span id="infoFolder"></span></p>
                                     </div>
                                     <div class="form-group">
-                                        <label class="form-label" for="edit-name">Name/Title</label>
+                                        <label class="form-label" for="edit-name">Display Title</label>
                                         <input type="text" id="edit-name" class="form-input">
                                     </div>
                                     <div class="form-group" id="rename-file-group">


### PR DESCRIPTION
## Summary
- add a stored title field to media records and expose it via the media listing and search
- surface and edit the friendly title in the media manager UI with a new update endpoint
- keep optional physical rename behavior while showing custom titles on gallery cards

## Testing
- php -l CMS/modules/media/upload_media.php
- php -l CMS/modules/media/rename_media.php
- php -l CMS/modules/media/list_media.php
- php -l CMS/index.php
- php -l CMS/modules/media/update_title.php

------
https://chatgpt.com/codex/tasks/task_e_68d74acc939483318df1f8027a5c4635