### PR TITLE
Add pagination support to media gallery

### DIFF
--- a/CMS/modules/media/list_media.php
+++ b/CMS/modules/media/list_media.php
@@ -9,6 +9,14 @@ $mediaFile = __DIR__ . '/../../data/media.json';
 $media = read_json_file($mediaFile);
 $query = strtolower(sanitize_text($_GET['q'] ?? ''));
 $folder = sanitize_text($_GET['folder'] ?? '');
+$sort = strtolower(sanitize_text($_GET['sort'] ?? 'custom'));
+$allowedSorts = ['custom','name','date','type','size','tags','dimensions'];
+if (!in_array($sort, $allowedSorts, true)) {
+    $sort = 'custom';
+}
+$order = strtolower($_GET['order'] ?? 'asc') === 'desc' ? 'desc' : 'asc';
+$limit = isset($_GET['limit']) ? max(0, (int)$_GET['limit']) : 0;
+$offset = isset($_GET['offset']) ? max(0, (int)$_GET['offset']) : 0;
 
 usort($media, function($a,$b){
     return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);
@@ -58,7 +66,80 @@ foreach ($results as &$item) {
         }
     }
 }
+unset($item);
+
+switch ($sort) {
+    case 'name':
+        usort($results, function($a, $b) {
+            return strcasecmp($a['name'] ?? '', $b['name'] ?? '');
+        });
+        break;
+    case 'date':
+        usort($results, function($a, $b) {
+            $aTime = $a['modified_at'] ?? ($a['uploaded_at'] ?? 0);
+            $bTime = $b['modified_at'] ?? ($b['uploaded_at'] ?? 0);
+            return $aTime <=> $bTime;
+        });
+        break;
+    case 'type':
+        usort($results, function($a, $b) {
+            return strcasecmp($a['type'] ?? '', $b['type'] ?? '');
+        });
+        break;
+    case 'size':
+        usort($results, function($a, $b) {
+            return ((int)($a['size'] ?? 0)) <=> ((int)($b['size'] ?? 0));
+        });
+        break;
+    case 'tags':
+        usort($results, function($a, $b) {
+            $aTags = isset($a['tags']) ? implode(',', (array)$a['tags']) : '';
+            $bTags = isset($b['tags']) ? implode(',', (array)$b['tags']) : '';
+            return strcasecmp($aTags, $bTags);
+        });
+        break;
+    case 'dimensions':
+        usort($results, function($a, $b) {
+            $aDim = ((int)($a['width'] ?? 0)) * ((int)($a['height'] ?? 0));
+            $bDim = ((int)($b['width'] ?? 0)) * ((int)($b['height'] ?? 0));
+            return $aDim <=> $bDim;
+        });
+        break;
+    default:
+        usort($results, function($a, $b) {
+            return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);
+        });
+}
+
+if ($order === 'desc') {
+    $results = array_reverse($results);
+}
+
+$results = array_values($results);
+$totalCount = count($results);
+$totalBytes = array_reduce($results, function($carry, $item) {
+    return $carry + (int)($item['size'] ?? 0);
+}, 0);
+$lastModified = 0;
+foreach ($results as $resultItem) {
+    if (isset($resultItem['modified_at']) && $resultItem['modified_at'] > $lastModified) {
+        $lastModified = $resultItem['modified_at'];
+    }
+}
+
+$pagedResults = $results;
+if ($limit > 0) {
+    $pagedResults = array_slice($results, $offset, $limit);
+} elseif ($offset > 0) {
+    $pagedResults = array_slice($results, $offset);
+}
 
 header('Content-Type: application/json');
-echo json_encode(['media'=>array_values($results), 'folders'=>$folders]);
+echo json_encode([
+    'media' => array_values($pagedResults),
+    'folders' => $folders,
+    'total' => $totalCount,
+    'total_size' => $totalBytes,
+    'last_modified' => $lastModified
+]);
 ?>

--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -2,6 +2,10 @@
 $(function(){
     let currentFolder = null;
     let currentImages = [];
+    let currentPage = 1;
+    let currentOffset = 0;
+    let totalImagesCount = 0;
+    let totalPages = 1;
     let cropper = null;
     let flipX = 1;
     let flipY = 1;
@@ -50,6 +54,10 @@ $(function(){
 
     function selectFolder(name){
         currentFolder = name;
+        currentPage = 1;
+        currentOffset = 0;
+        totalPages = 1;
+        totalImagesCount = 0;
         $('.folder-item').removeClass('active');
         $('.folder-item[data-folder="'+name+'"]').addClass('active');
         $('#selectedFolderName').text(name);
@@ -64,15 +72,38 @@ $(function(){
 
     function loadImages(){
         if(!currentFolder){
+            currentImages = [];
+            totalImagesCount = 0;
+            totalPages = 1;
+            currentOffset = 0;
             renderImages();
             return;
         }
-        $.getJSON('modules/media/list_media.php', {folder: currentFolder}, function(res){
+        const limit = itemsPerPage>0 ? itemsPerPage : 0;
+        const offset = limit ? (currentPage-1)*limit : 0;
+        const params = {folder: currentFolder, sort: sortBy, order: sortOrder};
+        if(limit){
+            params.limit = limit;
+            params.offset = offset;
+        }
+        $.getJSON('modules/media/list_media.php', params, function(res){
             currentImages = res.media || [];
-            const totalBytes = currentImages.reduce((s,m)=>s+parseInt(m.size||0),0);
-            const lastMod = currentImages.reduce((m,i)=>i.modified_at && i.modified_at>m?i.modified_at:m,0);
+            const parsedTotal = parseInt(res.total, 10);
+            totalImagesCount = Number.isNaN(parsedTotal) ? currentImages.length : parsedTotal;
+            const parsedBytes = parseInt(res.total_size, 10);
+            const totalBytes = Number.isNaN(parsedBytes) ? currentImages.reduce((s,m)=>s+parseInt(m.size||0),0) : parsedBytes;
+            const parsedLastMod = parseInt(res.last_modified, 10);
+            const lastMod = Number.isNaN(parsedLastMod) ? currentImages.reduce((m,i)=>i.modified_at && i.modified_at>m?i.modified_at:m,0) : parsedLastMod;
             const lastEdited = lastMod ? 'Last edited ' + new Date(lastMod*1000).toLocaleDateString() : 'No edits yet';
-            currentFolderMeta = currentImages.length+' files • '+formatFileSize(totalBytes)+' • '+lastEdited;
+            const limitPages = limit ? Math.max(1, Math.ceil(totalImagesCount/limit)) : 1;
+            if(limit && currentPage>limitPages && limitPages>0){
+                currentPage = limitPages;
+                loadImages();
+                return;
+            }
+            totalPages = limitPages;
+            currentOffset = offset;
+            currentFolderMeta = totalImagesCount+' files • '+formatFileSize(totalBytes)+' • '+lastEdited;
             $('#folderStats').text(currentFolderMeta);
             $('#mediaHeroFolderInfo').text(currentFolderMeta);
             renderImages();
@@ -109,8 +140,58 @@ $(function(){
                 imgs.sort((a,b)=>(a.order||0)-(b.order||0));
         }
         if(sortOrder==='desc') imgs.reverse();
-        if(itemsPerPage>0) imgs = imgs.slice(0, itemsPerPage);
+        if(itemsPerPage>0){
+            const startIndex = Math.max(0, (currentPage-1)*itemsPerPage - currentOffset);
+            imgs = imgs.slice(startIndex, startIndex + itemsPerPage);
+        }
         return imgs;
+    }
+
+    function renderPagination(){
+        const pagination = $('#galleryPagination');
+        if(!currentFolder || itemsPerPage<=0 || totalPages<=1){
+            pagination.hide().empty();
+            return;
+        }
+
+        pagination.empty().show();
+
+        const createButton = (label, page, disabled, active) => {
+            const btn = $('<button type="button" class="pagination-btn">'+label+'</button>');
+            if(disabled){
+                btn.prop('disabled', true).attr('aria-disabled', 'true').addClass('is-disabled');
+            }else{
+                btn.attr('data-page', page);
+            }
+            if(active){
+                btn.addClass('is-active');
+                btn.attr('aria-current', 'page');
+            }
+            if(label==='Prev'){
+                btn.attr('aria-label', 'Previous page');
+            }else if(label==='Next'){
+                btn.attr('aria-label', 'Next page');
+            }else{
+                btn.attr('aria-label', 'Go to page '+label);
+            }
+            return btn;
+        };
+
+        pagination.append(createButton('Prev', currentPage-1, currentPage===1, false));
+
+        const maxButtons = 5;
+        let start = Math.max(1, currentPage - Math.floor(maxButtons/2));
+        let end = start + maxButtons - 1;
+        if(end>totalPages){
+            end = totalPages;
+            start = Math.max(1, end - maxButtons + 1);
+        }
+
+        for(let page=start; page<=end; page++){
+            pagination.append(createButton(page, page, false, page===currentPage));
+        }
+
+        pagination.append(createButton('Next', currentPage+1, currentPage===totalPages, false));
     }
 
     function applyViewType(){
@@ -182,13 +263,18 @@ $(function(){
                     </div>');
                 grid.append(card);
             });
-            grid.sortable({
-                placeholder: 'ui-sortable-placeholder',
-                start: function(e, ui){ ui.placeholder.height(ui.item.height()); },
-                stop: function(){ updateOrder(); }
-            });
+            if(sortBy === 'custom' && totalPages <= 1){
+                grid.sortable({
+                    placeholder: 'ui-sortable-placeholder',
+                    start: function(e, ui){ ui.placeholder.height(ui.item.height()); },
+                    stop: function(){ updateOrder(); }
+                });
+            }else if(grid.hasClass('ui-sortable')){
+                grid.sortable('destroy');
+            }
         }
         applyViewType();
+        renderPagination();
     }
 
     function formatFileSize(bytes){
@@ -267,6 +353,10 @@ $(function(){
             $.post('modules/media/delete_folder.php',{folder:currentFolder},function(res){
                 if(res.status==='success'){
                     currentFolder = null;
+                    currentPage = 1;
+                    currentOffset = 0;
+                    totalPages = 1;
+                    totalImagesCount = 0;
                     $('#galleryHeader').hide();
                     loadFolders();
                     loadImages();
@@ -450,10 +540,18 @@ $(function(){
     });
     $('#saveFormat').change(updateSizeEstimate);
 
-    $('#sort-by').change(function(){ sortBy = this.value; renderImages(); });
-    $('#sort-order').change(function(){ sortOrder = this.value; renderImages(); });
+    $('#sort-by').change(function(){ sortBy = this.value; currentPage = 1; loadImages(); });
+    $('#sort-order').change(function(){ sortOrder = this.value; currentPage = 1; loadImages(); });
     $('#view-type').change(function(){ viewType = this.value; applyViewType(); });
-    $('#items-per-page').change(function(){ itemsPerPage = parseInt(this.value); renderImages(); });
+    $('#items-per-page').change(function(){ itemsPerPage = parseInt(this.value,10); currentPage = 1; loadImages(); });
+
+    $('#galleryPagination').on('click', '.pagination-btn[data-page]', function(){
+        const page = parseInt($(this).data('page'), 10);
+        if(!isNaN(page) && page>=1 && page<=totalPages && page!==currentPage){
+            currentPage = page;
+            loadImages();
+        }
+    });
 
     $(window).click(function(e){
         if(e.target.id==='createFolderModal'){ closeModal('createFolderModal'); $('#newFolderName').val(''); }

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -132,6 +132,7 @@
                                         <p>Click "Upload Media" to add new files.</p>
                                     </div>
                                     <div class="image-grid" id="imageGrid" style="display: none;"></div>
+                                    <div class="gallery-pagination" id="galleryPagination" style="display:none;"></div>
                                     <div id="dropZone" class="upload-drop">Drop images here</div>
                                 </div>
                             </div>

--- a/spark-cms.css
+++ b/spark-cms.css
@@ -72,3 +72,41 @@ body {
 }
 
 
+/* Media gallery pagination */
+.gallery-pagination {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+    margin: 16px 0;
+    flex-wrap: wrap;
+}
+
+.gallery-pagination .pagination-btn {
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    padding: 6px 12px;
+    color: #1e293b;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.gallery-pagination .pagination-btn:hover:not(.is-disabled) {
+    background: #2563eb;
+    border-color: #2563eb;
+    color: #fff;
+}
+
+.gallery-pagination .pagination-btn.is-active {
+    background: #2563eb;
+    border-color: #2563eb;
+    color: #fff;
+    cursor: default;
+}
+
+.gallery-pagination .pagination-btn.is-disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+


### PR DESCRIPTION
## Summary
- add pagination state management, rendering, and event handlers for the media gallery grid
- update the gallery view markup and styles to surface pagination controls in the UI
- extend list_media.php to honor limit/offset and sort parameters while returning paging metadata

## Testing
- php -l CMS/modules/media/list_media.php

------
https://chatgpt.com/codex/tasks/task_e_68d74adb7174833199b08387e9539a0a