### PR TITLE
Add cleanup workflow for branding image uploads

### DIFF
--- a/CMS/modules/settings/settings.js
+++ b/CMS/modules/settings/settings.js
@@ -6,6 +6,8 @@ $(function(){
     const $saveButton = $('#saveSettingsButton');
     const $logoPreview = $('#logoPreview');
     const $ogPreview = $('#ogImagePreview');
+    const $clearLogo = $('#clearLogo');
+    const $clearOgImage = $('#clearOgImage');
 
     function formatTimestamp(value){
         if(!value){
@@ -70,6 +72,27 @@ $(function(){
         }
     }
 
+    function setPreviewState($preview, $checkbox, src){
+        const hasSrc = Boolean(src);
+        $checkbox.data('previewSrc', hasSrc ? src : '');
+        $checkbox.prop('checked', false).prop('disabled', !hasSrc);
+        togglePreview($preview, src);
+    }
+
+    function bindClearToggle($checkbox, $preview){
+        $checkbox.on('change', function(){
+            if(this.checked){
+                togglePreview($preview, '');
+            } else {
+                const stored = $checkbox.data('previewSrc') || '';
+                togglePreview($preview, stored);
+            }
+        });
+    }
+
+    bindClearToggle($clearLogo, $logoPreview);
+    bindClearToggle($clearOgImage, $ogPreview);
+
     function loadSettings(){
         $.getJSON('modules/settings/list_settings.php', function(data){
             data = data || {};
@@ -77,7 +100,7 @@ $(function(){
             $('#tagline').val(data.tagline || '');
             $('#admin_email').val(data.admin_email || '');
 
-            togglePreview($logoPreview, data.logo || '');
+            setPreviewState($logoPreview, $clearLogo, data.logo || '');
 
             $('#timezone').val(data.timezone || 'America/Los_Angeles');
             $('#googleAnalytics').val(data.googleAnalytics || '');
@@ -98,7 +121,7 @@ $(function(){
             const openGraph = data.open_graph || {};
             $('#ogTitle').val(openGraph.title || '');
             $('#ogDescription').val(openGraph.description || '');
-            togglePreview($ogPreview, openGraph.image || '');
+            setPreviewState($ogPreview, $clearOgImage, openGraph.image || '');
 
             updateHeroMeta(data.last_updated || '');
             updateOverview();
@@ -110,7 +133,7 @@ $(function(){
         if(file){
             const reader = new FileReader();
             reader.onload = function(e){
-                togglePreview($logoPreview, e.target.result);
+                setPreviewState($logoPreview, $clearLogo, e.target.result);
                 updateOverview();
             };
             reader.readAsDataURL(file);
@@ -122,7 +145,7 @@ $(function(){
         if(file){
             const reader = new FileReader();
             reader.onload = function(e){
-                togglePreview($ogPreview, e.target.result);
+                setPreviewState($ogPreview, $clearOgImage, e.target.result);
             };
             reader.readAsDataURL(file);
         }

--- a/CMS/modules/settings/view.php
+++ b/CMS/modules/settings/view.php
@@ -61,6 +61,12 @@
                             <input type="file" class="form-input" id="logoFile" name="logo" accept="image/*">
                             <img id="logoPreview" class="settings-file-preview" src="" alt="Logo preview" hidden>
                         </div>
+                        <div class="form-option">
+                            <label class="form-checkbox">
+                                <input type="checkbox" id="clearLogo" name="clear_logo" value="1">
+                                <span>Remove current logo</span>
+                            </label>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label class="form-label" for="timezone">Timezone</label>
@@ -152,6 +158,12 @@
                         <div class="settings-file-input">
                             <input type="file" id="ogImageFile" name="ogImage" accept="image/*">
                             <img id="ogImagePreview" class="settings-file-preview" src="" alt="Open graph image preview" hidden>
+                        </div>
+                        <div class="form-option">
+                            <label class="form-checkbox">
+                                <input type="checkbox" id="clearOgImage" name="clear_og_image" value="1">
+                                <span>Remove current image</span>
+                            </label>
                         </div>
                         <div class="form-help">Upload a 1200 × 630px image for social sharing cards.</div>
                     </div>


### PR DESCRIPTION
## Summary
- capture existing logo and Open Graph image paths so prior uploads can be cleaned up when replaced
- add UI affordances for clearing stored branding images without new uploads and wire them into the save handler
- refresh settings JavaScript to manage preview/clear state for the logo and Open Graph image fields

## Testing
- php -l CMS/modules/settings/save_settings.php

------
https://chatgpt.com/codex/tasks/task_e_68d74b03b7208331ba5ec43e753d72c1