### PR TITLE
Enforce HTTPS validation for social links

### DIFF
--- a/CMS/includes/sanitize.php
+++ b/CMS/includes/sanitize.php
@@ -8,6 +8,27 @@ function sanitize_text(string $str): string {
 function sanitize_url(string $url): string {
     return filter_var(trim($url), FILTER_SANITIZE_URL) ?: '';
 }
+
+// Validates a social profile URL. Only allows HTTPS URLs that pass FILTER_VALIDATE_URL.
+function validate_social_url(string $url): string {
+    $url = trim($url);
+
+    if ($url === '') {
+        return '';
+    }
+
+    $validated = filter_var($url, FILTER_VALIDATE_URL);
+    if ($validated === false) {
+        return '';
+    }
+
+    $scheme = parse_url($validated, PHP_URL_SCHEME);
+    if (strtolower((string) $scheme) !== 'https') {
+        return '';
+    }
+
+    return $validated;
+}
 // Sanitizes an array of tags by running sanitize_text on each
 function sanitize_tags($tags) {
     if (!is_array($tags)) return [];

--- a/CMS/modules/settings/save_settings.php
+++ b/CMS/modules/settings/save_settings.php
@@ -39,8 +39,18 @@ if (!empty($_FILES['logo']['name']) && is_uploaded_file($_FILES['logo']['tmp_nam
 
 $social = is_array($settings['social'] ?? null) ? $settings['social'] : [];
 $socialFields = ['facebook', 'twitter', 'instagram', 'linkedin', 'youtube', 'tiktok'];
+$invalidSocialFields = [];
 foreach ($socialFields as $field) {
-    $social[$field] = sanitize_url($_POST[$field] ?? ($social[$field] ?? ''));
+    if (array_key_exists($field, $_POST)) {
+        $rawValue = is_string($_POST[$field]) ? $_POST[$field] : '';
+        $validatedValue = validate_social_url($rawValue);
+        if ($validatedValue === '' && trim($rawValue) !== '') {
+            $invalidSocialFields[] = $field;
+        }
+        $social[$field] = $validatedValue;
+    } else {
+        $social[$field] = validate_social_url($social[$field] ?? '');
+    }
 }
 $settings['social'] = $social;
 
@@ -69,4 +79,5 @@ echo json_encode([
     'open_graph' => [
         'image' => $openGraph['image'] ?? null,
     ],
+    'invalid_social_fields' => $invalidSocialFields,
 ]);

--- a/CMS/modules/settings/settings.js
+++ b/CMS/modules/settings/settings.js
@@ -6,6 +6,22 @@ $(function(){
     const $saveButton = $('#saveSettingsButton');
     const $logoPreview = $('#logoPreview');
     const $ogPreview = $('#ogImagePreview');
+    const socialFieldSelectors = {
+        facebook: '#facebookLink',
+        twitter: '#twitterLink',
+        instagram: '#instagramLink',
+        linkedin: '#linkedinLink',
+        youtube: '#youtubeLink',
+        tiktok: '#tiktokLink'
+    };
+    const socialFieldLabels = {
+        facebook: 'Facebook',
+        twitter: 'Twitter',
+        instagram: 'Instagram',
+        linkedin: 'LinkedIn',
+        youtube: 'YouTube',
+        tiktok: 'TikTok'
+    };
 
     function formatTimestamp(value){
         if(!value){
@@ -68,6 +84,22 @@ $(function(){
         } else {
             $img.attr('src', '').attr('hidden', true);
         }
+    }
+
+    function setSocialFieldValidity(invalidFields){
+        invalidFields = invalidFields || [];
+        Object.keys(socialFieldSelectors).forEach(function(field){
+            const selector = socialFieldSelectors[field];
+            const $input = $(selector);
+            if(!$input.length){
+                return;
+            }
+            if(invalidFields.includes(field)){
+                $input.addClass('is-danger').attr('aria-invalid', 'true');
+            } else {
+                $input.removeClass('is-danger').removeAttr('aria-invalid');
+            }
+        });
     }
 
     function loadSettings(){
@@ -149,10 +181,20 @@ $(function(){
                 $saveButton.removeClass('is-loading').prop('disabled', false);
             },
             success: function(response){
-                alertModal('Settings saved');
+                let message = 'Settings saved';
                 if(response && response.last_updated){
                     updateHeroMeta(response.last_updated);
                 }
+                if(response && Array.isArray(response.invalid_social_fields) && response.invalid_social_fields.length){
+                    setSocialFieldValidity(response.invalid_social_fields);
+                    const invalidNames = response.invalid_social_fields.map(function(field){
+                        return socialFieldLabels[field] || field;
+                    });
+                    message += '.\nSome social links were not saved. Please enter valid HTTPS URLs for: ' + invalidNames.join(', ');
+                } else {
+                    setSocialFieldValidity([]);
+                }
+                alertModal(message);
                 loadSettings();
             },
             error: function(){


### PR DESCRIPTION
## Summary
- add a helper to accept only HTTPS social URLs that pass PHP validation
- use the stricter validation when persisting social settings and return any rejected fields
- highlight invalid social inputs in the settings UI and inform administrators when links are dropped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d74b2272fc833182ccea40126bd045