### PR TITLE
Add dedicated SEO detail page for SEO module

### DIFF
--- a/CMS/modules/seo/seo.js
+++ b/CMS/modules/seo/seo.js
@@ -213,6 +213,10 @@ $(function () {
     }
 
     function handleItemClick(event) {
+        if ($(event.target).closest('.seo-open-detail-page').length) {
+            return;
+        }
+
         const el = event.currentTarget;
         const data = parsePageData(el);
         if (!data) {
@@ -220,6 +224,10 @@ $(function () {
         }
         openDetail(data);
     }
+
+    $dashboard.on('click', '.seo-open-detail-page', function (event) {
+        event.stopPropagation();
+    });
 
     $cards.on('click', handleItemClick);
     $tableRows.on('click', handleItemClick);


### PR DESCRIPTION
## Summary
- add a parameterized SEO detail page that renders page-level insights with new helper utilities
- update dashboard cards, table rows, and styles to surface "View full report" links into the detailed view
- adjust SEO module JavaScript to ignore clicks on the new detail links so the overlay modal is not triggered

## Testing
- php -l CMS/modules/seo/view.php


------
https://chatgpt.com/codex/tasks/task_e_68d74dd135fc8331a8da41af916111f3