### PR TITLE
Add extended social profile support in settings module

### DIFF
--- a/CMS/modules/settings/save_settings.php
+++ b/CMS/modules/settings/save_settings.php
@@ -166,7 +166,23 @@ if ($previousLogo && $previousLogo !== $newLogo) {
 }
 
 $social = is_array($settings['social'] ?? null) ? $settings['social'] : [];
-$socialFields = ['facebook', 'twitter', 'instagram', 'linkedin', 'youtube', 'tiktok'];
+$socialFields = [
+    'facebook',
+    'twitter',
+    'instagram',
+    'linkedin',
+    'youtube',
+    'tiktok',
+    'pinterest',
+    'snapchat',
+    'reddit',
+    'threads',
+    'mastodon',
+    'github',
+    'dribbble',
+    'twitch',
+    'whatsapp',
+];
 foreach ($socialFields as $field) {
     $social[$field] = sanitize_url($_POST[$field] ?? ($social[$field] ?? ''));
 }

--- a/CMS/modules/settings/settings.js
+++ b/CMS/modules/settings/settings.js
@@ -38,7 +38,16 @@ $(function(){
             '#instagramLink',
             '#linkedinLink',
             '#youtubeLink',
-            '#tiktokLink'
+            '#tiktokLink',
+            '#pinterestLink',
+            '#snapchatLink',
+            '#redditLink',
+            '#threadsLink',
+            '#mastodonLink',
+            '#githubLink',
+            '#dribbbleLink',
+            '#twitchLink',
+            '#whatsappLink'
         ];
         const socialCount = socialSelectors.reduce((count, selector) => {
             return count + ($(selector).val().trim() ? 1 : 0);
@@ -117,6 +126,15 @@ $(function(){
             $('#linkedinLink').val(social.linkedin || '');
             $('#youtubeLink').val(social.youtube || '');
             $('#tiktokLink').val(social.tiktok || '');
+            $('#pinterestLink').val(social.pinterest || '');
+            $('#snapchatLink').val(social.snapchat || '');
+            $('#redditLink').val(social.reddit || '');
+            $('#threadsLink').val(social.threads || '');
+            $('#mastodonLink').val(social.mastodon || '');
+            $('#githubLink').val(social.github || '');
+            $('#dribbbleLink').val(social.dribbble || '');
+            $('#twitchLink').val(social.twitch || '');
+            $('#whatsappLink').val(social.whatsapp || '');
 
             const openGraph = data.open_graph || {};
             $('#ogTitle').val(openGraph.title || '');

--- a/CMS/modules/settings/view.php
+++ b/CMS/modules/settings/view.php
@@ -139,6 +139,42 @@
                             <label class="form-label" for="tiktokLink">TikTok</label>
                             <input type="url" class="form-input" id="tiktokLink" name="tiktok" placeholder="https://tiktok.com/@youraccount">
                         </div>
+                        <div class="form-group">
+                            <label class="form-label" for="pinterestLink">Pinterest</label>
+                            <input type="url" class="form-input" id="pinterestLink" name="pinterest" placeholder="https://pinterest.com/yourprofile">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="snapchatLink">Snapchat</label>
+                            <input type="url" class="form-input" id="snapchatLink" name="snapchat" placeholder="https://snapchat.com/add/yourusername">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="redditLink">Reddit</label>
+                            <input type="url" class="form-input" id="redditLink" name="reddit" placeholder="https://reddit.com/u/yourusername">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="threadsLink">Threads</label>
+                            <input type="url" class="form-input" id="threadsLink" name="threads" placeholder="https://threads.net/@yourusername">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="mastodonLink">Mastodon</label>
+                            <input type="url" class="form-input" id="mastodonLink" name="mastodon" placeholder="https://mastodon.social/@yourusername">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="githubLink">GitHub</label>
+                            <input type="url" class="form-input" id="githubLink" name="github" placeholder="https://github.com/yourusername">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="dribbbleLink">Dribbble</label>
+                            <input type="url" class="form-input" id="dribbbleLink" name="dribbble" placeholder="https://dribbble.com/yourprofile">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="twitchLink">Twitch</label>
+                            <input type="url" class="form-input" id="twitchLink" name="twitch" placeholder="https://twitch.tv/yourchannel">
+                        </div>
+                        <div class="form-group">
+                            <label class="form-label" for="whatsappLink">WhatsApp</label>
+                            <input type="url" class="form-input" id="whatsappLink" name="whatsapp" placeholder="https://wa.me/yourphonenumber">
+                        </div>
                     </div>
                 </article>
 


### PR DESCRIPTION
## Summary
- add UI inputs in the settings social profiles section for Pinterest, Snapchat, Reddit, Threads, Mastodon, GitHub, Dribbble, Twitch, and WhatsApp
- load and count the new social profile fields in the settings JavaScript
- persist the additional social profile URLs on save

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d74f5454448331852d21b89652275d