### PR TITLE
Add quick action navigation to dashboard

### DIFF
--- a/CMS/modules/dashboard/dashboard.js
+++ b/CMS/modules/dashboard/dashboard.js
@@ -119,12 +119,65 @@ $(function(){
             const secondary = module.secondary || '';
             const $row = $('<tr>');
             if (module.id) {
-                $row.attr('data-module', module.id);
+                $row
+                    .attr('data-module', module.id)
+                    .attr('tabindex', '0')
+                    .attr('role', 'button')
+                    .addClass('dashboard-module-link');
             }
             $('<td>').text(name).appendTo($row);
             $('<td>').text(primary).appendTo($row);
             $('<td>').text(secondary).appendTo($row);
             $table.append($row);
+        });
+    }
+
+    function navigateToModule(section) {
+        if (!section) {
+            return;
+        }
+
+        const target = String(section).trim();
+        if (!target) {
+            return;
+        }
+
+        const safeTarget = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function')
+            ? CSS.escape(target)
+            : target.replace(/"/g, '\\"');
+        const $navItem = $(`.nav-item[data-section="${safeTarget}"]`);
+
+        if ($navItem.length) {
+            $navItem.trigger('click');
+            return;
+        }
+
+        $(document).trigger('sparkcms:navigate', { section: target });
+    }
+
+    function bindModuleNavigation() {
+        $('#dashboardQuickActions')
+            .on('click', '.dashboard-quick-card', function (event) {
+                event.preventDefault();
+                navigateToModule($(this).data('module'));
+            })
+            .on('keydown', '.dashboard-quick-card', function (event) {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    navigateToModule($(this).data('module'));
+                }
+            });
+
+        $('#moduleSummaryTable').on('click', 'tbody tr[data-module]', function (event) {
+            event.preventDefault();
+            navigateToModule($(this).data('module'));
+        });
+
+        $('#moduleSummaryTable').on('keydown', 'tbody tr[data-module]', function (event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                navigateToModule($(this).data('module'));
+            }
         });
     }
 
@@ -199,5 +252,6 @@ $(function(){
         });
     }
 
+    bindModuleNavigation();
     loadStats();
 });

--- a/CMS/modules/dashboard/view.php
+++ b/CMS/modules/dashboard/view.php
@@ -24,6 +24,81 @@
                             </div>
                         </header>
 
+                        <section class="dashboard-section" aria-labelledby="dashboardSectionQuick">
+                            <div class="dashboard-section-header">
+                                <div>
+                                    <h3 class="dashboard-section-title" id="dashboardSectionQuick">Quick actions</h3>
+                                    <p class="dashboard-section-description">Jump directly into the most used tools and keep work moving.</p>
+                                </div>
+                            </div>
+                            <div class="dashboard-quick-actions" id="dashboardQuickActions" role="list">
+                                <button type="button" class="dashboard-quick-card" data-module="pages" role="listitem">
+                                    <span class="dashboard-quick-icon pages" aria-hidden="true"><i class="fa-solid fa-file-lines"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">Pages</span>
+                                        <span class="dashboard-quick-description">Publish updates and organise your site structure.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                                <button type="button" class="dashboard-quick-card" data-module="blogs" role="listitem">
+                                    <span class="dashboard-quick-icon blogs" aria-hidden="true"><i class="fa-solid fa-pen-nib"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">Blogs</span>
+                                        <span class="dashboard-quick-description">Draft fresh stories and keep readers informed.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                                <button type="button" class="dashboard-quick-card" data-module="media" role="listitem">
+                                    <span class="dashboard-quick-icon media" aria-hidden="true"><i class="fa-solid fa-images"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">Media</span>
+                                        <span class="dashboard-quick-description">Upload assets and keep your library organised.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                                <button type="button" class="dashboard-quick-card" data-module="forms" role="listitem">
+                                    <span class="dashboard-quick-icon forms" aria-hidden="true"><i class="fa-solid fa-inbox"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">Forms</span>
+                                        <span class="dashboard-quick-description">Review submissions and fine-tune entry points.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                                <button type="button" class="dashboard-quick-card" data-module="users" role="listitem">
+                                    <span class="dashboard-quick-icon users" aria-hidden="true"><i class="fa-solid fa-user-shield"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">Users</span>
+                                        <span class="dashboard-quick-description">Manage team access and keep roles up to date.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                                <button type="button" class="dashboard-quick-card" data-module="settings" role="listitem">
+                                    <span class="dashboard-quick-icon settings" aria-hidden="true"><i class="fa-solid fa-sliders"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">Settings</span>
+                                        <span class="dashboard-quick-description">Fine tune branding, metadata, and site defaults.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                                <button type="button" class="dashboard-quick-card" data-module="analytics" role="listitem">
+                                    <span class="dashboard-quick-icon analytics" aria-hidden="true"><i class="fa-solid fa-chart-line"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">Analytics</span>
+                                        <span class="dashboard-quick-description">Track performance and spot opportunities.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                                <button type="button" class="dashboard-quick-card" data-module="seo" role="listitem">
+                                    <span class="dashboard-quick-icon seo" aria-hidden="true"><i class="fa-solid fa-magnifying-glass-chart"></i></span>
+                                    <span class="dashboard-quick-content">
+                                        <span class="dashboard-quick-label">SEO</span>
+                                        <span class="dashboard-quick-description">Resolve search optimisations and boost visibility.</span>
+                                    </span>
+                                    <span class="dashboard-quick-arrow" aria-hidden="true"><i class="fa-solid fa-arrow-right"></i></span>
+                                </button>
+                            </div>
+                        </section>
+
                         <section class="dashboard-section" aria-labelledby="dashboardSectionMetrics">
                             <div class="dashboard-section-header">
                                 <div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -834,6 +834,94 @@
             font-size: 15px;
         }
 
+        .dashboard-quick-actions {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+            margin-top: 24px;
+        }
+
+        .dashboard-quick-card {
+            align-items: center;
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(238, 242, 255, 0.9));
+            border: 1px solid rgba(148, 163, 184, 0.2);
+            border-radius: 18px;
+            box-shadow: 0 12px 30px -22px rgba(15, 23, 42, 0.5);
+            color: inherit;
+            cursor: pointer;
+            display: flex;
+            gap: 16px;
+            padding: 18px 20px;
+            position: relative;
+            text-align: left;
+            transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+            width: 100%;
+        }
+
+        .dashboard-quick-card:focus-visible {
+            outline: 3px solid rgba(99, 102, 241, 0.45);
+            outline-offset: 3px;
+        }
+
+        .dashboard-quick-card:hover,
+        .dashboard-quick-card:focus {
+            border-color: rgba(37, 99, 235, 0.45);
+            box-shadow: 0 18px 45px -22px rgba(59, 130, 246, 0.45);
+            transform: translateY(-3px);
+        }
+
+        .dashboard-quick-icon {
+            align-items: center;
+            border-radius: 999px;
+            display: inline-flex;
+            font-size: 20px;
+            height: 46px;
+            justify-content: center;
+            width: 46px;
+        }
+
+        .dashboard-quick-icon.pages { background: rgba(59, 130, 246, 0.14); color: #2563eb; }
+        .dashboard-quick-icon.blogs { background: rgba(250, 204, 21, 0.18); color: #d97706; }
+        .dashboard-quick-icon.media { background: rgba(129, 140, 248, 0.18); color: #6366f1; }
+        .dashboard-quick-icon.forms { background: rgba(16, 185, 129, 0.16); color: #059669; }
+        .dashboard-quick-icon.users { background: rgba(244, 114, 182, 0.2); color: #db2777; }
+        .dashboard-quick-icon.settings { background: rgba(148, 163, 184, 0.2); color: #475569; }
+        .dashboard-quick-icon.analytics { background: rgba(251, 146, 60, 0.2); color: #ea580c; }
+        .dashboard-quick-icon.seo { background: rgba(34, 197, 94, 0.18); color: #15803d; }
+
+        .dashboard-quick-content {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .dashboard-quick-label {
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: -0.01em;
+        }
+
+        .dashboard-quick-description {
+            color: rgba(30, 41, 59, 0.65);
+            font-size: 14px;
+            line-height: 1.4;
+        }
+
+        .dashboard-quick-arrow {
+            align-items: center;
+            color: rgba(30, 41, 59, 0.35);
+            display: flex;
+            font-size: 15px;
+            margin-left: auto;
+            transition: transform 0.2s ease, color 0.2s ease;
+        }
+
+        .dashboard-quick-card:hover .dashboard-quick-arrow,
+        .dashboard-quick-card:focus .dashboard-quick-arrow {
+            color: #2563eb;
+            transform: translateX(4px);
+        }
+
         .dashboard-metric-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -904,6 +992,21 @@
             font-weight: 600;
         }
 
+        .dashboard-table-wrapper .data-table tbody tr.dashboard-module-link {
+            cursor: pointer;
+            transition: background-color 0.2s ease, color 0.2s ease;
+        }
+
+        .dashboard-table-wrapper .data-table tbody tr.dashboard-module-link:hover,
+        .dashboard-table-wrapper .data-table tbody tr.dashboard-module-link:focus {
+            background-color: rgba(59, 130, 246, 0.08);
+        }
+
+        .dashboard-table-wrapper .data-table tbody tr.dashboard-module-link:focus-visible {
+            outline: 3px solid rgba(59, 130, 246, 0.45);
+            outline-offset: -3px;
+        }
+
         @media (max-width: 960px) {
             .dashboard-hero {
                 padding: 28px;
@@ -911,6 +1014,10 @@
 
             .dashboard-section {
                 padding: 24px;
+            }
+
+            .dashboard-quick-actions {
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
             }
         }
 
@@ -931,6 +1038,10 @@
             .dashboard-section {
                 padding: 20px;
             }
+
+            .dashboard-quick-actions {
+                grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+            }
         }
 
         @media (max-width: 540px) {
@@ -942,6 +1053,10 @@
                 flex-direction: column;
                 align-items: flex-start;
                 gap: 8px;
+            }
+
+            .dashboard-quick-actions {
+                grid-template-columns: 1fr;
             }
         }
         .stat-header {


### PR DESCRIPTION
## Summary
- add a quick actions panel to the dashboard with links into key CMS modules
- style the dashboard with new quick action cards and interactive summary rows
- wire the quick actions and module summary table to trigger navigation across modules

## Testing
- php -l CMS/modules/dashboard/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d7508676048331915074eac833ac9b