### PR TITLE
Move media library creation actions to gallery toolbar

### DIFF
--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -7,16 +7,6 @@
                                     <h2 class="media-hero-title">Media Library</h2>
                                     <p class="media-hero-subtitle">Keep your images, documents, and videos organised with a modern, visual workspace that mirrors the accessibility dashboard experience.</p>
                                 </div>
-                                <div class="media-hero-actions">
-                                    <button type="button" class="media-btn media-btn--ghost" id="createFolderBtn">
-                                        <i class="fa-solid fa-folder-plus" aria-hidden="true"></i>
-                                        <span>New Folder</span>
-                                    </button>
-                                    <button type="button" class="media-btn media-btn--primary is-disabled" id="uploadBtn" disabled aria-disabled="true">
-                                        <i class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></i>
-                                        <span>Upload Media</span>
-                                    </button>
-                                </div>
                             </div>
                             <div class="media-hero-meta">
                                 <span class="media-hero-chip">
@@ -70,14 +60,22 @@
                                 <div class="folder-list" id="folderList"></div>
                             </div>
                             <div class="media-gallery">
-                                <div class="gallery-header" id="galleryHeader" style="display: none;">
+                                <div class="gallery-header" id="galleryHeader">
                                     <div>
                                         <h2 id="selectedFolderName">Select a folder</h2>
                                         <div class="folder-stats" id="folderStats"></div>
                                     </div>
                                     <div class="gallery-actions">
-                                        <button class="btn btn-secondary" id="renameFolderBtn"><i class="fa-solid fa-pen" aria-hidden="true"></i><span>Rename</span></button>
-                                        <button class="btn btn-danger" id="deleteFolderBtn"><i class="fa-solid fa-trash" aria-hidden="true"></i><span>Delete</span></button>
+                                        <button type="button" class="btn btn-secondary" id="createFolderBtn">
+                                            <i class="fa-solid fa-folder-plus" aria-hidden="true"></i>
+                                            <span>New Folder</span>
+                                        </button>
+                                        <button type="button" class="btn btn-primary is-disabled" id="uploadBtn" disabled aria-disabled="true">
+                                            <i class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></i>
+                                            <span>Upload Media</span>
+                                        </button>
+                                        <button class="btn btn-secondary" id="renameFolderBtn" style="display: none;"><i class="fa-solid fa-pen" aria-hidden="true"></i><span>Rename</span></button>
+                                        <button class="btn btn-danger" id="deleteFolderBtn" style="display: none;"><i class="fa-solid fa-trash" aria-hidden="true"></i><span>Delete</span></button>
                                     </div>
                                 </div>
                                 <div class="gallery-content" id="galleryContent">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -5691,6 +5691,18 @@
     box-shadow: none;
 }
 
+.gallery-actions .btn-primary {
+    background: linear-gradient(135deg, #7c3aed, #2563eb);
+    color: #fff;
+    border: none;
+    box-shadow: 0 14px 30px rgba(79, 70, 229, 0.35);
+}
+
+.gallery-actions .btn-primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 36px rgba(79, 70, 229, 0.45);
+}
+
 .gallery-actions .btn-secondary {
     background: #e0f2fe;
     color: #0369a1;
@@ -5709,6 +5721,13 @@
 
 .gallery-actions .btn-danger:hover {
     background: #fecaca;
+}
+
+.gallery-actions .btn.is-disabled,
+.gallery-actions .btn[disabled] {
+    opacity: 0.55;
+    cursor: not-allowed;
+    box-shadow: none;
 }
 
 .gallery-content {


### PR DESCRIPTION
## Summary
- relocate the media library "New Folder" and "Upload Media" buttons into the gallery action bar beside the rename/delete controls
- keep the folder management header visible by default so creation and upload actions remain accessible before a folder is selected
- style the gallery action primary button and disabled states to match the new layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7eee62c508331801c1312ed4ec541