### PR TITLE
Rebuild calendar module backend to use JSON-driven admin page

### DIFF
--- a/CMS/modules/calendar/manage_data.php
+++ b/CMS/modules/calendar/manage_data.php
@@ -1,297 +1,478 @@
 <?php
+/************************************************************
+ * manage_data.php
+ * 
+ * A single admin page to manage categories & events from
+ * one JSON file: calendar_data.json
+ ************************************************************/
+
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
-require_once __DIR__ . '/../../includes/sanitize.php';
 require_login();
 
-date_default_timezone_set('America/Los_Angeles');
+define('CALENDAR_DATA_FILE', __DIR__ . '/../../data/calendar_data.json');
 
-$dataFile = __DIR__ . '/../../data/calendar_data.json';
-$data = read_json_file($dataFile);
-if (!isset($data['events']) || !is_array($data['events'])) {
-    $data['events'] = [];
-}
-if (!isset($data['categories']) || !is_array($data['categories'])) {
-    $data['categories'] = [];
-}
-
-$action = $_REQUEST['action'] ?? 'fetch';
-
-switch ($action) {
-    case 'fetch':
-        respond_success([
-            'events' => array_values(array_map('format_event_for_response', $data['events'])),
-            'categories' => array_values(array_map('format_category_for_response', $data['categories']))
-        ]);
-        break;
-
-    case 'save_event':
-        $result = save_event($data);
-        if ($result['status'] === 'success') {
-            write_calendar_data($dataFile, $data);
-        }
-        respond_json($result);
-        break;
-
-    case 'delete_event':
-        $result = delete_event($data);
-        if ($result['status'] === 'success') {
-            write_calendar_data($dataFile, $data);
-        }
-        respond_json($result);
-        break;
-
-    case 'save_category':
-        $result = save_category($data);
-        if ($result['status'] === 'success') {
-            write_calendar_data($dataFile, $data);
-        }
-        respond_json($result);
-        break;
-
-    case 'delete_category':
-        $result = delete_category($data);
-        if ($result['status'] === 'success') {
-            write_calendar_data($dataFile, $data);
-        }
-        respond_json($result);
-        break;
-
-    default:
-        respond_error('Unsupported action.');
+/** Read JSON => { 'categories': [...], 'events': [...] } */
+function readData() {
+    if (!file_exists(CALENDAR_DATA_FILE)) {
+        return ['categories'=>[], 'events'=>[]];
+    }
+    $json = file_get_contents(CALENDAR_DATA_FILE);
+    $data = json_decode($json, true);
+    return $data ?? ['categories'=>[], 'events'=>[]];
 }
 
-function save_event(array &$data): array
-{
-    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
-    $title = sanitize_text($_POST['title'] ?? '');
-    $description = trim((string) ($_POST['description'] ?? ''));
-    $startDate = trim((string) ($_POST['start_date'] ?? ''));
-    $endDate = trim((string) ($_POST['end_date'] ?? ''));
-    $startTime = trim((string) ($_POST['start_time'] ?? ''));
-    $endTime = trim((string) ($_POST['end_time'] ?? ''));
-    $allDay = !empty($_POST['all_day']);
-    $categoryId = sanitize_text($_POST['category_id'] ?? '');
-    $recurrenceType = sanitize_text($_POST['recurrence_type'] ?? 'none');
-    $recurrenceInterval = isset($_POST['recurrence_interval']) ? (int) $_POST['recurrence_interval'] : 1;
-    $recurrenceEndDate = trim((string) ($_POST['recurrence_end_date'] ?? ''));
+/** Write data */
+function writeData($data) {
+    file_put_contents(CALENDAR_DATA_FILE, json_encode($data, JSON_PRETTY_PRINT));
+}
 
-    if ($title === '') {
-        return ['status' => 'error', 'message' => 'Title is required.'];
+/** Helper: new cat ID */
+function generateCategoryId($cats) {
+    $max = 0;
+    foreach ($cats as $c) {
+        if (($c['id'] ?? 0) > $max) $max = (int) $c['id'];
     }
-    if ($startDate === '' || $endDate === '') {
-        return ['status' => 'error', 'message' => 'Start and end dates are required.'];
-    }
+    return $max + 1;
+}
 
-    $allowedRecurrence = ['none', 'daily', 'weekly', 'monthly', 'yearly'];
-    if (!in_array($recurrenceType, $allowedRecurrence, true)) {
-        $recurrenceType = 'none';
+/** Helper: new event ID */
+function generateEventId($events) {
+    $max = 0;
+    foreach ($events as $e) {
+        if (($e['id'] ?? 0) > $max) $max = (int) $e['id'];
     }
-    if ($recurrenceType === 'none') {
-        $recurrenceInterval = 1;
-        $recurrenceEndDate = '';
-    } else {
-        $recurrenceInterval = max(1, $recurrenceInterval);
-    }
+    return $max + 1;
+}
 
-    if ($allDay) {
-        $startTime = '00:00';
-        $endTime = '23:59';
-    } else {
-        if ($startTime === '') {
-            $startTime = '00:00';
-        }
-        if ($endTime === '') {
-            $endTime = $startTime;
-        }
-    }
+/** Convert "2025-01-10 15:00:00" => "2025-01-10T15:00" for datetime-local */
+function toDateTimeLocal($dt) {
+    if (!$dt) return '';
+    $ts = strtotime($dt);
+    if (!$ts) return '';
+    return date('Y-m-d\TH:i', $ts);
+}
 
-    $start = DateTimeImmutable::createFromFormat('Y-m-d H:i', $startDate . ' ' . $startTime);
-    $end = DateTimeImmutable::createFromFormat('Y-m-d H:i', $endDate . ' ' . $endTime);
-    if (!$start || !$end) {
-        return ['status' => 'error', 'message' => 'Invalid dates provided.'];
-    }
-    if ($end < $start) {
-        $end = $start->modify('+1 hour');
-        $endDate = $end->format('Y-m-d');
-        $endTime = $allDay ? '23:59' : $end->format('H:i');
-    }
+// Load data
+$data = readData();
+$categories = $data['categories'];
+$events = $data['events'];
 
-    $eventData = [
-        'id' => $id !== '' ? $id : uniqid('evt_', true),
-        'title' => $title,
-        'description' => $description,
-        'start_date' => $startDate,
-        'start_time' => $allDay ? null : $startTime,
-        'end_date' => $endDate,
-        'end_time' => $allDay ? null : $endTime,
-        'all_day' => $allDay,
-        'category_id' => $categoryId !== '' ? $categoryId : null,
-        'recurrence' => [
-            'type' => $recurrenceType,
-            'interval' => $recurrenceInterval,
-            'end_date' => $recurrenceEndDate !== '' ? $recurrenceEndDate : null
-        ],
-        'updated_at' => date(DateTime::ATOM)
-    ];
+$message = '';
+$action  = $_GET['action'] ?? '';
 
-    $found = false;
-    foreach ($data['events'] as &$event) {
-        if (isset($event['id']) && $event['id'] === $eventData['id']) {
-            $event = $eventData;
-            $found = true;
+// ================ CATEGORIES =================
+if ($action === 'add_category' && $_SERVER['REQUEST_METHOD']==='POST') {
+    $name  = trim($_POST['cat_name'] ?? '');
+    $color = trim($_POST['cat_color'] ?? '#ffffff');
+    if ($name !== '') {
+        $newId = generateCategoryId($categories);
+        $categories[] = [
+            'id'    => $newId,
+            'name'  => $name,
+            'color' => $color
+        ];
+        $data['categories'] = $categories;
+        writeData($data);
+        $message = "Category '$name' added.";
+    }
+}
+elseif ($action==='delete_category' && isset($_GET['cat_id'])) {
+    $cid = intval($_GET['cat_id']);
+    foreach ($categories as $idx=>$cat) {
+        if (($cat['id'] ?? 0)===$cid) {
+            $message = "Category '" . ($cat['name'] ?? 'Category') . "' deleted.";
+            array_splice($categories,$idx,1);
+            $data['categories']=$categories;
+            writeData($data);
             break;
         }
     }
-    unset($event);
-
-    if (!$found) {
-        $data['events'][] = $eventData;
-    }
-
-    return ['status' => 'success', 'event' => format_event_for_response($eventData)];
 }
 
-function delete_event(array &$data): array
-{
-    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
-    if ($id === '') {
-        return ['status' => 'error', 'message' => 'Missing event id.'];
-    }
-
-    $initialCount = count($data['events']);
-    $data['events'] = array_values(array_filter($data['events'], static function ($event) use ($id) {
-        return !is_array($event) || ($event['id'] ?? null) !== $id;
-    }));
-
-    if (count($data['events']) === $initialCount) {
-        return ['status' => 'error', 'message' => 'Event not found.'];
-    }
-
-    return ['status' => 'success'];
-}
-
-function save_category(array &$data): array
-{
-    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
-    $name = sanitize_text($_POST['name'] ?? '');
-    $color = trim((string) ($_POST['color'] ?? ''));
-
-    if ($name === '') {
-        return ['status' => 'error', 'message' => 'Category name is required.'];
-    }
-
-    if ($color === '' || !preg_match('/^#([0-9a-fA-F]{6})$/', $color)) {
-        $color = '#2563eb';
-    }
-
-    $categoryData = [
-        'id' => $id !== '' ? $id : uniqid('cat_', true),
-        'name' => $name,
-        'color' => $color,
-        'updated_at' => date(DateTime::ATOM)
-    ];
-
-    $found = false;
-    foreach ($data['categories'] as &$category) {
-        if (isset($category['id']) && $category['id'] === $categoryData['id']) {
-            $category = $categoryData;
-            $found = true;
+// ================ EVENTS =================
+if ($action==='delete_event' && isset($_GET['evt_id'])) {
+    $eid = intval($_GET['evt_id']);
+    foreach ($events as $idx=>$ev) {
+        if (($ev['id'] ?? 0)===$eid) {
+            $message = "Event #$eid ('" . ($ev['title'] ?? 'Event') . "') deleted.";
+            array_splice($events,$idx,1);
+            $data['events']=$events;
+            writeData($data);
             break;
         }
     }
-    unset($category);
+}
+elseif ($action==='save_event' && $_SERVER['REQUEST_METHOD']==='POST') {
+    $evtId = trim($_POST['evt_id'] ?? '');
+    $title = trim($_POST['title'] ?? '');
+    $start = trim($_POST['start_date'] ?? '');
+    if ($title && $start) {
+        $desc  = trim($_POST['description'] ?? '');
+        $end   = trim($_POST['end_date'] ?? '');
+        $cat   = trim($_POST['category'] ?? '');
+        $rInt  = trim($_POST['recurring_interval'] ?? 'none');
+        $rEnd  = trim($_POST['recurring_end_date'] ?? '');
 
-    if (!$found) {
-        $data['categories'][] = $categoryData;
+        if ($evtId==='') {
+            // add new
+            $newId = generateEventId($events);
+            $newEvt = [
+                'id'                 => $newId,
+                'title'              => $title,
+                'description'        => $desc,
+                'start_date'         => $start,
+                'end_date'           => $end,
+                'category'           => $cat,
+                'recurring_interval' => $rInt,
+                'recurring_end_date' => $rEnd
+            ];
+            $events[]=$newEvt;
+            $data['events']=$events;
+            writeData($data);
+            $message="New event (#$newId) added.";
+        } else {
+            // update existing
+            $found=false;
+            foreach ($events as &$evt) {
+                if (($evt['id'] ?? null)==$evtId) {
+                    $evt['title']              = $title;
+                    $evt['description']        = $desc;
+                    $evt['start_date']         = $start;
+                    $evt['end_date']           = $end;
+                    $evt['category']           = $cat;
+                    $evt['recurring_interval'] = $rInt;
+                    $evt['recurring_end_date'] = $rEnd;
+                    $found=true;
+                    break;
+                }
+            }
+            unset($evt);
+            if($found) {
+                $data['events']=$events;
+                writeData($data);
+                $message="Event #$evtId updated.";
+            } else {
+                $message="Event #$evtId not found.";
+            }
+        }
+    } else {
+        $message="Title & Start Date are required.";
     }
-
-    return ['status' => 'success', 'category' => format_category_for_response($categoryData)];
 }
 
-function delete_category(array &$data): array
-{
-    $id = isset($_POST['id']) ? trim((string) $_POST['id']) : '';
-    if ($id === '') {
-        return ['status' => 'error', 'message' => 'Missing category id.'];
-    }
+// Reload after changes
+$data=readData();
+$categories=$data['categories'];
+$events=$data['events'];
 
-    $initialCount = count($data['categories']);
-    $data['categories'] = array_values(array_filter($data['categories'], static function ($category) use ($id) {
-        return !is_array($category) || ($category['id'] ?? null) !== $id;
-    }));
-
-    if (count($data['categories']) === $initialCount) {
-        return ['status' => 'error', 'message' => 'Category not found.'];
-    }
-
-    foreach ($data['events'] as &$event) {
-        if (isset($event['category_id']) && $event['category_id'] === $id) {
-            $event['category_id'] = null;
+// Check if editing an event
+$editingEvent = [
+ 'id'=>'',
+ 'title'=>'',
+ 'description'=>'',
+ 'start_date'=>'',
+ 'end_date'=>'',
+ 'category'=>'',
+ 'recurring_interval'=>'none',
+ 'recurring_end_date'=>''
+];
+$editingEventId = 0;
+$openNewEventModal = isset($_GET['new_event']);
+if(isset($_GET['edit_event'])) {
+    $editingEventId = intval($_GET['edit_event']);
+    foreach ($events as $ev) {
+        if(($ev['id'] ?? 0)===$editingEventId) {
+            $editingEvent=$ev;
+            break;
         }
     }
-    unset($event);
-
-    return ['status' => 'success'];
 }
 
-function write_calendar_data(string $file, array $data): void
-{
-    write_json_file($file, [
-        'events' => array_values($data['events']),
-        'categories' => array_values($data['categories'])
-    ]);
-}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Manage Calendar Data</title>
+  <link 
+    rel="stylesheet" 
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+/>
+</head>
+<body>
+<div class="container py-4">
+  <h1>Manage Calendar Data</h1>
+  <?php if($message):?>
+    <div class="alert alert-info"><?php echo htmlspecialchars($message, ENT_QUOTES, 'UTF-8'); ?></div>
+  <?php endif;?>
 
-function format_event_for_response($event): array
-{
-    if (!is_array($event)) {
-        return [];
-    }
-    return [
-        'id' => $event['id'] ?? '',
-        'title' => $event['title'] ?? '',
-        'description' => $event['description'] ?? '',
-        'start_date' => $event['start_date'] ?? '',
-        'start_time' => $event['start_time'] ?? '',
-        'end_date' => $event['end_date'] ?? '',
-        'end_time' => $event['end_time'] ?? '',
-        'all_day' => !empty($event['all_day']),
-        'category_id' => $event['category_id'] ?? '',
-        'recurrence' => [
-            'type' => $event['recurrence']['type'] ?? 'none',
-            'interval' => $event['recurrence']['interval'] ?? 1,
-            'end_date' => $event['recurrence']['end_date'] ?? null
-        ],
-        'updated_at' => $event['updated_at'] ?? null
-    ];
-}
+  <p>
+    <a href="../../admin.php#calendar" class="btn btn-secondary">← View Calendar</a>
+    <!-- Button to open the Add/Edit Event modal for "New Event" -->
+    <button 
+      type="button"
+      class="btn btn-primary"
+      data-bs-toggle="modal" 
+      data-bs-target="#manageEventModal"
+      onclick="document.getElementById('evt_id_field').value='';"
+    >
+      + Add New Event
+    </button>
+    <!-- New Manage Categories Button -->
+    <button 
+      type="button"
+      class="btn btn-outline-secondary"
+      data-bs-toggle="modal" 
+      data-bs-target="#manageCategories"
+    >
+      Manage Categories
+    </button>
+  </p>
 
-function format_category_for_response($category): array
-{
-    if (!is_array($category)) {
-        return [];
-    }
-    return [
-        'id' => $category['id'] ?? '',
-        'name' => $category['name'] ?? '',
-        'color' => $category['color'] ?? '#2563eb',
-        'updated_at' => $category['updated_at'] ?? null
-    ];
-}
+  <!-- List of events -->
+  <div class="card mb-4">
+    <div class="card-header"><strong>All Events</strong></div>
+    <div class="card-body p-0">
+      <table class="table mb-0">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Start</th>
+            <th>End</th>
+            <th>Category</th>
+            <th>Recurrence</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+        <?php if(!empty($events)):?>
+          <?php foreach($events as $evt):?>
+          <tr>
+            <td><?php echo htmlspecialchars($evt['id'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?php echo htmlspecialchars($evt['title'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?php echo htmlspecialchars($evt['start_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?php echo htmlspecialchars($evt['end_date'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?php echo htmlspecialchars($evt['category'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?php echo htmlspecialchars($evt['recurring_interval'] ?? 'none', ENT_QUOTES, 'UTF-8'); ?></td>
+            <td style="width:180px;">
+              <!-- "Edit" button opens the same modal, but we send user to ?edit_event=ID
+                   so the server can populate the fields, and we'll auto-trigger the modal. -->
+              <a href="?edit_event=<?php echo urlencode((string)($evt['id'] ?? '')); ?>" 
+                 class="btn btn-sm btn-primary">
+                 Edit
+              </a>
+              <a href="?action=delete_event&amp;evt_id=<?php echo urlencode((string)($evt['id'] ?? '')); ?>"
+                 class="btn btn-sm btn-danger"
+                 onclick="return confirm('Delete event #<?php echo htmlspecialchars($evt['id'] ?? '', ENT_QUOTES, 'UTF-8'); ?>?');">
+                 Delete
+              </a>
+            </td>
+          </tr>
+          <?php endforeach;?>
+        <?php else:?>
+          <tr><td colspan="7">No events found.</td></tr>
+        <?php endif;?>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
 
-function respond_success(array $payload = []): void
-{
-    respond_json(['status' => 'success'] + $payload);
-}
+<!-- ================== ADD/EDIT EVENT MODAL ================== -->
+<div class="modal fade" id="manageEventModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <?php if(!empty($editingEvent['id'])):?>
+          <h5 class="modal-title">Edit Event #<?php echo htmlspecialchars($editingEvent['id'], ENT_QUOTES, 'UTF-8'); ?></h5>
+        <?php else:?>
+          <h5 class="modal-title">Add New Event</h5>
+        <?php endif;?>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form class="row g-3" method="POST" action="?action=save_event">
+          <!-- Hidden ID field -->
+          <input 
+            type="hidden" 
+            name="evt_id" 
+            id="evt_id_field"
+            value="<?php echo htmlspecialchars($editingEvent['id'] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+          />
 
-function respond_error(string $message): void
-{
-    respond_json(['status' => 'error', 'message' => $message]);
-}
+          <div class="col-md-6">
+            <label class="form-label">Title*</label>
+            <input 
+              type="text" 
+              name="title" 
+              class="form-control"
+              value="<?php echo htmlspecialchars($editingEvent['title'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" 
+              required
+            />
+          </div>
 
-function respond_json(array $payload): void
-{
-    header('Content-Type: application/json');
-    echo json_encode($payload);
-}
+          <div class="col-md-6">
+            <label class="form-label">Category</label>
+            <select name="category" class="form-select">
+              <option value="">(None)</option>
+              <?php foreach($categories as $cat):?>
+                <option 
+                  value="<?php echo htmlspecialchars($cat['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>" 
+                  <?php if(($editingEvent['category'] ?? '')==($cat['name'] ?? '')) echo 'selected';?>
+                >
+                  <?php echo htmlspecialchars($cat['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>
+                </option>
+              <?php endforeach;?>
+            </select>
+          </div>
+
+          <div class="col-md-6">
+            <label class="form-label">Start Date/Time*</label>
+            <input 
+              type="datetime-local" 
+              name="start_date" 
+              class="form-control"
+              value="<?php echo htmlspecialchars(toDateTimeLocal($editingEvent['start_date'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
+              required
+            />
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">End Date/Time</label>
+            <input 
+              type="datetime-local" 
+              name="end_date" 
+              class="form-control"
+              value="<?php echo htmlspecialchars(toDateTimeLocal($editingEvent['end_date'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
+            />
+          </div>
+
+          <div class="col-md-6">
+            <label class="form-label">Recurrence</label>
+            <select name="recurring_interval" class="form-select">
+              <?php $interval = $editingEvent['recurring_interval'] ?? 'none'; ?>
+              <option value="none"    <?php if($interval==='none') echo 'selected';?>>None</option>
+              <option value="daily"   <?php if($interval==='daily') echo 'selected';?>>Daily</option>
+              <option value="weekly"  <?php if($interval==='weekly') echo 'selected';?>>Weekly</option>
+              <option value="monthly" <?php if($interval==='monthly') echo 'selected';?>>Monthly</option>
+              <option value="yearly"  <?php if($interval==='yearly') echo 'selected';?>>Yearly</option>
+            </select>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Recurrence End</label>
+            <input 
+              type="datetime-local" 
+              name="recurring_end_date"
+              class="form-control"
+              value="<?php echo htmlspecialchars(toDateTimeLocal($editingEvent['recurring_end_date'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
+            />
+          </div>
+
+          <div class="col-12">
+            <label class="form-label">Description</label>
+            <textarea name="description" class="form-control"
+            ><?php echo htmlspecialchars($editingEvent['description'] ?? '', ENT_QUOTES, 'UTF-8'); ?></textarea>
+          </div>
+
+          <div class="col-12">
+            <button type="submit" class="btn btn-success">Save Event</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============== MANAGE CATEGORIES MODAL (unchanged) ============== -->
+<div class="modal fade" id="manageCategories" tabindex="-1">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Manage Categories</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <!-- List categories, add new, etc. -->
+        <?php if(!empty($categories)):?>
+          <table class="table table-bordered">
+            <thead>
+              <tr>
+                <th>ID</th><th>Name</th><th>Color</th><th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+            <?php foreach($categories as $cat):?>
+              <tr>
+                <td><?php echo htmlspecialchars($cat['id'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+                <td><?php echo htmlspecialchars($cat['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?></td>
+                <td>
+                  <span style="display:inline-block;width:20px;height:20px;background:<?php echo htmlspecialchars($cat['color'] ?? '#fff', ENT_QUOTES, 'UTF-8'); ?>;"></span>
+                  <?php echo htmlspecialchars($cat['color'] ?? '#fff', ENT_QUOTES, 'UTF-8'); ?>
+                </td>
+                <td style="width:100px;">
+                  <a href="?action=delete_category&amp;cat_id=<?php echo urlencode((string)($cat['id'] ?? '')); ?>"
+                     class="btn btn-sm btn-danger"
+                     onclick="return confirm('Delete category <?php echo htmlspecialchars($cat['name'] ?? '', ENT_QUOTES, 'UTF-8'); ?>?');">
+                     Delete
+                  </a>
+                </td>
+              </tr>
+            <?php endforeach;?>
+            </tbody>
+          </table>
+        <?php else:?>
+          <p>No categories yet.</p>
+        <?php endif;?>
+
+        <hr>
+        <h6>Add Category</h6>
+        <form class="row g-3" method="POST" action="?action=add_category">
+          <div class="col-md-6">
+            <input 
+              type="text" 
+              name="cat_name" 
+              class="form-control" 
+              placeholder="Category Name" 
+              required
+            />
+          </div>
+          <div class="col-md-4">
+            <input 
+              type="color" 
+              name="cat_color" 
+              class="form-control form-control-color" 
+              value="#ffffff" 
+              title="Pick a color"
+            />
+          </div>
+          <div class="col-md-2">
+            <button type="submit" class="btn btn-primary w-100">Add</button>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button 
+          type="button" 
+          class="btn btn-secondary" 
+          data-bs-dismiss="modal">
+          Close
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script 
+  src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js">
+</script>
+<script>
+  // If we have ?edit_event, show the modal automatically on page load.
+  <?php if ($editingEventId || $openNewEventModal): ?>
+    document.addEventListener("DOMContentLoaded", function() {
+      var myModal = new bootstrap.Modal(document.getElementById('manageEventModal'));
+      myModal.show();
+    });
+  <?php endif; ?>
+</script>
+</body>
+</html>

--- a/CMS/modules/calendar/public_feed.php
+++ b/CMS/modules/calendar/public_feed.php
@@ -24,7 +24,7 @@ if ($timezone !== '') {
         $tz = new DateTimeZone($timezone);
         date_default_timezone_set($tz->getName());
     } catch (Exception $e) {
-        // Ignore invalid timezone values and continue with default.
+        // Ignore invalid timezone values.
     }
 }
 
@@ -47,12 +47,16 @@ $upcomingEnd = $upcomingStart->modify('+30 days');
 
 $categoryMap = [];
 foreach ($categories as $category) {
-    if (!is_array($category) || empty($category['id'])) {
+    if (!is_array($category)) {
         continue;
     }
-    $categoryMap[$category['id']] = [
-        'id' => $category['id'],
-        'name' => $category['name'] ?? 'Category',
+    $name = trim((string) ($category['name'] ?? ''));
+    if ($name === '') {
+        continue;
+    }
+    $categoryMap[$name] = [
+        'id' => $category['id'] ?? null,
+        'name' => $name,
         'color' => $category['color'] ?? '#2563eb',
     ];
 }
@@ -63,16 +67,16 @@ $upcoming = [];
 $recurringSeries = 0;
 
 foreach ($events as $event) {
-    if (!is_array($event) || empty($event['id']) || empty($event['title'])) {
+    if (!is_array($event) || empty($event['title'])) {
         continue;
     }
 
-    $recurrenceType = normalize_recurrence_type($event['recurrence']['type'] ?? ($event['recurrence_type'] ?? 'none'));
+    $recurrenceType = normalize_recurrence_type($event['recurring_interval'] ?? 'none');
     if ($recurrenceType !== 'none') {
         $recurringSeries++;
     }
 
-    if ($categoryFilter !== '' && (!isset($event['category_id']) || $event['category_id'] !== $categoryFilter)) {
+    if ($categoryFilter !== '' && trim((string) ($event['category'] ?? '')) !== $categoryFilter) {
         continue;
     }
 
@@ -83,15 +87,15 @@ foreach ($events as $event) {
         }
     }
 
-    $category = null;
-    if (!empty($event['category_id']) && isset($categoryMap[$event['category_id']])) {
-        $category = $categoryMap[$event['category_id']];
+    $categoryName = trim((string) ($event['category'] ?? ''));
+    $category = $categoryName !== '' && isset($categoryMap[$categoryName]) ? $categoryMap[$categoryName] : null;
+
+    $occurrences = expand_event_occurrences($event, $monthStart, $monthEnd, $category);
+    if ($occurrences) {
+        $results = array_merge($results, $occurrences);
     }
 
-    $occurrences = generate_occurrences($event, $monthStart, $monthEnd, $category, $recurrenceType);
-    $results = array_merge($results, $occurrences);
-
-    $upcomingOccurrences = generate_occurrences($event, $upcomingStart, $upcomingEnd, $category, $recurrenceType);
+    $upcomingOccurrences = expand_event_occurrences($event, $upcomingStart, $upcomingEnd, $category);
     if ($upcomingOccurrences) {
         $upcoming = array_merge($upcoming, $upcomingOccurrences);
     }


### PR DESCRIPTION
## Summary
- replace the calendar manage_data.php endpoint with a Bootstrap-driven admin page that directly edits the shared calendar_data.json file
- refactor the calendar helper and backend/feed endpoints to parse the new simplified event schema and expand recurrences
- update the admin calendar UI script to consume the static JSON data, redirect management actions to the new page, and keep metrics/upcoming views in sync

## Testing
- php -l CMS/modules/calendar/manage_data.php
- php -l CMS/modules/calendar/calendar_backend.php
- php -l CMS/modules/calendar/calendar_helpers.php
- php -l CMS/modules/calendar/public_feed.php

------
https://chatgpt.com/codex/tasks/task_e_68d7f253a3fc83319a59910b61f73c2d