### PR TITLE
Remove card background and shadow

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -7918,10 +7918,10 @@
         }
 
         .content-section :is(article, section, div)[class*='-card'] {
-            background: var(--module-surface);
+            background: none;
             border: 1px solid var(--module-border);
             border-radius: var(--module-radius-md);
-            box-shadow: var(--module-shadow-card);
+            box-shadow: none;
             padding: 24px;
         }
 


### PR DESCRIPTION
## Summary
- set content cards within content sections to have no background
- remove box shadow styling from the same card elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f696ea208331b791ffb10ee32908