### PR TITLE
Update calendar events to 2025-2026

### DIFF
--- a/CMS/data/calendar_data.json
+++ b/CMS/data/calendar_data.json
@@ -4,9 +4,9 @@
             "id": "evt_spring_campaign_kickoff",
             "title": "Spring Campaign Kickoff",
             "description": "Finalize goals, timelines, and messaging pillars for the spring integrated marketing campaign.",
-            "start_date": "2024-04-02",
+            "start_date": "2025-04-02",
             "start_time": "09:00",
-            "end_date": "2024-04-02",
+            "end_date": "2025-04-02",
             "end_time": "10:30",
             "all_day": false,
             "category_id": "cat_marketing",
@@ -15,15 +15,15 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-25T09:30:00-07:00"
+            "updated_at": "2025-03-25T09:30:00-07:00"
         },
         {
             "id": "evt_product_launch_dry_run",
             "title": "Product Launch Dry Run",
             "description": "Cross-functional rehearsal of launch demos, talking points, and contingency plans.",
-            "start_date": "2024-04-10",
+            "start_date": "2025-04-10",
             "start_time": "14:00",
-            "end_date": "2024-04-10",
+            "end_date": "2025-04-10",
             "end_time": "16:00",
             "all_day": false,
             "category_id": "cat_product",
@@ -32,15 +32,15 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-25T10:15:00-07:00"
+            "updated_at": "2025-03-25T10:15:00-07:00"
         },
         {
             "id": "evt_community_town_hall",
             "title": "Community Town Hall",
             "description": "Monthly open forum for customers and partners to ask questions and share feedback.",
-            "start_date": "2024-04-13",
+            "start_date": "2025-04-13",
             "start_time": "18:00",
-            "end_date": "2024-04-13",
+            "end_date": "2025-04-13",
             "end_time": "19:30",
             "all_day": false,
             "category_id": "cat_community",
@@ -49,15 +49,15 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-26T08:45:00-07:00"
+            "updated_at": "2025-03-26T08:45:00-07:00"
         },
         {
             "id": "evt_customer_advisory_board",
             "title": "Customer Advisory Board",
             "description": "Quarterly strategy session with CAB members to review roadmap priorities.",
-            "start_date": "2024-04-17",
+            "start_date": "2025-04-17",
             "start_time": "11:00",
-            "end_date": "2024-04-17",
+            "end_date": "2025-04-17",
             "end_time": "12:30",
             "all_day": false,
             "category_id": "cat_product",
@@ -66,15 +66,15 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-26T11:10:00-07:00"
+            "updated_at": "2025-03-26T11:10:00-07:00"
         },
         {
             "id": "evt_spring_launch_day",
             "title": "Spring Product Launch Day",
             "description": "Public release of v5.2, coordinated marketing, sales, and support go-live activities.",
-            "start_date": "2024-04-18",
+            "start_date": "2025-04-18",
             "start_time": null,
-            "end_date": "2024-04-18",
+            "end_date": "2025-04-18",
             "end_time": null,
             "all_day": true,
             "category_id": "cat_product",
@@ -83,15 +83,15 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-27T07:55:00-07:00"
+            "updated_at": "2025-03-27T07:55:00-07:00"
         },
         {
             "id": "evt_new_hire_orientation",
             "title": "New Hire Orientation",
             "description": "Day-one onboarding covering culture, tools, compliance, and department overviews.",
-            "start_date": "2024-04-22",
+            "start_date": "2025-04-22",
             "start_time": "09:00",
-            "end_date": "2024-04-22",
+            "end_date": "2025-04-22",
             "end_time": "15:00",
             "all_day": false,
             "category_id": "cat_training",
@@ -100,15 +100,15 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-27T09:40:00-07:00"
+            "updated_at": "2025-03-27T09:40:00-07:00"
         },
         {
             "id": "evt_quarterly_ops_review",
             "title": "Quarterly Operations Review",
             "description": "Review key metrics, SLAs, and resourcing needs for the upcoming quarter.",
-            "start_date": "2024-04-24",
+            "start_date": "2025-04-24",
             "start_time": "10:00",
-            "end_date": "2024-04-24",
+            "end_date": "2025-04-24",
             "end_time": "12:00",
             "all_day": false,
             "category_id": "cat_operations",
@@ -117,32 +117,32 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-27T14:20:00-07:00"
+            "updated_at": "2025-03-27T14:20:00-07:00"
         },
         {
             "id": "evt_weekly_support_sync",
             "title": "Weekly Support Standup",
             "description": "Fast status sync for escalations, staffing, and roadmap alignment with product support.",
-            "start_date": "2024-04-01",
+            "start_date": "2025-04-01",
             "start_time": "08:30",
-            "end_date": "2024-04-01",
+            "end_date": "2025-04-01",
             "end_time": "09:00",
             "all_day": false,
             "category_id": "cat_operations",
             "recurrence": {
                 "type": "weekly",
                 "interval": 1,
-                "end_date": "2024-06-24"
+                "end_date": "2025-06-24"
             },
-            "updated_at": "2024-03-28T08:05:00-07:00"
+            "updated_at": "2025-03-28T08:05:00-07:00"
         },
         {
             "id": "evt_volunteer_day",
             "title": "Community Volunteer Day",
             "description": "Join local partners for a day of service; lunch and transportation provided.",
-            "start_date": "2024-05-04",
+            "start_date": "2026-05-04",
             "start_time": null,
-            "end_date": "2024-05-04",
+            "end_date": "2026-05-04",
             "end_time": null,
             "all_day": true,
             "category_id": "cat_community",
@@ -151,15 +151,15 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-28T09:25:00-07:00"
+            "updated_at": "2026-03-28T09:25:00-07:00"
         },
         {
             "id": "evt_analytics_workshop",
             "title": "Advanced Analytics Workshop",
             "description": "Hands-on training covering cohort analysis, feature usage dashboards, and forecasting models.",
-            "start_date": "2024-05-08",
+            "start_date": "2026-05-08",
             "start_time": "13:00",
-            "end_date": "2024-05-08",
+            "end_date": "2026-05-08",
             "end_time": "16:00",
             "all_day": false,
             "category_id": "cat_training",
@@ -168,7 +168,7 @@
                 "interval": 1,
                 "end_date": null
             },
-            "updated_at": "2024-03-28T11:00:00-07:00"
+            "updated_at": "2026-03-28T11:00:00-07:00"
         }
     ],
     "categories": [


### PR DESCRIPTION
## Summary
- retargeted all calendar event dates to fall in 2025 and 2026
- refreshed recurrence end dates and updated_at timestamps to match the new schedule

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f83cb8d48331b584e0cc8015798e