### PR TITLE
Align module hero layouts with accessibility dashboard

### DIFF
--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -47,18 +47,18 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
 ?>
 <div class="content-section" id="analytics">
     <div class="analytics-dashboard">
-        <header class="analytics-hero">
-            <div class="analytics-hero-content">
+        <header class="a11y-hero analytics-hero">
+            <div class="a11y-hero-content analytics-hero-content">
                 <div class="analytics-hero-text">
-                    <h2 class="analytics-hero-title">Analytics Dashboard</h2>
-                    <p class="analytics-hero-subtitle">Monitor traffic trends, understand what resonates, and uncover pages that need promotion.</p>
+                    <h2 class="a11y-hero-title analytics-hero-title">Analytics Dashboard</h2>
+                    <p class="a11y-hero-subtitle analytics-hero-subtitle">Monitor traffic trends, understand what resonates, and uncover pages that need promotion.</p>
                 </div>
-                <div class="analytics-hero-actions">
-                    <button type="button" class="analytics-btn analytics-btn--primary" data-analytics-action="refresh" data-loading-text="Refreshing&hellip;">
+                <div class="a11y-hero-actions analytics-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--primary" data-analytics-action="refresh" data-loading-text="Refreshing&hellip;">
                         <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                         <span class="analytics-btn__text">Refresh data</span>
                     </button>
-                    <span class="analytics-hero-meta" id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
+                    <span class="a11y-hero-meta analytics-hero-meta" id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
                         <?php echo $lastUpdatedDisplay
                             ? 'Data refreshed ' . htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES)
                             : 'Data refreshed moments ago'; ?>

--- a/CMS/modules/blogs/view.php
+++ b/CMS/modules/blogs/view.php
@@ -1,24 +1,24 @@
 <!-- File: view.php -->
 <div class="content-section" id="blogs">
     <div class="blog-dashboard">
-        <header class="blog-hero">
-            <div class="blog-hero-content">
+        <header class="a11y-hero blog-hero">
+            <div class="a11y-hero-content blog-hero-content">
                 <div>
-                    <h2 class="blog-hero-title">Editorial Dashboard</h2>
-                    <p class="blog-hero-subtitle">Plan, publish, and measure the health of your content pipeline.</p>
+                    <h2 class="a11y-hero-title blog-hero-title">Editorial Dashboard</h2>
+                    <p class="a11y-hero-subtitle blog-hero-subtitle">Plan, publish, and measure the health of your content pipeline.</p>
                 </div>
-                <div class="blog-hero-actions">
-                    <button type="button" class="blog-btn blog-btn--ghost" id="categoriesBtn">
+                <div class="a11y-hero-actions blog-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--ghost" id="categoriesBtn">
                         <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
                         <span>Manage Categories</span>
                     </button>
-                    <button type="button" class="blog-btn blog-btn--primary" id="newPostBtn">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="newPostBtn">
                         <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
                         <span>New Post</span>
                     </button>
                 </div>
             </div>
-            <div class="blog-hero-meta">
+            <div class="a11y-hero-meta blog-hero-meta">
                 <i class="fa-regular fa-clock" aria-hidden="true"></i>
                 <span id="blogsLastUpdated">No posts yet</span>
             </div>

--- a/CMS/modules/calendar/view.php
+++ b/CMS/modules/calendar/view.php
@@ -6,18 +6,18 @@ date_default_timezone_set('America/Los_Angeles');
 ?>
 <div class="content-section" id="calendar">
     <div class="calendar-dashboard" data-timezone="America/Los_Angeles">
-        <header class="calendar-hero">
-            <div class="calendar-hero__content">
+        <header class="a11y-hero calendar-hero">
+            <div class="a11y-hero-content calendar-hero__content">
                 <div>
-                    <h2 class="calendar-hero__title">Events &amp; Campaign Calendar</h2>
-                    <p class="calendar-hero__subtitle">Plan launches, keep teams aligned, and give stakeholders a single source of truth for every upcoming milestone.</p>
+                    <h2 class="a11y-hero-title calendar-hero__title">Events &amp; Campaign Calendar</h2>
+                    <p class="a11y-hero-subtitle calendar-hero__subtitle">Plan launches, keep teams aligned, and give stakeholders a single source of truth for every upcoming milestone.</p>
                 </div>
-                <div class="calendar-hero__actions">
-                    <button type="button" class="calendar-btn calendar-btn--ghost" id="calendarManageCategoriesBtn">
+                <div class="a11y-hero-actions calendar-hero__actions">
+                    <button type="button" class="a11y-btn a11y-btn--ghost" id="calendarManageCategoriesBtn">
                         <i class="fa-solid fa-palette" aria-hidden="true"></i>
                         <span>Manage categories</span>
                     </button>
-                    <button type="button" class="calendar-btn calendar-btn--primary" id="calendarNewEventBtn">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="calendarNewEventBtn">
                         <i class="fa-solid fa-plus" aria-hidden="true"></i>
                         <span>New event</span>
                     </button>

--- a/CMS/modules/dashboard/view.php
+++ b/CMS/modules/dashboard/view.php
@@ -1,25 +1,27 @@
 <!-- File: view.php -->
                 <div class="content-section active" id="dashboard">
                     <div class="dashboard-shell">
-                        <header class="dashboard-hero">
-                            <div class="dashboard-hero-content">
-                                <span class="dashboard-hero-label">Control centre</span>
-                                <h2 class="dashboard-hero-title">Dashboard overview</h2>
-                                <p class="dashboard-hero-subtitle">
+                        <header class="a11y-hero dashboard-hero">
+                            <div class="a11y-hero-content dashboard-hero-content">
+                                <div>
+                                    <span class="a11y-hero-label dashboard-hero-label">Control centre</span>
+                                    <h2 class="a11y-hero-title dashboard-hero-title">Dashboard overview</h2>
+                                    <p class="a11y-hero-subtitle dashboard-hero-subtitle">
                                     Monitor the health of your content, media, and optimisation efforts from one unified view.
-                                </p>
-                                <div class="dashboard-hero-actions">
-                                    <button type="button" class="dashboard-btn dashboard-btn--primary" id="dashboardRefresh">
+                                    </p>
+                                </div>
+                                <div class="a11y-hero-actions dashboard-hero-actions">
+                                    <button type="button" class="a11y-btn a11y-btn--primary" id="dashboardRefresh">
                                         <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                                         <span>Refresh insights</span>
                                     </button>
-                                    <a class="dashboard-btn dashboard-btn--ghost" href="../" target="_blank" rel="noopener">
+                                    <a class="a11y-btn a11y-btn--ghost" href="../" target="_blank" rel="noopener">
                                         <i class="fa-solid fa-up-right-from-square" aria-hidden="true"></i>
                                         <span>View site</span>
                                     </a>
                                 </div>
                             </div>
-                            <div class="dashboard-hero-meta" id="dashboardLastUpdated" aria-live="polite">
+                            <div class="a11y-hero-meta dashboard-hero-meta" id="dashboardLastUpdated" aria-live="polite">
                                 Insights update automatically every few moments.
                             </div>
                         </header>

--- a/CMS/modules/logs/view.php
+++ b/CMS/modules/logs/view.php
@@ -162,28 +162,30 @@ if ($uniqueUsersCount === 1) {
 ?>
 <div class="content-section" id="logs">
     <div class="logs-dashboard" data-logs="<?php echo $logsJson; ?>" data-endpoint="modules/logs/list_logs.php">
-        <header class="logs-hero">
-            <div class="logs-hero-copy">
-                <h2 class="logs-hero-title">Activity Logs</h2>
-                <p class="logs-hero-subtitle">Monitor publishing events, workflow actions, and page edits from a single, friendly timeline.</p>
-                <div class="logs-hero-meta">
-                    <div>
-                        <span class="logs-hero-meta__label">Last activity</span>
-                        <span class="logs-hero-meta__value" id="logsLastActivity" title="<?php echo htmlspecialchars($lastActivityExact, ENT_QUOTES, 'UTF-8'); ?>">
-                            <?php echo htmlspecialchars($lastActivityLabel, ENT_QUOTES, 'UTF-8'); ?>
-                        </span>
+        <header class="a11y-hero logs-hero">
+            <div class="a11y-hero-content logs-hero-content">
+                <div class="logs-hero-copy">
+                    <h2 class="a11y-hero-title logs-hero-title">Activity Logs</h2>
+                    <p class="a11y-hero-subtitle logs-hero-subtitle">Monitor publishing events, workflow actions, and page edits from a single, friendly timeline.</p>
+                    <div class="logs-hero-meta">
+                        <div>
+                            <span class="logs-hero-meta__label">Last activity</span>
+                            <span class="logs-hero-meta__value" id="logsLastActivity" title="<?php echo htmlspecialchars($lastActivityExact, ENT_QUOTES, 'UTF-8'); ?>">
+                                <?php echo htmlspecialchars($lastActivityLabel, ENT_QUOTES, 'UTF-8'); ?>
+                            </span>
                     </div>
                     <div>
                         <span class="logs-hero-meta__label">Past 24 hours</span>
                         <span class="logs-hero-meta__value" id="logsPast24h"><?php echo $last24Hours; ?></span>
                     </div>
+                    </div>
                 </div>
-            </div>
-            <div class="logs-hero-actions">
-                <button type="button" class="logs-btn logs-btn--ghost" id="logsRefreshBtn">
-                    <i class="fas fa-rotate" aria-hidden="true"></i>
-                    <span>Refresh</span>
-                </button>
+                <div class="a11y-hero-actions logs-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--ghost" id="logsRefreshBtn">
+                        <i class="fas fa-rotate" aria-hidden="true"></i>
+                        <span>Refresh</span>
+                    </button>
+                </div>
             </div>
         </header>
 

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -1,18 +1,18 @@
 <!-- File: view.php -->
                 <div class="content-section" id="media">
                     <div class="media-dashboard">
-                        <header class="media-hero">
-                            <div class="media-hero-content">
+                        <header class="a11y-hero media-hero">
+                            <div class="a11y-hero-content media-hero-content">
                                 <div>
-                                    <h2 class="media-hero-title">Media Library</h2>
-                                    <p class="media-hero-subtitle">Keep your images, documents, and videos organised with a modern, visual workspace that mirrors the accessibility dashboard experience.</p>
+                                    <h2 class="a11y-hero-title media-hero-title">Media Library</h2>
+                                    <p class="a11y-hero-subtitle media-hero-subtitle">Keep your images, documents, and videos organised with a modern, visual workspace that mirrors the accessibility dashboard experience.</p>
                                 </div>
-                                <div class="media-hero-actions">
-                                    <button type="button" class="media-btn media-btn--ghost" id="createFolderBtn">
+                                <div class="a11y-hero-actions media-hero-actions">
+                                    <button type="button" class="a11y-btn a11y-btn--ghost" id="createFolderBtn">
                                         <i class="fa-solid fa-folder-plus" aria-hidden="true"></i>
                                         <span>New Folder</span>
                                     </button>
-                                    <button type="button" class="media-btn media-btn--primary is-disabled" id="uploadBtn" disabled aria-disabled="true">
+                                    <button type="button" class="a11y-btn a11y-btn--primary is-disabled" id="uploadBtn" disabled aria-disabled="true">
                                         <i class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></i>
                                         <span>Upload Media</span>
                                     </button>

--- a/CMS/modules/menus/view.php
+++ b/CMS/modules/menus/view.php
@@ -90,23 +90,23 @@ $filterCounts = [
 ?>
 <div class="content-section" id="menus">
     <div class="menu-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdatedIso, ENT_QUOTES); ?>">
-        <header class="menu-hero">
-            <div class="menu-hero-content">
+        <header class="a11y-hero menu-hero">
+            <div class="a11y-hero-content menu-hero-content">
                 <div>
-                    <h2 class="menu-hero-title">Navigation Menus</h2>
-                    <p class="menu-hero-subtitle">Craft intuitive navigation experiences and keep every menu in sync with your site's structure.</p>
+                    <h2 class="a11y-hero-title menu-hero-title">Navigation Menus</h2>
+                    <p class="a11y-hero-subtitle menu-hero-subtitle">Craft intuitive navigation experiences and keep every menu in sync with your site's structure.</p>
                 </div>
-                <div class="menu-hero-actions">
-                    <button type="button" class="menu-btn menu-btn--primary" id="newMenuBtn">
+                <div class="a11y-hero-actions menu-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="newMenuBtn">
                         <i class="fas fa-plus" aria-hidden="true"></i>
                         <span>New Menu</span>
                     </button>
-                    <button type="button" class="menu-btn menu-btn--icon" id="refreshMenusBtn" aria-label="Refresh menus">
+                    <button type="button" class="a11y-btn a11y-btn--icon" id="refreshMenusBtn" aria-label="Refresh menus">
                         <i class="fas fa-rotate" aria-hidden="true"></i>
                     </button>
                 </div>
             </div>
-            <span class="menu-hero-meta">
+            <span class="a11y-hero-meta menu-hero-meta">
                 <i class="fas fa-clock" aria-hidden="true"></i>
                 Last updated: <span class="js-last-updated"><?php echo htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES); ?></span>
             </span>

--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -54,25 +54,27 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
 ?>
 <div class="content-section" id="pages">
     <div class="pages-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES); ?>">
-        <header class="pages-hero">
-            <div class="pages-hero-content">
-                <span class="pages-hero-label">Content</span>
-                <h2 class="pages-hero-title">Pages</h2>
-                <p class="pages-hero-subtitle">Keep your site structure organised and publish updates with confidence.</p>
-                <div class="pages-hero-actions">
-                    <button type="button" class="pages-btn pages-btn--primary" id="newPageBtn">
+        <header class="a11y-hero pages-hero">
+            <div class="a11y-hero-content pages-hero-content">
+                <div>
+                    <span class="a11y-hero-label pages-hero-label">Content</span>
+                    <h2 class="a11y-hero-title pages-hero-title">Pages</h2>
+                    <p class="a11y-hero-subtitle pages-hero-subtitle">Keep your site structure organised and publish updates with confidence.</p>
+                </div>
+                <div class="a11y-hero-actions pages-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="newPageBtn">
                         <i class="fa-solid fa-plus" aria-hidden="true"></i>
                         <span>New Page</span>
                     </button>
-                    <a class="pages-btn pages-btn--ghost" href="../" target="_blank" rel="noopener">
+                    <a class="a11y-btn a11y-btn--ghost" href="../" target="_blank" rel="noopener">
                         <i class="fa-solid fa-up-right-from-square" aria-hidden="true"></i>
                         <span>View Site</span>
                     </a>
+                    <span class="a11y-hero-meta pages-hero-meta">
+                        <i class="fa-solid fa-clock" aria-hidden="true"></i>
+                        Last edit: <?php echo htmlspecialchars($lastUpdatedDisplay); ?>
+                    </span>
                 </div>
-                <span class="pages-hero-meta">
-                    <i class="fa-solid fa-clock" aria-hidden="true"></i>
-                    Last edit: <?php echo htmlspecialchars($lastUpdatedDisplay); ?>
-                </span>
             </div>
             <div class="pages-overview-grid">
                 <div class="pages-overview-card">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -254,7 +254,7 @@
         .logs-hero-meta {
             display: flex;
             gap: 28px;
-            margin-top: 24px;
+            margin-top: 0;
             flex-wrap: wrap;
         }
 
@@ -822,9 +822,7 @@
 
         .dashboard-hero-meta {
             position: relative;
-            margin-top: 24px;
-            font-size: 14px;
-            color: rgba(255, 255, 255, 0.85);
+            margin-top: 0;
         }
 
         .dashboard-section {
@@ -1453,18 +1451,7 @@
         }
 
         .pages-hero-meta {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 18px;
-            border-radius: 999px;
-            background: rgba(15,23,42,0.28);
-            font-size: 13px;
-            margin-top: 6px;
-        }
-
-        .pages-hero-meta i {
-            font-size: 14px;
+            margin-top: 0;
         }
 
         .pages-overview-grid {
@@ -1831,6 +1818,19 @@
             flex-wrap: wrap;
         }
 
+        .a11y-hero-label {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.18);
+            color: rgba(255, 255, 255, 0.9);
+            font-size: 13px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
         .a11y-hero-title {
             font-size: 30px;
             font-weight: 600;
@@ -1875,6 +1875,13 @@
             text-decoration: none;
             background: rgba(255,255,255,0.16);
             color: #fff;
+        }
+
+        .a11y-btn.is-disabled,
+        .a11y-btn[disabled] {
+            opacity: 0.55;
+            cursor: not-allowed;
+            box-shadow: none;
         }
 
         .a11y-btn:focus-visible {
@@ -2122,14 +2129,7 @@
         }
 
         .analytics-hero-meta {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 16px;
-            border-radius: 999px;
-            background: rgba(15,23,42,0.35);
-            font-size: 13px;
-            color: rgba(255,255,255,0.85);
+            margin-top: 0;
         }
 
         .analytics-btn {
@@ -3702,14 +3702,7 @@
         }
 
         .menu-hero-meta {
-            margin-top: 18px;
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 8px 18px;
-            border-radius: 999px;
-            background: rgba(15, 23, 42, 0.28);
-            font-size: 13px;
+            margin-top: 0;
         }
 
         .menu-btn {
@@ -4568,14 +4561,7 @@
 }
 
 .blog-hero-meta {
-    margin-top: 20px;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 14px;
-    opacity: 0.85;
-    position: relative;
-    z-index: 1;
+    margin-top: 0;
 }
 
 .blog-hero-meta i {
@@ -7674,12 +7660,12 @@
             --module-radius-lg: 24px;
             --module-radius-md: 18px;
             --module-radius-sm: 12px;
-            --module-hero-gradient: linear-gradient(135deg, #312e81 0%, #6366f1 100%);
+            --module-hero-gradient: linear-gradient(135deg, #5b21b6 0%, #2563eb 100%);
             --module-hero-overlay: rgba(255, 255, 255, 0.12);
             --module-surface: #ffffff;
             --module-border: rgba(148, 163, 184, 0.28);
             --module-text-muted: rgba(226, 232, 240, 0.9);
-            --module-shadow-hero: 0 32px 60px rgba(15, 23, 42, 0.35);
+            --module-shadow-hero: 0 20px 48px rgba(37, 99, 235, 0.35);
             --module-shadow-card: 0 18px 40px rgba(15, 23, 42, 0.12);
         }
 


### PR DESCRIPTION
## Summary
- apply the accessibility dashboard hero layout classes to every module header
- swap hero action buttons to the shared a11y button styles and keep module-specific metadata inline with the hero shell
- update shared CSS variables and helpers so every module hero inherits the same gradient, label, and disabled button treatments

## Testing
- `for f in CMS/modules/{analytics,blogs,calendar,dashboard,logs,media,menus,pages}/view.php; do php -l "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68d7f8e530188331872c77f77b46a6fd