### PR TITLE
Refocus calendar module on event list

### DIFF
--- a/CMS/modules/calendar/calendar.js
+++ b/CMS/modules/calendar/calendar.js
@@ -49,18 +49,6 @@
             state.currentMonth = state.currentMonth.add(1, 'month');
             refreshMonth();
         });
-        $('.calendar-toggle-btn').on('click', function () {
-            const view = $(this).data('view');
-            $('.calendar-toggle-btn').removeClass('active');
-            $(this).addClass('active');
-            if (view === 'list') {
-                $('#calendarGridView').attr('hidden', true);
-                $('#calendarListView').removeAttr('hidden');
-            } else {
-                $('#calendarListView').attr('hidden', true);
-                $('#calendarGridView').removeAttr('hidden');
-            }
-        });
         $('#calendarSearch').on('input', debounce(function () {
             state.filters.search = $(this).val().trim();
             refreshMonth();
@@ -125,7 +113,6 @@
                 }
                 state.events = response.events || [];
                 state.upcoming = response.upcoming || buildUpcoming(state.events);
-                renderCalendar();
                 renderList();
                 renderUpcoming();
                 updateMetrics(response.meta);
@@ -137,58 +124,6 @@
 
     function updateMonthLabel() {
         $('#calendarCurrentMonth').text(state.currentMonth.format('MMMM YYYY'));
-    }
-
-    function renderCalendar() {
-        const grid = $('#calendarGrid');
-        grid.empty();
-        const firstDayOfMonth = state.currentMonth.startOf('month');
-        const daysInMonth = state.currentMonth.daysInMonth();
-        const startWeekday = firstDayOfMonth.day();
-        const today = state.today.startOf('day');
-
-        for (let i = 0; i < startWeekday; i++) {
-            grid.append('<div class="calendar-cell calendar-cell--empty" role="presentation"></div>');
-        }
-
-        for (let day = 1; day <= daysInMonth; day++) {
-            const date = firstDayOfMonth.date(day);
-            const cell = $('<div>', {
-                class: 'calendar-cell',
-                role: 'gridcell',
-                'data-date': date.format('YYYY-MM-DD')
-            });
-            const header = $('<div>', { class: 'calendar-cell__header' });
-            const label = $('<span>', { text: day, class: 'calendar-cell__day' });
-            if (date.isSame(today, 'day')) {
-                cell.addClass('calendar-cell--today');
-                label.attr('aria-label', 'Today');
-            }
-            header.append(label);
-            cell.append(header);
-
-            const eventsForDay = state.events.filter(function (event) {
-                return dayjsLib(event.start).isSame(date, 'day');
-            });
-
-            const eventList = $('<div>', { class: 'calendar-cell__events' });
-            eventsForDay.forEach(function (event) {
-                const eventItem = $('<button>', {
-                    type: 'button',
-                    class: 'calendar-event-chip',
-                    text: event.title,
-                    css: {
-                        backgroundColor: event.category && event.category.color ? event.category.color : '#2563eb'
-                    }
-                }).on('click', function () {
-                    openEventDetail(event);
-                });
-                eventList.append(eventItem);
-            });
-
-            cell.append(eventList);
-            grid.append(cell);
-        }
     }
 
     function renderList() {

--- a/CMS/modules/calendar/view.php
+++ b/CMS/modules/calendar/view.php
@@ -6,21 +6,21 @@ date_default_timezone_set('America/Los_Angeles');
 ?>
 <div class="content-section" id="calendar">
     <div class="calendar-dashboard" data-timezone="America/Los_Angeles">
+        <div class="calendar-dashboard__actions">
+            <button type="button" class="calendar-btn calendar-btn--ghost" id="calendarManageCategoriesBtn">
+                <i class="fa-solid fa-palette" aria-hidden="true"></i>
+                <span>Manage categories</span>
+            </button>
+            <button type="button" class="calendar-btn calendar-btn--primary" id="calendarNewEventBtn">
+                <i class="fa-solid fa-plus" aria-hidden="true"></i>
+                <span>New event</span>
+            </button>
+        </div>
         <header class="calendar-hero">
             <div class="calendar-hero__content">
                 <div>
                     <h2 class="calendar-hero__title">Events &amp; Campaign Calendar</h2>
                     <p class="calendar-hero__subtitle">Plan launches, keep teams aligned, and give stakeholders a single source of truth for every upcoming milestone.</p>
-                </div>
-                <div class="calendar-hero__actions">
-                    <button type="button" class="calendar-btn calendar-btn--ghost" id="calendarManageCategoriesBtn">
-                        <i class="fa-solid fa-palette" aria-hidden="true"></i>
-                        <span>Manage categories</span>
-                    </button>
-                    <button type="button" class="calendar-btn calendar-btn--primary" id="calendarNewEventBtn">
-                        <i class="fa-solid fa-plus" aria-hidden="true"></i>
-                        <span>New event</span>
-                    </button>
                 </div>
             </div>
             <dl class="calendar-hero__metrics">
@@ -43,54 +43,34 @@ date_default_timezone_set('America/Los_Angeles');
             </dl>
         </header>
 
-        <section class="calendar-controls" aria-label="Calendar controls">
-            <div class="calendar-controls__primary">
-                <div class="calendar-month-nav" role="group" aria-label="Month navigation">
-                    <button type="button" id="calendarPrevMonth" class="calendar-icon-btn" aria-label="Previous month">
-                        <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
-                    </button>
-                    <div class="calendar-month-label" id="calendarCurrentMonth">Month YYYY</div>
-                    <button type="button" id="calendarNextMonth" class="calendar-icon-btn" aria-label="Next month">
-                        <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
-                    </button>
-                </div>
-                <div class="calendar-view-toggle" role="group" aria-label="View mode">
-                    <button type="button" class="calendar-toggle-btn active" data-view="grid">Calendar</button>
-                    <button type="button" class="calendar-toggle-btn" data-view="list">List</button>
-                </div>
-            </div>
-            <div class="calendar-controls__filters">
-                <label class="calendar-search" for="calendarSearch">
-                    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
-                    <input type="search" id="calendarSearch" placeholder="Search events, launches, campaigns" aria-label="Search events">
-                </label>
-                <label class="calendar-filter">
-                    <span>Category</span>
-                    <select id="calendarCategoryFilter">
-                        <option value="">All categories</option>
-                    </select>
-                </label>
-            </div>
-        </section>
-
         <div class="calendar-layout">
-            <section class="calendar-view" id="calendarGridView" aria-label="Calendar view">
-                <div class="calendar-weekdays" role="row">
-                    <span role="columnheader">Sun</span>
-                    <span role="columnheader">Mon</span>
-                    <span role="columnheader">Tue</span>
-                    <span role="columnheader">Wed</span>
-                    <span role="columnheader">Thu</span>
-                    <span role="columnheader">Fri</span>
-                    <span role="columnheader">Sat</span>
-                </div>
-                <div class="calendar-grid" id="calendarGrid" role="grid" aria-live="polite"></div>
-            </section>
-
-            <section class="calendar-list" id="calendarListView" aria-label="List view" hidden>
+            <section class="calendar-list" id="calendarListView" aria-label="Event list">
                 <header class="calendar-list__header">
-                    <h3>Timeline</h3>
-                    <p>Every event across categories in chronological order.</p>
+                    <div class="calendar-list__intro">
+                        <h3>Timeline</h3>
+                        <p>Every event across categories in chronological order.</p>
+                    </div>
+                    <div class="calendar-list__tools" aria-label="Calendar tools">
+                        <div class="calendar-month-nav" role="group" aria-label="Month navigation">
+                            <button type="button" id="calendarPrevMonth" class="calendar-icon-btn" aria-label="Previous month">
+                                <i class="fa-solid fa-chevron-left" aria-hidden="true"></i>
+                            </button>
+                            <div class="calendar-month-label" id="calendarCurrentMonth">Month YYYY</div>
+                            <button type="button" id="calendarNextMonth" class="calendar-icon-btn" aria-label="Next month">
+                                <i class="fa-solid fa-chevron-right" aria-hidden="true"></i>
+                            </button>
+                        </div>
+                        <label class="calendar-search" for="calendarSearch">
+                            <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                            <input type="search" id="calendarSearch" placeholder="Search events, launches, campaigns" aria-label="Search events">
+                        </label>
+                        <label class="calendar-filter">
+                            <span>Category</span>
+                            <select id="calendarCategoryFilter">
+                                <option value="">All categories</option>
+                            </select>
+                        </label>
+                    </div>
                 </header>
                 <div class="calendar-list__container" id="calendarList"></div>
             </section>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -7292,10 +7292,24 @@
     opacity: 0.9;
 }
 
-#calendar .calendar-hero__actions {
+#calendar .calendar-dashboard__actions {
     display: flex;
+    justify-content: flex-end;
     gap: 12px;
     flex-wrap: wrap;
+    margin-bottom: 24px;
+}
+
+#calendar .calendar-dashboard__actions .calendar-btn--ghost {
+    background: #eff6ff;
+    color: #1d4ed8;
+    border-color: #bfdbfe;
+}
+
+#calendar .calendar-dashboard__actions .calendar-btn--primary {
+    background: #2563eb;
+    color: #fff;
+    box-shadow: 0 16px 32px -24px rgba(37, 99, 235, 0.6);
 }
 
 #calendar .calendar-hero__metrics {
@@ -7536,6 +7550,27 @@
     border-bottom: 1px solid #e2e8f0;
     padding-bottom: 12px;
     margin-bottom: 16px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.calendar-list__intro {
+    max-width: 460px;
+}
+
+.calendar-list__tools {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    justify-content: flex-start;
+}
+
+.calendar-list__tools .calendar-filter {
+    margin-bottom: 0;
 }
 
 .calendar-list__container {
@@ -7794,12 +7829,6 @@
 }
 
 @media (max-width: 768px) {
-    .calendar-controls__primary,
-    .calendar-controls__filters {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
     .calendar-layout {
         padding: 16px;
     }
@@ -7810,6 +7839,23 @@
 
     .calendar-weekdays {
         display: none;
+    }
+
+    #calendar .calendar-dashboard__actions {
+        justify-content: flex-start;
+    }
+
+    .calendar-list__header {
+        align-items: stretch;
+    }
+
+    .calendar-list__tools {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .calendar-list__tools .calendar-search {
+        flex: 1 1 100%;
     }
 }
 


### PR DESCRIPTION
## Summary
- surface the calendar action buttons at the top of the dashboard and remove the inline calendar grid markup
- restructure the calendar view to present the event list and filters directly beneath the hero content
- simplify the calendar JavaScript to drop grid rendering logic and refresh only the list/upcoming widgets, updating supporting styles for the new layout

## Testing
- php -l CMS/modules/calendar/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d7fa4f4f988331add076b9ad3d4ca6