### PR TITLE
Add three new blog posts data entries

### DIFF
--- a/CMS/data/blog_posts.json
+++ b/CMS/data/blog_posts.json
@@ -37,5 +37,44 @@
     "publishDate": "2024-02-01T09:00:00",
     "tags": "ai, web design, future, ux",
     "createdAt": "2024-01-25T16:45:00"
+  },
+  {
+    "id": 4,
+    "title": "Designing Accessible Web Experiences",
+    "slug": "designing-accessible-web-experiences",
+    "excerpt": "Practical tips for building inclusive websites that everyone can use with ease.",
+    "content": "<p>Accessibility should be considered at every stage of a project. Start by ensuring semantic HTML, providing sufficient color contrast, and testing with assistive technologies...</p>",
+    "category": "Accessibility",
+    "author": "Lisa Wong",
+    "status": "published",
+    "publishDate": "2024-02-05T11:15:00",
+    "tags": "accessibility, inclusive design, web standards",
+    "createdAt": "2024-02-02T09:30:00"
+  },
+  {
+    "id": 5,
+    "title": "Optimizing CMS Performance for Editors",
+    "slug": "optimizing-cms-performance-editors",
+    "excerpt": "Learn how to improve content authoring speed by tuning your CMS for performance.",
+    "content": "<p>Editors rely on fast dashboards and responsive interfaces. Optimize database queries, leverage caching layers, and monitor slow interactions to keep your CMS running smoothly...</p>",
+    "category": "Productivity",
+    "author": "David Kim",
+    "status": "published",
+    "publishDate": "2024-02-10T08:45:00",
+    "tags": "cms, performance, productivity",
+    "createdAt": "2024-02-07T13:20:00"
+  },
+  {
+    "id": 6,
+    "title": "Content Strategy for Growing Startups",
+    "slug": "content-strategy-growing-startups",
+    "excerpt": "A framework that helps startup teams plan and execute impactful content campaigns.",
+    "content": "<p>Startups can achieve sustainable growth with a focused content strategy. Define your audience personas, set measurable goals, and build an editorial calendar that aligns with product milestones...</p>",
+    "category": "Marketing",
+    "author": "Priya Patel",
+    "status": "scheduled",
+    "publishDate": "2024-02-18T10:30:00",
+    "tags": "content strategy, startups, marketing",
+    "createdAt": "2024-02-09T17:10:00"
   }
 ]


### PR DESCRIPTION
## Summary
- add three additional entries to the blog posts data set for accessibility, CMS performance, and startup content topics

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d7fe55b198833196680bf158332720