### PR TITLE
Standardize module heroes to accessibility style

### DIFF
--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -47,50 +47,50 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
 ?>
 <div class="content-section" id="analytics">
     <div class="analytics-dashboard">
-        <header class="analytics-hero">
-            <div class="analytics-hero-content">
+        <header class="a11y-hero analytics-hero">
+            <div class="a11y-hero-content analytics-hero-content">
                 <div class="analytics-hero-text">
-                    <h2 class="analytics-hero-title">Analytics Dashboard</h2>
-                    <p class="analytics-hero-subtitle">Monitor traffic trends, understand what resonates, and uncover pages that need promotion.</p>
+                    <h2 class="a11y-hero-title analytics-hero-title">Analytics Dashboard</h2>
+                    <p class="a11y-hero-subtitle analytics-hero-subtitle">Monitor traffic trends, understand what resonates, and uncover pages that need promotion.</p>
                 </div>
-                <div class="analytics-hero-actions">
+                <div class="a11y-hero-actions analytics-hero-actions">
                     <button type="button" class="analytics-btn analytics-btn--primary" data-analytics-action="refresh" data-loading-text="Refreshing&hellip;">
                         <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                         <span class="analytics-btn__text">Refresh data</span>
                     </button>
-                    <span class="analytics-hero-meta" id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
+                    <span class="a11y-hero-meta analytics-hero-meta" id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
                         <?php echo $lastUpdatedDisplay
                             ? 'Data refreshed ' . htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES)
                             : 'Data refreshed moments ago'; ?>
                     </span>
                 </div>
             </div>
-            <div class="analytics-overview-grid">
-                <article class="analytics-overview-card">
-                    <div class="analytics-overview-value" id="analyticsTotalViews" data-value="<?php echo (int) $totalViews; ?>"><?php echo number_format($totalViews); ?></div>
-                    <div class="analytics-overview-label">Total Views</div>
+            <div class="a11y-overview-grid analytics-overview-grid">
+                <div class="a11y-overview-card analytics-overview-card">
+                    <div class="a11y-overview-value analytics-overview-value" id="analyticsTotalViews" data-value="<?php echo (int) $totalViews; ?>"><?php echo number_format($totalViews); ?></div>
+                    <div class="a11y-overview-label analytics-overview-label">Total Views</div>
                     <?php if (!empty($topPages)):
                         $topPage = $topPages[0]; ?>
                         <div class="analytics-overview-hint">Top page: <?php echo htmlspecialchars($topPage['title'] ?? 'Untitled', ENT_QUOTES); ?> (<?php echo number_format((int) ($topPage['views'] ?? 0)); ?>)</div>
                     <?php else: ?>
                         <div class="analytics-overview-hint">Traffic insights will appear as data arrives.</div>
                     <?php endif; ?>
-                </article>
-                <article class="analytics-overview-card">
-                    <div class="analytics-overview-value" id="analyticsAverageViews" data-value="<?php echo $averageViews; ?>"><?php echo number_format($averageViews, 1); ?></div>
-                    <div class="analytics-overview-label">Avg. views per page</div>
+                </div>
+                <div class="a11y-overview-card analytics-overview-card">
+                    <div class="a11y-overview-value analytics-overview-value" id="analyticsAverageViews" data-value="<?php echo $averageViews; ?>"><?php echo number_format($averageViews, 1); ?></div>
+                    <div class="a11y-overview-label analytics-overview-label">Avg. views per page</div>
                     <div class="analytics-overview-hint">Based on <?php echo number_format($totalPages); ?> published pages</div>
-                </article>
-                <article class="analytics-overview-card">
-                    <div class="analytics-overview-value" id="analyticsTotalPages" data-value="<?php echo $totalPages; ?>"><?php echo number_format($totalPages); ?></div>
-                    <div class="analytics-overview-label">Published pages</div>
+                </div>
+                <div class="a11y-overview-card analytics-overview-card">
+                    <div class="a11y-overview-value analytics-overview-value" id="analyticsTotalPages" data-value="<?php echo $totalPages; ?>"><?php echo number_format($totalPages); ?></div>
+                    <div class="a11y-overview-label analytics-overview-label">Published pages</div>
                     <div class="analytics-overview-hint">Includes static and dynamic content</div>
-                </article>
-                <article class="analytics-overview-card">
-                    <div class="analytics-overview-value" id="analyticsZeroPages" data-value="<?php echo $zeroViewCount; ?>"><?php echo number_format($zeroViewCount); ?></div>
-                    <div class="analytics-overview-label">Pages with no views</div>
+                </div>
+                <div class="a11y-overview-card analytics-overview-card">
+                    <div class="a11y-overview-value analytics-overview-value" id="analyticsZeroPages" data-value="<?php echo $zeroViewCount; ?>"><?php echo number_format($zeroViewCount); ?></div>
+                    <div class="a11y-overview-label analytics-overview-label">Pages with no views</div>
                     <div class="analytics-overview-hint"><?php echo $zeroViewCount > 0 ? 'Great candidates for internal promotion.' : 'Every published page has traffic.'; ?></div>
-                </article>
+                </div>
             </div>
         </header>
 

--- a/CMS/modules/blogs/view.php
+++ b/CMS/modules/blogs/view.php
@@ -1,13 +1,13 @@
 <!-- File: view.php -->
 <div class="content-section" id="blogs">
     <div class="blog-dashboard">
-        <header class="blog-hero">
-            <div class="blog-hero-content">
+        <header class="a11y-hero blog-hero">
+            <div class="a11y-hero-content blog-hero-content">
                 <div>
-                    <h2 class="blog-hero-title">Editorial Dashboard</h2>
-                    <p class="blog-hero-subtitle">Plan, publish, and measure the health of your content pipeline.</p>
+                    <h2 class="a11y-hero-title blog-hero-title">Editorial Dashboard</h2>
+                    <p class="a11y-hero-subtitle blog-hero-subtitle">Plan, publish, and measure the health of your content pipeline.</p>
                 </div>
-                <div class="blog-hero-actions">
+                <div class="a11y-hero-actions blog-hero-actions">
                     <button type="button" class="blog-btn blog-btn--ghost" id="categoriesBtn">
                         <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
                         <span>Manage Categories</span>
@@ -16,29 +16,29 @@
                         <i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>
                         <span>New Post</span>
                     </button>
+                    <span class="a11y-hero-meta blog-hero-meta">
+                        <i class="fa-regular fa-clock" aria-hidden="true"></i>
+                        <span id="blogsLastUpdated">No posts yet</span>
+                    </span>
                 </div>
             </div>
-            <div class="blog-hero-meta">
-                <i class="fa-regular fa-clock" aria-hidden="true"></i>
-                <span id="blogsLastUpdated">No posts yet</span>
-            </div>
-            <div class="blog-overview-grid">
-                <article class="blog-overview-card">
-                    <span class="blog-overview-label">Total Posts</span>
-                    <span class="blog-overview-value" id="totalPosts">0</span>
-                </article>
-                <article class="blog-overview-card">
-                    <span class="blog-overview-label">Published</span>
-                    <span class="blog-overview-value" id="publishedPosts">0</span>
-                </article>
-                <article class="blog-overview-card">
-                    <span class="blog-overview-label">Drafts</span>
-                    <span class="blog-overview-value" id="draftPosts">0</span>
-                </article>
-                <article class="blog-overview-card">
-                    <span class="blog-overview-label">Scheduled</span>
-                    <span class="blog-overview-value" id="scheduledPosts">0</span>
-                </article>
+            <div class="a11y-overview-grid blog-overview-grid">
+                <div class="a11y-overview-card blog-overview-card">
+                    <div class="a11y-overview-label blog-overview-label">Total Posts</div>
+                    <div class="a11y-overview-value blog-overview-value" id="totalPosts">0</div>
+                </div>
+                <div class="a11y-overview-card blog-overview-card">
+                    <div class="a11y-overview-label blog-overview-label">Published</div>
+                    <div class="a11y-overview-value blog-overview-value" id="publishedPosts">0</div>
+                </div>
+                <div class="a11y-overview-card blog-overview-card">
+                    <div class="a11y-overview-label blog-overview-label">Drafts</div>
+                    <div class="a11y-overview-value blog-overview-value" id="draftPosts">0</div>
+                </div>
+                <div class="a11y-overview-card blog-overview-card">
+                    <div class="a11y-overview-label blog-overview-label">Scheduled</div>
+                    <div class="a11y-overview-value blog-overview-value" id="scheduledPosts">0</div>
+                </div>
             </div>
         </header>
 

--- a/CMS/modules/calendar/view.php
+++ b/CMS/modules/calendar/view.php
@@ -6,41 +6,41 @@ date_default_timezone_set('America/Los_Angeles');
 ?>
 <div class="content-section" id="calendar">
     <div class="calendar-dashboard" data-timezone="America/Los_Angeles">
-        <div class="calendar-dashboard__actions">
-            <button type="button" class="calendar-btn calendar-btn--ghost" id="calendarManageCategoriesBtn">
-                <i class="fa-solid fa-palette" aria-hidden="true"></i>
-                <span>Manage categories</span>
-            </button>
-            <button type="button" class="calendar-btn calendar-btn--primary" id="calendarNewEventBtn">
-                <i class="fa-solid fa-plus" aria-hidden="true"></i>
-                <span>New event</span>
-            </button>
-        </div>
-        <header class="calendar-hero">
-            <div class="calendar-hero__content">
+        <header class="a11y-hero calendar-hero">
+            <div class="a11y-hero-content calendar-hero__content">
                 <div>
-                    <h2 class="calendar-hero__title">Events &amp; Campaign Calendar</h2>
-                    <p class="calendar-hero__subtitle">Plan launches, keep teams aligned, and give stakeholders a single source of truth for every upcoming milestone.</p>
+                    <h2 class="a11y-hero-title calendar-hero__title">Events &amp; Campaign Calendar</h2>
+                    <p class="a11y-hero-subtitle calendar-hero__subtitle">Plan launches, keep teams aligned, and give stakeholders a single source of truth for every upcoming milestone.</p>
+                </div>
+                <div class="a11y-hero-actions calendar-hero__actions">
+                    <button type="button" class="calendar-btn calendar-btn--ghost" id="calendarManageCategoriesBtn">
+                        <i class="fa-solid fa-palette" aria-hidden="true"></i>
+                        <span>Manage categories</span>
+                    </button>
+                    <button type="button" class="calendar-btn calendar-btn--primary" id="calendarNewEventBtn">
+                        <i class="fa-solid fa-plus" aria-hidden="true"></i>
+                        <span>New event</span>
+                    </button>
                 </div>
             </div>
-            <dl class="calendar-hero__metrics">
-                <div>
-                    <dt>Events this month</dt>
-                    <dd id="calendarMetricMonth">0</dd>
+            <div class="a11y-overview-grid calendar-hero__metrics">
+                <div class="a11y-overview-card calendar-hero__metric">
+                    <div class="a11y-overview-label">Events this month</div>
+                    <div class="a11y-overview-value" id="calendarMetricMonth">0</div>
                 </div>
-                <div>
-                    <dt>Scheduled campaigns</dt>
-                    <dd id="calendarMetricCampaigns">0</dd>
+                <div class="a11y-overview-card calendar-hero__metric">
+                    <div class="a11y-overview-label">Scheduled campaigns</div>
+                    <div class="a11y-overview-value" id="calendarMetricCampaigns">0</div>
                 </div>
-                <div>
-                    <dt>Categories</dt>
-                    <dd id="calendarMetricCategories">0</dd>
+                <div class="a11y-overview-card calendar-hero__metric">
+                    <div class="a11y-overview-label">Categories</div>
+                    <div class="a11y-overview-value" id="calendarMetricCategories">0</div>
                 </div>
-                <div>
-                    <dt>Last updated</dt>
-                    <dd id="calendarMetricUpdated">Just now</dd>
+                <div class="a11y-overview-card calendar-hero__metric">
+                    <div class="a11y-overview-label">Last updated</div>
+                    <div class="a11y-overview-value" id="calendarMetricUpdated">Just now</div>
                 </div>
-            </dl>
+            </div>
         </header>
 
         <div class="calendar-layout">

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -97,26 +97,25 @@ $lastSubmissionLabel = $latestSubmission > 0
                     </span>
                 </div>
             </div>
+            <div class="a11y-overview-grid forms-overview">
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="formsStatForms"><?php echo (int) $totalForms; ?></div>
+                    <div class="a11y-overview-label">Published forms</div>
+                </div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="formsStatActive"><?php echo (int) $activeFormsCount; ?></div>
+                    <div class="a11y-overview-label">Collecting responses</div>
+                </div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="formsStatSubmissions"><?php echo (int) $totalSubmissions; ?></div>
+                    <div class="a11y-overview-label">Total submissions</div>
+                </div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="formsStatRecent"><?php echo (int) $recentSubmissions; ?></div>
+                    <div class="a11y-overview-label">Last 30 days</div>
+                </div>
+            </div>
         </header>
-
-        <div class="a11y-overview-grid forms-overview">
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="formsStatForms"><?php echo (int) $totalForms; ?></div>
-                <div class="a11y-overview-label">Published forms</div>
-            </div>
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="formsStatActive"><?php echo (int) $activeFormsCount; ?></div>
-                <div class="a11y-overview-label">Collecting responses</div>
-            </div>
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="formsStatSubmissions"><?php echo (int) $totalSubmissions; ?></div>
-                <div class="a11y-overview-label">Total submissions</div>
-            </div>
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="formsStatRecent"><?php echo (int) $recentSubmissions; ?></div>
-                <div class="a11y-overview-label">Last 30 days</div>
-            </div>
-        </div>
 
         <div class="forms-main-grid">
             <section class="a11y-detail-card forms-table-card">

--- a/CMS/modules/import_export/view.php
+++ b/CMS/modules/import_export/view.php
@@ -1,5 +1,44 @@
 <!-- File: view.php -->
                 <div class="content-section" id="import">
-                    <h2>Import/Export</h2>
-                    <p>Import or export CMS data.</p>
+                    <div class="import-dashboard">
+                        <header class="a11y-hero import-hero">
+                            <div class="a11y-hero-content import-hero-content">
+                                <div>
+                                    <h2 class="a11y-hero-title import-hero-title">Import &amp; Export</h2>
+                                    <p class="a11y-hero-subtitle import-hero-subtitle">Transfer site content, menus, media, and settings between environments with confidence.</p>
+                                </div>
+                                <div class="a11y-hero-actions import-hero-actions">
+                                    <button type="button" class="a11y-btn a11y-btn--primary" id="startImportBtn">
+                                        <i class="fas fa-file-arrow-up" aria-hidden="true"></i>
+                                        <span>Start import</span>
+                                    </button>
+                                    <button type="button" class="a11y-btn a11y-btn--ghost" id="startExportBtn">
+                                        <i class="fas fa-file-arrow-down" aria-hidden="true"></i>
+                                        <span>Generate export</span>
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="a11y-overview-grid import-overview-grid">
+                                <div class="a11y-overview-card import-overview-card">
+                                    <div class="a11y-overview-label">Last import</div>
+                                    <div class="a11y-overview-value" id="importLastRun">—</div>
+                                </div>
+                                <div class="a11y-overview-card import-overview-card">
+                                    <div class="a11y-overview-label">Last export</div>
+                                    <div class="a11y-overview-value" id="exportLastRun">—</div>
+                                </div>
+                                <div class="a11y-overview-card import-overview-card">
+                                    <div class="a11y-overview-label">Available profiles</div>
+                                    <div class="a11y-overview-value" id="importProfilesCount">0</div>
+                                </div>
+                                <div class="a11y-overview-card import-overview-card">
+                                    <div class="a11y-overview-label">Exports generated</div>
+                                    <div class="a11y-overview-value" id="exportGeneratedCount">0</div>
+                                </div>
+                            </div>
+                        </header>
+                        <div class="import-placeholder">
+                            <p>Import or export CMS data.</p>
+                        </div>
+                    </div>
                 </div>

--- a/CMS/modules/logs/view.php
+++ b/CMS/modules/logs/view.php
@@ -162,61 +162,58 @@ if ($uniqueUsersCount === 1) {
 ?>
 <div class="content-section" id="logs">
     <div class="logs-dashboard" data-logs="<?php echo $logsJson; ?>" data-endpoint="modules/logs/list_logs.php">
-        <header class="logs-hero">
-            <div class="logs-hero-copy">
-                <h2 class="logs-hero-title">Activity Logs</h2>
-                <p class="logs-hero-subtitle">Monitor publishing events, workflow actions, and page edits from a single, friendly timeline.</p>
-                <div class="logs-hero-meta">
-                    <div>
+        <header class="a11y-hero logs-hero">
+            <div class="a11y-hero-content logs-hero-content">
+                <div>
+                    <h2 class="a11y-hero-title logs-hero-title">Activity Logs</h2>
+                    <p class="a11y-hero-subtitle logs-hero-subtitle">Monitor publishing events, workflow actions, and page edits from a single, friendly timeline.</p>
+                </div>
+                <div class="a11y-hero-actions logs-hero-actions">
+                    <button type="button" class="logs-btn logs-btn--ghost" id="logsRefreshBtn">
+                        <i class="fas fa-rotate" aria-hidden="true"></i>
+                        <span>Refresh</span>
+                    </button>
+                    <span class="a11y-hero-meta logs-hero-meta-item">
                         <span class="logs-hero-meta__label">Last activity</span>
                         <span class="logs-hero-meta__value" id="logsLastActivity" title="<?php echo htmlspecialchars($lastActivityExact, ENT_QUOTES, 'UTF-8'); ?>">
                             <?php echo htmlspecialchars($lastActivityLabel, ENT_QUOTES, 'UTF-8'); ?>
                         </span>
-                    </div>
-                    <div>
+                    </span>
+                    <span class="a11y-hero-meta logs-hero-meta-item">
                         <span class="logs-hero-meta__label">Past 24 hours</span>
                         <span class="logs-hero-meta__value" id="logsPast24h"><?php echo $last24Hours; ?></span>
-                    </div>
+                    </span>
                 </div>
             </div>
-            <div class="logs-hero-actions">
-                <button type="button" class="logs-btn logs-btn--ghost" id="logsRefreshBtn">
-                    <i class="fas fa-rotate" aria-hidden="true"></i>
-                    <span>Refresh</span>
-                </button>
-            </div>
-        </header>
-
-        <section class="logs-stats" aria-label="Activity summary">
-            <div class="logs-stats-grid">
-                <article class="logs-stat-card">
-                    <span class="logs-stat-label">Total events</span>
-                    <span class="logs-stat-value" id="logsTotalCount"><?php echo $totalLogs; ?></span>
-                    <span class="logs-stat-hint"><span id="logsLast7Days"><?php echo $last7Days; ?></span> in the last 7 days</span>
-                </article>
-                <article class="logs-stat-card">
-                    <span class="logs-stat-label">Active editors</span>
-                    <span class="logs-stat-value" id="logsUserCount"><?php echo $uniqueUsersCount; ?></span>
-                    <span class="logs-stat-hint"><?php echo htmlspecialchars($editorsHint, ENT_QUOTES, 'UTF-8'); ?></span>
-                </article>
-                <article class="logs-stat-card">
-                    <span class="logs-stat-label">Pages updated</span>
-                    <span class="logs-stat-value" id="logsPageCount"><?php echo $uniquePagesCount; ?></span>
-                    <span class="logs-stat-hint">
+            <div class="a11y-overview-grid logs-overview-grid">
+                <div class="a11y-overview-card logs-overview-card">
+                    <div class="a11y-overview-label logs-stat-label">Total events</div>
+                    <div class="a11y-overview-value logs-stat-value" id="logsTotalCount"><?php echo $totalLogs; ?></div>
+                    <div class="logs-stat-hint"><span id="logsLast7Days"><?php echo $last7Days; ?></span> in the last 7 days</div>
+                </div>
+                <div class="a11y-overview-card logs-overview-card">
+                    <div class="a11y-overview-label logs-stat-label">Active editors</div>
+                    <div class="a11y-overview-value logs-stat-value" id="logsUserCount"><?php echo $uniqueUsersCount; ?></div>
+                    <div class="logs-stat-hint"><?php echo htmlspecialchars($editorsHint, ENT_QUOTES, 'UTF-8'); ?></div>
+                </div>
+                <div class="a11y-overview-card logs-overview-card">
+                    <div class="a11y-overview-label logs-stat-label">Pages updated</div>
+                    <div class="a11y-overview-value logs-stat-value" id="logsPageCount"><?php echo $uniquePagesCount; ?></div>
+                    <div class="logs-stat-hint">
                         <?php if ($uniquePagesCount > 0): ?>
                             Most recent: <?php echo $recentPageTitle; ?>
                         <?php else: ?>
                             Waiting for the first edit
                         <?php endif; ?>
-                    </span>
-                </article>
-                <article class="logs-stat-card">
-                    <span class="logs-stat-label">Most common action</span>
-                    <span class="logs-stat-value" id="logsTopActionLabel"><?php echo $topActionLabel; ?></span>
-                    <span class="logs-stat-hint" id="logsTopActionCount"><?php echo htmlspecialchars($topActionCountText, ENT_QUOTES, 'UTF-8'); ?></span>
-                </article>
+                    </div>
+                </div>
+                <div class="a11y-overview-card logs-overview-card">
+                    <div class="a11y-overview-label logs-stat-label">Most common action</div>
+                    <div class="a11y-overview-value logs-stat-value" id="logsTopActionLabel"><?php echo $topActionLabel; ?></div>
+                    <div class="logs-stat-hint" id="logsTopActionCount"><?php echo htmlspecialchars($topActionCountText, ENT_QUOTES, 'UTF-8'); ?></div>
+                </div>
             </div>
-        </section>
+        </header>
 
         <section class="logs-activity" aria-label="Activity feed">
             <div class="logs-activity-header">

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -1,13 +1,13 @@
 <!-- File: view.php -->
                 <div class="content-section" id="media">
                     <div class="media-dashboard">
-                        <header class="media-hero">
-                            <div class="media-hero-content">
+                        <header class="a11y-hero media-hero">
+                            <div class="a11y-hero-content media-hero-content">
                                 <div>
-                                    <h2 class="media-hero-title">Media Library</h2>
-                                    <p class="media-hero-subtitle">Keep your images, documents, and videos organised with a modern, visual workspace that mirrors the accessibility dashboard experience.</p>
+                                    <h2 class="a11y-hero-title media-hero-title">Media Library</h2>
+                                    <p class="a11y-hero-subtitle media-hero-subtitle">Keep your images, documents, and videos organised with a modern, visual workspace that mirrors the accessibility dashboard experience.</p>
                                 </div>
-                                <div class="media-hero-actions">
+                                <div class="a11y-hero-actions media-hero-actions">
                                     <button type="button" class="media-btn media-btn--ghost" id="createFolderBtn">
                                         <i class="fa-solid fa-folder-plus" aria-hidden="true"></i>
                                         <span>New Folder</span>
@@ -36,31 +36,30 @@
                                     <span id="mediaStorageSummary">0 used</span>
                                 </span>
                             </div>
+                            <div class="a11y-overview-grid media-overview-grid">
+                                <div class="a11y-overview-card media-overview-card">
+                                    <span class="media-overview-icon"><i class="fa-solid fa-folder-open" aria-hidden="true"></i></span>
+                                    <div class="media-overview-content">
+                                        <span class="a11y-overview-label media-overview-label">Folders</span>
+                                        <span class="a11y-overview-value media-overview-value" id="totalFolders">0</span>
+                                    </div>
+                                </div>
+                                <div class="a11y-overview-card media-overview-card">
+                                    <span class="media-overview-icon"><i class="fa-solid fa-images" aria-hidden="true"></i></span>
+                                    <div class="media-overview-content">
+                                        <span class="a11y-overview-label media-overview-label">Files</span>
+                                        <span class="a11y-overview-value media-overview-value" id="totalImages">0</span>
+                                    </div>
+                                </div>
+                                <div class="a11y-overview-card media-overview-card">
+                                    <span class="media-overview-icon"><i class="fa-solid fa-database" aria-hidden="true"></i></span>
+                                    <div class="media-overview-content">
+                                        <span class="a11y-overview-label media-overview-label">Storage Used</span>
+                                        <span class="a11y-overview-value media-overview-value" id="totalSize">0</span>
+                                    </div>
+                                </div>
+                            </div>
                         </header>
-
-                        <div class="media-overview-grid">
-                            <article class="media-overview-card">
-                                <span class="media-overview-icon"><i class="fa-solid fa-folder-open" aria-hidden="true"></i></span>
-                                <div class="media-overview-content">
-                                    <span class="media-overview-label">Folders</span>
-                                    <span class="media-overview-value" id="totalFolders">0</span>
-                                </div>
-                            </article>
-                            <article class="media-overview-card">
-                                <span class="media-overview-icon"><i class="fa-solid fa-images" aria-hidden="true"></i></span>
-                                <div class="media-overview-content">
-                                    <span class="media-overview-label">Files</span>
-                                    <span class="media-overview-value" id="totalImages">0</span>
-                                </div>
-                            </article>
-                            <article class="media-overview-card">
-                                <span class="media-overview-icon"><i class="fa-solid fa-database" aria-hidden="true"></i></span>
-                                <div class="media-overview-content">
-                                    <span class="media-overview-label">Storage Used</span>
-                                    <span class="media-overview-value" id="totalSize">0</span>
-                                </div>
-                            </article>
-                        </div>
 
                         <div class="media-workspace">
                             <div class="media-sidebar">

--- a/CMS/modules/menus/view.php
+++ b/CMS/modules/menus/view.php
@@ -90,13 +90,13 @@ $filterCounts = [
 ?>
 <div class="content-section" id="menus">
     <div class="menu-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdatedIso, ENT_QUOTES); ?>">
-        <header class="menu-hero">
-            <div class="menu-hero-content">
+        <header class="a11y-hero menu-hero">
+            <div class="a11y-hero-content menu-hero-content">
                 <div>
-                    <h2 class="menu-hero-title">Navigation Menus</h2>
-                    <p class="menu-hero-subtitle">Craft intuitive navigation experiences and keep every menu in sync with your site's structure.</p>
+                    <h2 class="a11y-hero-title menu-hero-title">Navigation Menus</h2>
+                    <p class="a11y-hero-subtitle menu-hero-subtitle">Craft intuitive navigation experiences and keep every menu in sync with your site's structure.</p>
                 </div>
-                <div class="menu-hero-actions">
+                <div class="a11y-hero-actions menu-hero-actions">
                     <button type="button" class="menu-btn menu-btn--primary" id="newMenuBtn">
                         <i class="fas fa-plus" aria-hidden="true"></i>
                         <span>New Menu</span>
@@ -104,32 +104,31 @@ $filterCounts = [
                     <button type="button" class="menu-btn menu-btn--icon" id="refreshMenusBtn" aria-label="Refresh menus">
                         <i class="fas fa-rotate" aria-hidden="true"></i>
                     </button>
+                    <span class="a11y-hero-meta menu-hero-meta">
+                        <i class="fas fa-clock" aria-hidden="true"></i>
+                        Last updated: <span class="js-last-updated"><?php echo htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES); ?></span>
+                    </span>
                 </div>
             </div>
-            <span class="menu-hero-meta">
-                <i class="fas fa-clock" aria-hidden="true"></i>
-                Last updated: <span class="js-last-updated"><?php echo htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES); ?></span>
-            </span>
+            <div class="a11y-overview-grid menu-overview-grid">
+                <div class="a11y-overview-card menu-overview-card">
+                    <div class="a11y-overview-label menu-overview-label">Total Menus</div>
+                    <div class="a11y-overview-value menu-overview-value" id="menuStatTotal"><?php echo $totalMenus; ?></div>
+                </div>
+                <div class="a11y-overview-card menu-overview-card">
+                    <div class="a11y-overview-label menu-overview-label">Total Links</div>
+                    <div class="a11y-overview-value menu-overview-value" id="menuStatLinks"><?php echo $totalLinks; ?></div>
+                </div>
+                <div class="a11y-overview-card menu-overview-card">
+                    <div class="a11y-overview-label menu-overview-label">Menus with Submenus</div>
+                    <div class="a11y-overview-value menu-overview-value" id="menuStatNested"><?php echo $menusWithNested; ?></div>
+                </div>
+                <div class="a11y-overview-card menu-overview-card">
+                    <div class="a11y-overview-label menu-overview-label">Average Links per Menu</div>
+                    <div class="a11y-overview-value menu-overview-value" id="menuStatAverage"><?php echo $averageLinks; ?></div>
+                </div>
+            </div>
         </header>
-
-        <div class="menu-overview-grid">
-            <div class="menu-overview-card">
-                <div class="menu-overview-value" id="menuStatTotal"><?php echo $totalMenus; ?></div>
-                <div class="menu-overview-label">Total Menus</div>
-            </div>
-            <div class="menu-overview-card">
-                <div class="menu-overview-value" id="menuStatLinks"><?php echo $totalLinks; ?></div>
-                <div class="menu-overview-label">Total Links</div>
-            </div>
-            <div class="menu-overview-card">
-                <div class="menu-overview-value" id="menuStatNested"><?php echo $menusWithNested; ?></div>
-                <div class="menu-overview-label">Menus with Submenus</div>
-            </div>
-            <div class="menu-overview-card">
-                <div class="menu-overview-value" id="menuStatAverage"><?php echo $averageLinks; ?></div>
-                <div class="menu-overview-label">Average Links per Menu</div>
-            </div>
-        </div>
 
         <div class="menu-controls">
             <label class="menu-search" for="menuSearchInput">

--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -54,12 +54,14 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
 ?>
 <div class="content-section" id="pages">
     <div class="pages-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES); ?>">
-        <header class="pages-hero">
-            <div class="pages-hero-content">
-                <span class="pages-hero-label">Content</span>
-                <h2 class="pages-hero-title">Pages</h2>
-                <p class="pages-hero-subtitle">Keep your site structure organised and publish updates with confidence.</p>
-                <div class="pages-hero-actions">
+        <header class="a11y-hero pages-hero">
+            <div class="a11y-hero-content pages-hero-content">
+                <div>
+                    <span class="pages-hero-label">Content</span>
+                    <h2 class="a11y-hero-title pages-hero-title">Pages</h2>
+                    <p class="a11y-hero-subtitle pages-hero-subtitle">Keep your site structure organised and publish updates with confidence.</p>
+                </div>
+                <div class="a11y-hero-actions pages-hero-actions">
                     <button type="button" class="pages-btn pages-btn--primary" id="newPageBtn">
                         <i class="fa-solid fa-plus" aria-hidden="true"></i>
                         <span>New Page</span>
@@ -68,28 +70,28 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                         <i class="fa-solid fa-up-right-from-square" aria-hidden="true"></i>
                         <span>View Site</span>
                     </a>
+                    <span class="a11y-hero-meta pages-hero-meta">
+                        <i class="fa-solid fa-clock" aria-hidden="true"></i>
+                        Last edit: <?php echo htmlspecialchars($lastUpdatedDisplay); ?>
+                    </span>
                 </div>
-                <span class="pages-hero-meta">
-                    <i class="fa-solid fa-clock" aria-hidden="true"></i>
-                    Last edit: <?php echo htmlspecialchars($lastUpdatedDisplay); ?>
-                </span>
             </div>
-            <div class="pages-overview-grid">
-                <div class="pages-overview-card">
-                    <div class="pages-overview-value"><?php echo $totalPages; ?></div>
-                    <div class="pages-overview-label">Total Pages</div>
+            <div class="a11y-overview-grid pages-overview-grid">
+                <div class="a11y-overview-card pages-overview-card">
+                    <div class="a11y-overview-label pages-overview-label">Total Pages</div>
+                    <div class="a11y-overview-value pages-overview-value"><?php echo $totalPages; ?></div>
                 </div>
-                <div class="pages-overview-card">
-                    <div class="pages-overview-value"><?php echo $publishedPages; ?></div>
-                    <div class="pages-overview-label">Published</div>
+                <div class="a11y-overview-card pages-overview-card">
+                    <div class="a11y-overview-label pages-overview-label">Published</div>
+                    <div class="a11y-overview-value pages-overview-value"><?php echo $publishedPages; ?></div>
                 </div>
-                <div class="pages-overview-card">
-                    <div class="pages-overview-value"><?php echo $draftPages; ?></div>
-                    <div class="pages-overview-label">Drafts</div>
+                <div class="a11y-overview-card pages-overview-card">
+                    <div class="a11y-overview-label pages-overview-label">Drafts</div>
+                    <div class="a11y-overview-value pages-overview-value"><?php echo $draftPages; ?></div>
                 </div>
-                <div class="pages-overview-card">
-                    <div class="pages-overview-value"><?php echo $totalViews; ?></div>
-                    <div class="pages-overview-label">Total Views</div>
+                <div class="a11y-overview-card pages-overview-card">
+                    <div class="a11y-overview-label pages-overview-label">Total Views</div>
+                    <div class="a11y-overview-value pages-overview-value"><?php echo $totalViews; ?></div>
                 </div>
             </div>
         </header>

--- a/CMS/modules/search/view.php
+++ b/CMS/modules/search/view.php
@@ -37,12 +37,54 @@ if ($lower !== '') {
         }
     }
 }
+$resultCount = count($results);
+$typeCounts = [
+    'Page' => 0,
+    'Post' => 0,
+    'Media' => 0,
+];
+foreach ($results as $entry) {
+    $type = $entry['type'] ?? '';
+    if (isset($typeCounts[$type])) {
+        $typeCounts[$type]++;
+    }
+}
 ?>
 <div class="content-section" id="search" data-query="<?php echo htmlspecialchars($q); ?>">
-    <div class="table-card">
-        <div class="table-header">
-            <div class="table-title">Search Results<?php if($q!=='') echo ' for \''.htmlspecialchars($q).'\''; ?></div>
-        </div>
+    <div class="search-dashboard">
+        <header class="a11y-hero search-hero">
+            <div class="a11y-hero-content search-hero-content">
+                <div>
+                    <h2 class="a11y-hero-title search-hero-title">Unified Search</h2>
+                    <p class="a11y-hero-subtitle search-hero-subtitle">Surface pages, posts, and media without leaving the dashboard.</p>
+                </div>
+                <div class="a11y-hero-actions search-hero-actions">
+                    <span class="a11y-hero-meta search-hero-meta">
+                        <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
+                        <?php echo $resultCount === 1 ? 'Showing 1 result' : 'Showing ' . number_format($resultCount) . ' results'; ?><?php if ($q !== ''): ?> for “<?php echo htmlspecialchars($q); ?>”<?php endif; ?>
+                    </span>
+                </div>
+            </div>
+            <div class="a11y-overview-grid search-overview-grid">
+                <div class="a11y-overview-card search-overview-card">
+                    <div class="a11y-overview-label">Pages</div>
+                    <div class="a11y-overview-value" id="searchCountPages"><?php echo number_format($typeCounts['Page']); ?></div>
+                </div>
+                <div class="a11y-overview-card search-overview-card">
+                    <div class="a11y-overview-label">Posts</div>
+                    <div class="a11y-overview-value" id="searchCountPosts"><?php echo number_format($typeCounts['Post']); ?></div>
+                </div>
+                <div class="a11y-overview-card search-overview-card">
+                    <div class="a11y-overview-label">Media</div>
+                    <div class="a11y-overview-value" id="searchCountMedia"><?php echo number_format($typeCounts['Media']); ?></div>
+                </div>
+            </div>
+        </header>
+
+        <div class="table-card">
+            <div class="table-header">
+                <div class="table-title">Search Results<?php if($q!=='') echo ' for \''.htmlspecialchars($q).'\''; ?></div>
+            </div>
         <table class="data-table">
             <thead>
                 <tr><th>Type</th><th>Title</th><th>Slug</th><th>Status</th><th>Actions</th></tr>
@@ -78,5 +120,6 @@ if ($lower !== '') {
                 <?php endif; ?>
             </tbody>
         </table>
+        </div>
     </div>
 </div>

--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -1162,7 +1162,7 @@ if ($detailSlug !== null && $detailSlug !== '') {
             font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
             color: #0f172a;
         }
-        .seo-dashboard .seo-header {
+        .seo-dashboard .seo-hero {
             background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
             color: #fff;
             border-radius: 20px;
@@ -1171,7 +1171,7 @@ if ($detailSlug !== null && $detailSlug !== '') {
             position: relative;
             overflow: hidden;
         }
-        .seo-dashboard .seo-header::after {
+        .seo-dashboard .seo-hero::after {
             content: "";
             position: absolute;
             inset: auto -60px -90px auto;
@@ -1180,11 +1180,11 @@ if ($detailSlug !== null && $detailSlug !== '') {
             background: rgba(255,255,255,0.12);
             border-radius: 50%;
         }
-        .seo-dashboard .seo-header-content {
+        .seo-dashboard .seo-hero-content {
             position: relative;
             z-index: 1;
         }
-        .seo-dashboard h1 {
+        .seo-dashboard .seo-hero-title {
             font-size: 28px;
             font-weight: 700;
             margin-bottom: 12px;
@@ -1606,30 +1606,38 @@ if ($detailSlug !== null && $detailSlug !== '') {
         }
     </style>
 
-    <div class="seo-header">
-        <div class="seo-header-content">
-            <h1>SEO Dashboard</h1>
-            <p class="seo-lead">Monitor SEO health across your published pages. Track metadata quality, spot urgent issues, and drill into page-level recommendations.</p>
-            <div class="seo-overview">
-                <div class="seo-overview-card">
-                    <div class="seo-overview-value"><?php echo (int) $summary['total_pages']; ?></div>
-                    <div class="seo-overview-label">Total Pages</div>
-                </div>
-                <div class="seo-overview-card">
-                    <div class="seo-overview-value"><?php echo (int) $averageScore; ?></div>
-                    <div class="seo-overview-label">Average Score</div>
-                </div>
-                <div class="seo-overview-card">
-                    <div class="seo-overview-value"><?php echo (int) $summary['attention_pages']; ?></div>
-                    <div class="seo-overview-label">Pages Needing Attention</div>
-                </div>
-                <div class="seo-overview-card">
-                    <div class="seo-overview-value"><?php echo (int) $summary['metadata_gaps']; ?></div>
-                    <div class="seo-overview-label">Metadata Gaps</div>
-                </div>
+    <header class="a11y-hero seo-hero">
+        <div class="a11y-hero-content seo-hero-content">
+            <div>
+                <h1 class="a11y-hero-title seo-hero-title">SEO Dashboard</h1>
+                <p class="a11y-hero-subtitle seo-lead">Monitor SEO health across your published pages. Track metadata quality, spot urgent issues, and drill into page-level recommendations.</p>
+            </div>
+            <div class="a11y-hero-actions seo-hero-actions">
+                <span class="a11y-hero-meta seo-hero-meta">
+                    <i class="fa-solid fa-chart-line" aria-hidden="true"></i>
+                    Real-time insights from your published content
+                </span>
             </div>
         </div>
-    </div>
+        <div class="a11y-overview-grid seo-overview">
+            <div class="a11y-overview-card seo-overview-card">
+                <div class="a11y-overview-label seo-overview-label">Total Pages</div>
+                <div class="a11y-overview-value seo-overview-value"><?php echo (int) $summary['total_pages']; ?></div>
+            </div>
+            <div class="a11y-overview-card seo-overview-card">
+                <div class="a11y-overview-label seo-overview-label">Average Score</div>
+                <div class="a11y-overview-value seo-overview-value"><?php echo (int) $averageScore; ?></div>
+            </div>
+            <div class="a11y-overview-card seo-overview-card">
+                <div class="a11y-overview-label seo-overview-label">Pages Needing Attention</div>
+                <div class="a11y-overview-value seo-overview-value"><?php echo (int) $summary['attention_pages']; ?></div>
+            </div>
+            <div class="a11y-overview-card seo-overview-card">
+                <div class="a11y-overview-label seo-overview-label">Metadata Gaps</div>
+                <div class="a11y-overview-value seo-overview-value"><?php echo (int) $summary['metadata_gaps']; ?></div>
+            </div>
+        </div>
+    </header>
 
     <div class="seo-controls">
         <div class="seo-search">

--- a/CMS/modules/speed/view.php
+++ b/CMS/modules/speed/view.php
@@ -566,13 +566,12 @@ $dashboardStats = [
                     </span>
                 </div>
             </div>
-        </header>
-        <div class="a11y-overview-grid">
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="speedStatTotalPages"><?php echo $dashboardStats['totalPages']; ?></div>
-                <div class="a11y-overview-label">Total Pages</div>
-            </div>
-            <div class="a11y-overview-card">
+            <div class="a11y-overview-grid">
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="speedStatTotalPages"><?php echo $dashboardStats['totalPages']; ?></div>
+                    <div class="a11y-overview-label">Total Pages</div>
+                </div>
+                <div class="a11y-overview-card">
                 <div class="a11y-overview-value" id="speedStatAvgScore"><?php echo $dashboardStats['avgScore']; ?>%</div>
                 <div class="a11y-overview-label">Average Score</div>
             </div>
@@ -580,11 +579,12 @@ $dashboardStats = [
                 <div class="a11y-overview-value" id="speedStatCritical"><?php echo $dashboardStats['criticalAlerts']; ?></div>
                 <div class="a11y-overview-label">Critical Alerts</div>
             </div>
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="speedStatSlow"><?php echo $dashboardStats['slowPages']; ?></div>
-                <div class="a11y-overview-label">Pages needing attention</div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="speedStatSlow"><?php echo $dashboardStats['slowPages']; ?></div>
+                    <div class="a11y-overview-label">Pages needing attention</div>
+                </div>
             </div>
-        </div>
+        </header>
         <div class="a11y-controls">
             <label class="a11y-search" for="speedSearchInput">
                 <i class="fas fa-search" aria-hidden="true"></i>

--- a/CMS/modules/users/view.php
+++ b/CMS/modules/users/view.php
@@ -3,8 +3,10 @@
     <div class="a11y-dashboard users-dashboard" data-last-refresh="">
         <header class="a11y-hero users-hero">
             <div class="a11y-hero-content">
-                <h2 class="a11y-hero-title">Team access &amp; permissions</h2>
-                <p class="a11y-hero-subtitle">Review account health, monitor roles, and invite new collaborators from a single, polished dashboard.</p>
+                <div>
+                    <h2 class="a11y-hero-title">Team access &amp; permissions</h2>
+                    <p class="a11y-hero-subtitle">Review account health, monitor roles, and invite new collaborators from a single, polished dashboard.</p>
+                </div>
                 <div class="a11y-hero-actions">
                     <button type="button" class="a11y-btn a11y-btn--primary" id="usersNewBtn">
                         <i class="fas fa-user-plus" aria-hidden="true"></i>
@@ -14,20 +16,18 @@
                         <i class="fas fa-rotate" aria-hidden="true"></i>
                         <span>Refresh</span>
                     </button>
+                    <span class="a11y-hero-meta users-last-sync">
+                        <i class="fas fa-clock" aria-hidden="true"></i>
+                        Last updated <span id="usersLastSync">just now</span>
+                    </span>
                 </div>
-                <span class="a11y-hero-meta users-last-sync">
-                    <i class="fas fa-clock" aria-hidden="true"></i>
-                    Last updated <span id="usersLastSync">just now</span>
-                </span>
             </div>
-        </header>
-
-        <div class="a11y-overview-grid users-overview">
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="usersStatTotal">0</div>
-                <div class="a11y-overview-label">Total members</div>
-            </div>
-            <div class="a11y-overview-card">
+            <div class="a11y-overview-grid users-overview">
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="usersStatTotal">0</div>
+                    <div class="a11y-overview-label">Total members</div>
+                </div>
+                <div class="a11y-overview-card">
                 <div class="a11y-overview-value" id="usersStatActive">0</div>
                 <div class="a11y-overview-label">Active accounts</div>
             </div>
@@ -35,11 +35,12 @@
                 <div class="a11y-overview-value" id="usersStatAdmins">0</div>
                 <div class="a11y-overview-label">Administrators</div>
             </div>
-            <div class="a11y-overview-card">
-                <div class="a11y-overview-value" id="usersStatRecent">0</div>
-                <div class="a11y-overview-label">New this month</div>
+                <div class="a11y-overview-card">
+                    <div class="a11y-overview-value" id="usersStatRecent">0</div>
+                    <div class="a11y-overview-label">New this month</div>
+                </div>
             </div>
-        </div>
+        </header>
 
         <div class="a11y-controls users-controls">
             <label class="a11y-search" for="usersSearchInput">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -213,14 +213,6 @@
 
         .logs-hero {
             position: relative;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            gap: 32px;
-            padding: 32px;
-            border-radius: 24px;
-            color: #fff;
-            overflow: hidden;
             background: linear-gradient(135deg, #312e81, #4c1d95);
             box-shadow: 0 30px 60px -40px rgba(76, 29, 149, 0.6);
         }
@@ -231,12 +223,6 @@
             inset: 0;
             background: linear-gradient(135deg, rgba(255, 255, 255, 0.05), rgba(147, 197, 253, 0.15));
             pointer-events: none;
-        }
-
-        .logs-hero-copy {
-            position: relative;
-            z-index: 1;
-            max-width: 640px;
         }
 
         .logs-hero-title {
@@ -251,34 +237,31 @@
             opacity: 0.9;
         }
 
-        .logs-hero-meta {
-            display: flex;
-            gap: 28px;
-            margin-top: 24px;
-            flex-wrap: wrap;
+        .logs-hero-actions {
+            position: relative;
+            z-index: 1;
         }
 
-        .logs-hero-meta > div {
-            display: flex;
+        .logs-hero-meta-item {
+            display: inline-flex;
             flex-direction: column;
-            gap: 4px;
+            gap: 6px;
+            padding: 12px 16px;
+            border-radius: 16px;
+            background: rgba(15, 23, 42, 0.25);
+            min-width: 180px;
         }
 
         .logs-hero-meta__label {
             font-size: 12px;
             text-transform: uppercase;
             letter-spacing: 1.2px;
-            opacity: 0.65;
+            opacity: 0.7;
         }
 
         .logs-hero-meta__value {
             font-size: 18px;
             font-weight: 600;
-        }
-
-        .logs-hero-actions {
-            position: relative;
-            z-index: 1;
         }
 
         .logs-btn {
@@ -318,18 +301,75 @@
             animation: logs-spin 0.9s linear infinite;
         }
 
+        /* Search module */
+        #search .search-dashboard {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .search-hero {
+            background: linear-gradient(135deg, #0284c7, #312e81);
+            box-shadow: 0 24px 48px rgba(8, 145, 178, 0.35);
+        }
+
+        .search-hero-meta {
+            color: rgba(226, 232, 240, 0.9);
+        }
+
+        .search-overview-grid .a11y-overview-card {
+            background: rgba(15, 23, 42, 0.3);
+            border: 1px solid rgba(148, 163, 184, 0.2);
+        }
+
+        .search-overview-grid .a11y-overview-value {
+            font-size: 24px;
+            font-weight: 600;
+        }
+
+        /* Import/Export module */
+        #import .import-dashboard {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .import-hero {
+            background: linear-gradient(135deg, #1e3a8a, #047857);
+            box-shadow: 0 24px 48px rgba(4, 120, 87, 0.35);
+        }
+
+        .import-overview-grid .a11y-overview-card {
+            background: rgba(15, 23, 42, 0.28);
+            border: 1px solid rgba(15, 118, 110, 0.25);
+        }
+
+        .import-overview-grid .a11y-overview-value {
+            font-size: 24px;
+            font-weight: 600;
+        }
+
+        .import-placeholder {
+            background: #ffffff;
+            border-radius: 16px;
+            padding: 24px;
+            box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+            color: #475569;
+            font-size: 15px;
+        }
+
         @keyframes logs-spin {
             from { transform: rotate(0deg); }
             to { transform: rotate(360deg); }
         }
 
-        .logs-stats-grid {
+        .logs-overview-grid {
             display: grid;
             gap: 20px;
             grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
         }
 
-        .logs-stat-card {
+        .logs-overview-card {
             background: #fff;
             border-radius: 20px;
             padding: 24px;
@@ -7266,18 +7306,8 @@
 #calendar .calendar-hero {
     background: linear-gradient(135deg, #2563eb 0%, #7c3aed 100%);
     color: #fff;
-    padding: 32px;
-    border-radius: 24px;
     margin-bottom: 32px;
     box-shadow: 0 24px 40px -24px rgba(37, 99, 235, 0.6);
-}
-
-#calendar .calendar-hero__content {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 24px;
 }
 
 #calendar .calendar-hero__title {
@@ -7292,41 +7322,29 @@
     opacity: 0.9;
 }
 
-#calendar .calendar-dashboard__actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin-bottom: 24px;
-}
-
-#calendar .calendar-dashboard__actions .calendar-btn--ghost {
+#calendar .calendar-hero__actions .calendar-btn--ghost {
     background: #eff6ff;
     color: #1d4ed8;
     border-color: #bfdbfe;
 }
 
-#calendar .calendar-dashboard__actions .calendar-btn--primary {
+#calendar .calendar-hero__actions .calendar-btn--primary {
     background: #2563eb;
     color: #fff;
     box-shadow: 0 16px 32px -24px rgba(37, 99, 235, 0.6);
 }
 
 #calendar .calendar-hero__metrics {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 16px;
     margin-top: 28px;
 }
 
-#calendar .calendar-hero__metrics dt {
-    font-size: 13px;
-    text-transform: uppercase;
-    opacity: 0.75;
+#calendar .calendar-hero__metrics .a11y-overview-card {
+    background: rgba(15, 23, 42, 0.25);
+    border: 1px solid rgba(148, 163, 184, 0.15);
 }
 
-#calendar .calendar-hero__metrics dd {
-    font-size: 24px;
+#calendar .calendar-hero__metrics .a11y-overview-value {
+    font-size: 26px;
     font-weight: 600;
 }
 
@@ -7894,6 +7912,9 @@
             .pages-hero,
             .blog-hero,
             .logs-hero,
+            .search-hero,
+            .import-hero,
+            .seo-hero,
             .a11y-hero,
             .dashboard-hero) {
             position: relative;
@@ -7915,6 +7936,9 @@
             .pages-hero,
             .blog-hero,
             .logs-hero,
+            .search-hero,
+            .import-hero,
+            .seo-hero,
             .a11y-hero,
             .dashboard-hero)::before,
         :is(.analytics-hero,
@@ -7924,6 +7948,9 @@
             .pages-hero,
             .blog-hero,
             .logs-hero,
+            .search-hero,
+            .import-hero,
+            .seo-hero,
             .a11y-hero,
             .dashboard-hero)::after {
             content: '';
@@ -7940,6 +7967,9 @@
             .pages-hero,
             .blog-hero,
             .logs-hero,
+            .search-hero,
+            .import-hero,
+            .seo-hero,
             .a11y-hero,
             .dashboard-hero)::before {
             width: 240px;
@@ -7955,6 +7985,9 @@
             .pages-hero,
             .blog-hero,
             .logs-hero,
+            .search-hero,
+            .import-hero,
+            .seo-hero,
             .a11y-hero,
             .dashboard-hero)::after {
             width: 180px;
@@ -7969,7 +8002,10 @@
             .media-hero-content,
             .pages-hero-content,
             .blog-hero-content,
-            .logs-hero-copy,
+            .logs-hero-content,
+            .search-hero-content,
+            .import-hero-content,
+            .seo-hero-content,
             .a11y-hero-content,
             .dashboard-hero-content) {
             position: relative;
@@ -7985,7 +8021,10 @@
                 .media-hero-content,
                 .pages-hero-content,
                 .blog-hero-content,
-                .logs-hero-copy,
+                .logs-hero-content,
+                .search-hero-content,
+                .import-hero-content,
+                .seo-hero-content,
                 .a11y-hero-content,
                 .dashboard-hero-content) {
                 flex-direction: row;
@@ -8002,6 +8041,9 @@
             .pages-hero-title,
             .blog-hero-title,
             .logs-hero-title,
+            .search-hero-title,
+            .import-hero-title,
+            .seo-hero-title,
             .a11y-hero-title,
             .dashboard-hero-title) {
             font-size: 32px;
@@ -8017,6 +8059,9 @@
             .pages-hero-subtitle,
             .blog-hero-subtitle,
             .logs-hero-subtitle,
+            .search-hero-subtitle,
+            .import-hero-subtitle,
+            .seo-hero-subtitle,
             .a11y-hero-subtitle,
             .dashboard-hero-subtitle) {
             margin: 0;
@@ -8033,6 +8078,9 @@
             .pages-hero-actions,
             .blog-hero-actions,
             .logs-hero-actions,
+            .search-hero-actions,
+            .import-hero-actions,
+            .seo-hero-actions,
             .a11y-hero-actions,
             .dashboard-hero-actions) {
             display: inline-flex;
@@ -8049,6 +8097,9 @@
                 .pages-hero-actions,
                 .blog-hero-actions,
                 .logs-hero-actions,
+                .search-hero-actions,
+                .import-hero-actions,
+                .seo-hero-actions,
                 .a11y-hero-actions,
                 .dashboard-hero-actions) {
                 margin-left: auto;
@@ -8060,6 +8111,9 @@
             .media-hero-meta,
             .pages-hero-meta,
             .blog-hero-meta,
+            .search-hero-meta,
+            .import-hero-meta,
+            .seo-hero-meta,
             .a11y-hero-meta) {
             display: inline-flex;
             align-items: center;
@@ -8070,44 +8124,6 @@
             color: var(--module-text-muted);
             font-size: 13px;
             letter-spacing: 0.02em;
-        }
-
-        .logs-hero-meta,
-        .calendar-hero__metrics {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-            gap: 16px;
-            padding: 20px;
-            border-radius: var(--module-radius-md);
-            background: rgba(15, 23, 42, 0.28);
-            color: #ffffff;
-        }
-
-        .calendar-hero__metrics div,
-        .logs-hero-meta > div {
-            display: flex;
-            flex-direction: column;
-            gap: 4px;
-        }
-
-        :is(.logs-hero-meta__label,
-            .calendar-hero__metrics dt) {
-            font-size: 12px;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            color: var(--module-text-muted);
-        }
-
-        :is(.logs-hero-meta__value,
-            .calendar-hero__metrics dd) {
-            font-size: 22px;
-            font-weight: 600;
-            margin: 0;
-            color: #ffffff;
-        }
-
-        .calendar-hero__metrics dd {
-            margin-top: 2px;
         }
 
         .content-section :is(article, section, div)[class*='-card'] {


### PR DESCRIPTION
## Summary
- align each module dashboard header with the accessibility hero layout and move their key metrics into the hero band
- add new hero experiences for the Search and Import/Export modules so they match the standardized presentation
- refresh shared styling to support the unified hero pattern, including updated logs badges and search/import hero treatments

## Testing
- for file in CMS/modules/analytics/view.php CMS/modules/blogs/view.php CMS/modules/calendar/view.php CMS/modules/forms/view.php CMS/modules/import_export/view.php CMS/modules/logs/view.php CMS/modules/media/view.php CMS/modules/menus/view.php CMS/modules/pages/view.php CMS/modules/search/view.php CMS/modules/seo/view.php CMS/modules/speed/view.php CMS/modules/users/view.php; do php -l $file; done
- php -l CMS/modules/forms/view.php


------
https://chatgpt.com/codex/tasks/task_e_68d7fdfd63f08331a6cd4db90148ac27