### PR TITLE
Add analytics data export functionality

### DIFF
--- a/CMS/modules/analytics/export.php
+++ b/CMS/modules/analytics/export.php
@@ -1,0 +1,115 @@
+<?php
+// File: export.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+
+require_login();
+
+$filter = isset($_GET['filter']) ? strtolower((string) $_GET['filter']) : 'all';
+$search = isset($_GET['search']) ? trim((string) $_GET['search']) : '';
+
+$allowedFilters = ['all', 'top', 'growing', 'no-views'];
+if (!in_array($filter, $allowedFilters, true)) {
+    $filter = 'all';
+}
+
+$pagesFile = __DIR__ . '/../../data/pages.json';
+$pages = read_json_file($pagesFile);
+
+$entries = [];
+foreach ($pages as $page) {
+    $title = isset($page['title']) ? (string) $page['title'] : 'Untitled';
+    $slug = isset($page['slug']) ? (string) $page['slug'] : '';
+    $views = isset($page['views']) ? (int) $page['views'] : 0;
+    if ($views < 0) {
+        $views = 0;
+    }
+
+    $entries[] = [
+        'title' => $title,
+        'slug' => $slug,
+        'views' => $views,
+    ];
+}
+
+usort($entries, static function ($a, $b) {
+    return ($b['views'] ?? 0) <=> ($a['views'] ?? 0);
+});
+
+$totalViews = 0;
+$totalPages = count($entries);
+foreach ($entries as $entry) {
+    $totalViews += $entry['views'];
+}
+
+$averageViews = $totalPages > 0 ? $totalViews / $totalPages : 0;
+
+foreach ($entries as $index => &$entry) {
+    $status = 'growing';
+    $label = 'Steady traffic';
+
+    if ($entry['views'] === 0) {
+        $status = 'no-views';
+        $label = 'Needs promotion';
+    } elseif ($index < 3 || $entry['views'] >= $averageViews) {
+        $status = 'top';
+        $label = 'Top performer';
+    }
+
+    $entry['status'] = $status;
+    $entry['label'] = $label;
+    $entry['rank'] = $index + 1;
+}
+unset($entry);
+
+$searchTerm = $search;
+
+$filtered = array_values(array_filter($entries, static function ($entry) use ($filter, $searchTerm) {
+    if ($filter !== 'all' && $entry['status'] !== $filter) {
+        return false;
+    }
+
+    if ($searchTerm === '') {
+        return true;
+    }
+
+    $encoding = 'UTF-8';
+    if (function_exists('mb_stripos')) {
+        return (mb_stripos($entry['title'], $searchTerm, 0, $encoding) !== false)
+            || (mb_stripos($entry['slug'], $searchTerm, 0, $encoding) !== false);
+    }
+
+    return (stripos($entry['title'], $searchTerm) !== false)
+        || (stripos($entry['slug'], $searchTerm) !== false);
+}));
+
+$filename = 'analytics-export-' . date('Ymd-His') . '.csv';
+
+$output = fopen('php://output', 'wb');
+if ($output === false) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Unable to generate export.']);
+    exit;
+}
+
+header('Content-Type: text/csv; charset=UTF-8');
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+fputcsv($output, ['Title', 'Slug', 'Views', 'Segment', 'Rank']);
+
+foreach ($filtered as $entry) {
+    $slug = $entry['slug'] !== '' ? '/' . ltrim($entry['slug'], '/') : '/';
+    fputcsv($output, [
+        $entry['title'],
+        $slug,
+        $entry['views'],
+        $entry['label'],
+        $entry['rank'],
+    ]);
+}
+
+fclose($output);
+exit;

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -58,6 +58,10 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
                         <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                         <span class="analytics-btn__text">Refresh data</span>
                     </button>
+                    <button type="button" class="analytics-btn analytics-btn--ghost" data-analytics-action="export" data-loading-text="Exporting&hellip;">
+                        <i class="fa-solid fa-download" aria-hidden="true"></i>
+                        <span class="analytics-btn__text">Export CSV</span>
+                    </button>
                     <span class="a11y-hero-meta analytics-hero-meta" id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
                         <?php echo $lastUpdatedDisplay
                             ? 'Data refreshed ' . htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES)


### PR DESCRIPTION
## Summary
- add an export button to the analytics dashboard actions
- implement a CSV export endpoint that honors active filters
- wire the analytics client to request exports, manage loading state, and trigger downloads

## Testing
- php -l CMS/modules/analytics/export.php

------
https://chatgpt.com/codex/tasks/task_e_68d8029b17a48331bec705fac3ab0269