### PR TITLE
Add sortable analytics table headers

### DIFF
--- a/CMS/modules/analytics/analytics.css
+++ b/CMS/modules/analytics/analytics.css
@@ -1,0 +1,87 @@
+/* File: analytics.css */
+.analytics-table__sort {
+    appearance: none;
+    background: none;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    font: inherit;
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    padding: 0;
+    text-transform: uppercase;
+    width: 100%;
+    transition: color 0.2s ease;
+}
+
+.analytics-table__sort:hover,
+.analytics-table__sort:focus-visible {
+    color: #0f172a;
+}
+
+.analytics-table__sort:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
+    border-radius: 6px;
+}
+
+.analytics-table__sort.is-active {
+    color: #0f172a;
+    font-weight: 600;
+}
+
+.analytics-table__sort-label {
+    pointer-events: none;
+}
+
+.analytics-table__sort-indicator {
+    display: inline-flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 0.9rem;
+    height: 0.95rem;
+    position: relative;
+}
+
+.analytics-table__sort-indicator::before,
+.analytics-table__sort-indicator::after {
+    content: '';
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    display: block;
+    opacity: 0.35;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.analytics-table__sort-indicator::before {
+    border-bottom: 5px solid currentColor;
+    margin-bottom: 2px;
+}
+
+.analytics-table__sort-indicator::after {
+    border-top: 5px solid currentColor;
+    margin-top: 2px;
+}
+
+.analytics-table__sort.is-ascending .analytics-table__sort-indicator::before {
+    opacity: 1;
+    transform: translateY(-1px);
+}
+
+.analytics-table__sort.is-ascending .analytics-table__sort-indicator::after {
+    opacity: 0.15;
+}
+
+.analytics-table__sort.is-descending .analytics-table__sort-indicator::after {
+    opacity: 1;
+    transform: translateY(1px);
+}
+
+.analytics-table__sort.is-descending .analytics-table__sort-indicator::before {
+    opacity: 0.15;
+}

--- a/CMS/modules/analytics/analytics.js
+++ b/CMS/modules/analytics/analytics.js
@@ -4,6 +4,10 @@ $(function(){
         entries: [],
         filter: 'all',
         view: 'grid',
+        sort: {
+            key: 'views',
+            direction: 'desc',
+        },
         summary: {
             totalViews: 0,
             averageViews: 0,
@@ -21,6 +25,7 @@ $(function(){
     const $grid = $('#analyticsGrid');
     const $table = $('#analyticsTableView');
     const $tableBody = $('#analyticsTableBody');
+    const $sortButtons = $('[data-analytics-sort]');
     const $empty = $('#analyticsEmptyState');
     const $search = $('#analyticsSearchInput');
     const $filterButtons = $('[data-analytics-filter]');
@@ -263,11 +268,16 @@ $(function(){
     }
 
     function renderTable(items){
-        $tableBody.empty();
-        if (!items.length) {
+        updateSortIndicators();
+        if (!$tableBody.length) {
             return;
         }
-        const rows = items.map(function(item){
+        const sorted = sortItemsForTable(items);
+        $tableBody.empty();
+        if (!sorted.length) {
+            return;
+        }
+        const rows = sorted.map(function(item){
             return (
                 '<tr>' +
                     '<td class="analytics-table__title">' + escapeHtml(item.title) + '</td>' +
@@ -307,18 +317,89 @@ $(function(){
     function render(){
         const results = applyFilters();
         const hasResults = results.length > 0;
+        renderTable(results);
         if (state.view === 'grid') {
             renderGrid(results);
-            $tableBody.empty();
             $grid.removeAttr('hidden');
             $table.attr('hidden', true);
         } else {
-            renderTable(results);
-            $grid.empty();
+            renderGrid([]);
             $grid.attr('hidden', true);
             $table.removeAttr('hidden');
         }
         updateEmptyState(hasResults);
+    }
+
+    function sortItemsForTable(items){
+        const sorted = Array.isArray(items) ? items.slice() : [];
+        if (sorted.length <= 1) {
+            return sorted;
+        }
+        const key = state.sort.key;
+        const direction = state.sort.direction === 'asc' ? 1 : -1;
+        sorted.sort(function(a, b){
+            let comparison = 0;
+            if (key === 'title') {
+                comparison = a.titleLower.localeCompare(b.titleLower, undefined, { sensitivity: 'base' });
+            } else if (key === 'slug') {
+                comparison = a.slugLower.localeCompare(b.slugLower, undefined, { sensitivity: 'base' });
+            } else {
+                comparison = (a.views || 0) - (b.views || 0);
+            }
+            if (comparison === 0) {
+                comparison = (a.rank || 0) - (b.rank || 0);
+            }
+            return comparison * direction;
+        });
+        return sorted;
+    }
+
+    function updateSortIndicators(){
+        if (!$sortButtons.length) {
+            return;
+        }
+        $sortButtons.each(function(){
+            const $button = $(this);
+            const key = $button.data('analyticsSort');
+            if (!key) {
+                return;
+            }
+            const isActive = key === state.sort.key;
+            const isAscending = isActive && state.sort.direction === 'asc';
+            const ariaValue = isActive ? (isAscending ? 'ascending' : 'descending') : 'none';
+            const baseLabel = $button.data('analyticsSortLabel') || $button.find('.analytics-table__sort-label').text().trim() || 'Column';
+            const activeLabel = isActive ? baseLabel + ' column, sorted ' + (isAscending ? 'ascending' : 'descending') : 'Sort by ' + baseLabel + ' column';
+
+            $button.toggleClass('is-active', isActive);
+            $button.toggleClass('is-ascending', isAscending);
+            $button.toggleClass('is-descending', isActive && !isAscending);
+            $button.attr('aria-label', activeLabel);
+
+            const $header = $button.closest('th');
+            if ($header.length) {
+                $header.attr('aria-sort', ariaValue);
+            } else {
+                $button.attr('aria-sort', ariaValue);
+            }
+        });
+    }
+
+    function setSort(key){
+        if (!key) {
+            return;
+        }
+        const current = state.sort.key;
+        let direction = 'asc';
+        if (current === key) {
+            direction = state.sort.direction === 'asc' ? 'desc' : 'asc';
+        } else if (key === 'views') {
+            direction = 'desc';
+        }
+        state.sort = {
+            key: key,
+            direction: direction,
+        };
+        render();
     }
 
     function setFilter(filter){
@@ -404,6 +485,13 @@ $(function(){
     $search.on('input', debounce(function(){
         render();
     }, 150));
+
+    $sortButtons.on('click', function(){
+        const sortKey = $(this).data('analyticsSort');
+        if (sortKey) {
+            setSort(sortKey);
+        }
+    });
 
     if ($refreshBtn.length) {
         $refreshBtn.on('click', function(){

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -45,6 +45,7 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
     ? date('M j, Y g:i a', $lastUpdatedTimestamp)
     : null;
 ?>
+<link rel="stylesheet" href="modules/analytics/analytics.css">
 <div class="content-section" id="analytics">
     <div class="analytics-dashboard">
         <header class="a11y-hero analytics-hero">
@@ -179,9 +180,24 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
             <table class="analytics-table__table">
                 <thead>
                     <tr>
-                        <th scope="col">Title</th>
-                        <th scope="col">Slug</th>
-                        <th scope="col">Views</th>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="analytics-table__sort" data-analytics-sort="title" data-analytics-sort-label="Title">
+                                <span class="analytics-table__sort-label">Title</span>
+                                <span class="analytics-table__sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="analytics-table__sort" data-analytics-sort="slug" data-analytics-sort-label="Slug">
+                                <span class="analytics-table__sort-label">Slug</span>
+                                <span class="analytics-table__sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th scope="col" aria-sort="descending">
+                            <button type="button" class="analytics-table__sort" data-analytics-sort="views" data-analytics-sort-label="Views">
+                                <span class="analytics-table__sort-label">Views</span>
+                                <span class="analytics-table__sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
                     </tr>
                 </thead>
                 <tbody id="analyticsTableBody"></tbody>


### PR DESCRIPTION
## Summary
- convert the analytics table headers into interactive sort controls with aria-sort metadata
- update the analytics dashboard script to re-sort rows when a header button is clicked and refresh the table view
- add dedicated styles that highlight the active sort direction for each column control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8029d21708331988cf4f9a0bad595