### PR TITLE
Add date range picker to analytics dashboard

### DIFF
--- a/CMS/modules/analytics/analytics_data.php
+++ b/CMS/modules/analytics/analytics_data.php
@@ -7,8 +7,38 @@ require_login();
 $pagesFile = __DIR__ . '/../../data/pages.json';
 $pages = read_json_file($pagesFile);
 
+$startParam = isset($_GET['start']) ? (string) $_GET['start'] : null;
+$endParam = isset($_GET['end']) ? (string) $_GET['end'] : null;
+
+$startTimestamp = null;
+$endTimestamp = null;
+
+if ($startParam) {
+    $startTime = strtotime($startParam . ' 00:00:00');
+    if ($startTime !== false) {
+        $startTimestamp = $startTime;
+    }
+}
+
+if ($endParam) {
+    $endTime = strtotime($endParam . ' 23:59:59');
+    if ($endTime !== false) {
+        $endTimestamp = $endTime;
+    }
+}
+
 $data = [];
 foreach ($pages as $p) {
+    $lastModified = isset($p['last_modified']) ? (int) $p['last_modified'] : 0;
+
+    if ($startTimestamp !== null && $lastModified > 0 && $lastModified < $startTimestamp) {
+        continue;
+    }
+
+    if ($endTimestamp !== null && $lastModified > 0 && $lastModified > $endTimestamp) {
+        continue;
+    }
+
     $data[] = [
         'title' => $p['title'],
         'slug' => $p['slug'],

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -44,6 +44,16 @@ foreach ($sortedPages as $page) {
 $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
     ? date('M j, Y g:i a', $lastUpdatedTimestamp)
     : null;
+
+$rangeEndTimestamp = $lastUpdatedTimestamp > 0 ? $lastUpdatedTimestamp : time();
+$rangeStartTimestamp = strtotime('-29 days', $rangeEndTimestamp);
+if ($rangeStartTimestamp === false) {
+    $rangeStartTimestamp = $rangeEndTimestamp;
+}
+$defaultRangeStart = date('Y-m-d', $rangeStartTimestamp);
+$defaultRangeEnd = date('Y-m-d', $rangeEndTimestamp);
+$defaultRangePreset = '30';
+$defaultRangeLabel = 'Last 30 days';
 ?>
 <div class="content-section" id="analytics">
     <div class="analytics-dashboard">
@@ -54,14 +64,36 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
                     <p class="a11y-hero-subtitle analytics-hero-subtitle">Monitor traffic trends, understand what resonates, and uncover pages that need promotion.</p>
                 </div>
                 <div class="a11y-hero-actions analytics-hero-actions">
+                    <div class="analytics-range-picker" role="group" aria-label="Select analytics date range">
+                        <div class="analytics-range-picker__inputs">
+                            <label class="analytics-range-picker__field" for="analyticsDateStart">
+                                <span>Start</span>
+                                <input type="date" id="analyticsDateStart" value="<?php echo htmlspecialchars($defaultRangeStart, ENT_QUOTES); ?>" aria-label="Select start date">
+                            </label>
+                            <span class="analytics-range-picker__separator" aria-hidden="true">to</span>
+                            <label class="analytics-range-picker__field" for="analyticsDateEnd">
+                                <span>End</span>
+                                <input type="date" id="analyticsDateEnd" value="<?php echo htmlspecialchars($defaultRangeEnd, ENT_QUOTES); ?>" aria-label="Select end date">
+                            </label>
+                        </div>
+                        <div class="analytics-range-picker__presets" role="group" aria-label="Quick date presets">
+                            <button type="button" class="analytics-range-picker__preset" data-analytics-range="7">Last 7 days</button>
+                            <button type="button" class="analytics-range-picker__preset is-active" data-analytics-range="30">Last 30 days</button>
+                            <button type="button" class="analytics-range-picker__preset" data-analytics-range="90">Last 90 days</button>
+                        </div>
+                    </div>
                     <button type="button" class="analytics-btn analytics-btn--primary" data-analytics-action="refresh" data-loading-text="Refreshing&hellip;">
                         <i class="fa-solid fa-rotate" aria-hidden="true"></i>
                         <span class="analytics-btn__text">Refresh data</span>
                     </button>
-                    <span class="a11y-hero-meta analytics-hero-meta" id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
-                        <?php echo $lastUpdatedDisplay
-                            ? 'Data refreshed ' . htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES)
-                            : 'Data refreshed moments ago'; ?>
+                    <span class="a11y-hero-meta analytics-hero-meta" id="analyticsMeta">
+                        <span id="analyticsLastUpdated" data-timestamp="<?php echo $lastUpdatedTimestamp > 0 ? htmlspecialchars(date(DATE_ATOM, $lastUpdatedTimestamp), ENT_QUOTES) : ''; ?>">
+                            <?php echo $lastUpdatedDisplay
+                                ? 'Data refreshed ' . htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES)
+                                : 'Data refreshed moments ago'; ?>
+                        </span>
+                        <span class="analytics-hero-meta__divider" aria-hidden="true">&bull;</span>
+                        <span id="analyticsRangeLabel"><?php echo htmlspecialchars($defaultRangeLabel, ENT_QUOTES); ?></span>
                     </span>
                 </div>
             </div>
@@ -199,5 +231,11 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
     window.analyticsInitialMeta = <?php echo json_encode([
         'lastUpdated' => $lastUpdatedDisplay ? 'Data refreshed ' . $lastUpdatedDisplay : 'Data refreshed moments ago',
         'lastUpdatedIso' => $lastUpdatedTimestamp > 0 ? date(DATE_ATOM, $lastUpdatedTimestamp) : null,
+        'range' => [
+            'start' => $defaultRangeStart,
+            'end' => $defaultRangeEnd,
+        ],
+        'preset' => $defaultRangePreset,
+        'rangeLabel' => $defaultRangeLabel,
     ], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE); ?>;
 </script>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2308,6 +2308,89 @@
             flex-wrap: wrap;
         }
 
+        .analytics-range-picker {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            background: rgba(15,23,42,0.35);
+            border-radius: 14px;
+            padding: 12px 16px;
+            min-width: 240px;
+        }
+
+        .analytics-range-picker__inputs {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .analytics-range-picker__field {
+            display: flex;
+            flex-direction: column;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: rgba(226,232,240,0.8);
+        }
+
+        .analytics-range-picker__field input {
+            margin-top: 4px;
+            background: rgba(15,23,42,0.55);
+            border: 1px solid rgba(148, 163, 184, 0.45);
+            border-radius: 10px;
+            color: #fff;
+            padding: 6px 12px;
+            min-width: 140px;
+            font-size: 13px;
+        }
+
+        .analytics-range-picker__field input:focus {
+            outline: none;
+            border-color: rgba(56, 189, 248, 0.85);
+            box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+        }
+
+        .analytics-range-picker__field input::-webkit-calendar-picker-indicator {
+            filter: invert(1);
+        }
+
+        .analytics-range-picker__separator {
+            font-size: 12px;
+            color: rgba(226,232,240,0.7);
+        }
+
+        .analytics-range-picker__presets {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .analytics-range-picker__preset {
+            border: 1px solid transparent;
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 12px;
+            font-weight: 600;
+            color: #e2e8f0;
+            background: rgba(15,23,42,0.45);
+            cursor: pointer;
+            transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+        }
+
+        .analytics-range-picker__preset:hover,
+        .analytics-range-picker__preset.is-active {
+            background: #38bdf8;
+            color: #0f172a;
+            border-color: #38bdf8;
+        }
+
+        .analytics-hero-meta__divider {
+            opacity: 0.6;
+            display: inline-block;
+            padding: 0 4px;
+        }
+
         .analytics-hero-meta {
             display: inline-flex;
             align-items: center;
@@ -2750,6 +2833,36 @@
 
         .analytics-empty-state i {
             font-size: 32px;
+        }
+
+        @media (max-width: 1024px) {
+            .analytics-range-picker {
+                width: 100%;
+            }
+        }
+
+        @media (max-width: 720px) {
+            .analytics-hero-actions {
+                align-items: stretch;
+            }
+
+            .analytics-range-picker {
+                width: 100%;
+            }
+
+            .analytics-range-picker__inputs {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            .analytics-range-picker__separator {
+                display: none;
+            }
+
+            .analytics-range-picker__field input {
+                width: 100%;
+                min-width: 0;
+            }
         }
 
         @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add a dual date input and quick presets to the analytics hero so the active range is visible alongside the refresh control
- teach the analytics dashboard script to manage range state, fetch filtered datasets, and refresh the overview, insights, and table
- filter analytics data responses by the requested dates and style the new picker for responsive layouts

## Testing
- php -l CMS/modules/analytics/view.php
- php -l CMS/modules/analytics/analytics_data.php


------
https://chatgpt.com/codex/tasks/task_e_68d802969f2c8331b90986c976541ecc