### PR TITLE
Add date range filtering to activity logs

### DIFF
--- a/CMS/modules/logs/view.php
+++ b/CMS/modules/logs/view.php
@@ -222,6 +222,17 @@ if ($uniqueUsersCount === 1) {
                     <p id="logsMatchCount"><?php echo htmlspecialchars($matchCountLabel, ENT_QUOTES, 'UTF-8'); ?></p>
                 </div>
                 <div class="logs-controls">
+                    <div class="logs-date-range" aria-label="Filter activity by date range">
+                        <label for="logsStartDate">
+                            <span>From</span>
+                            <input type="date" id="logsStartDate" name="logsStartDate">
+                        </label>
+                        <span class="logs-date-range-separator" aria-hidden="true">–</span>
+                        <label for="logsEndDate">
+                            <span>To</span>
+                            <input type="date" id="logsEndDate" name="logsEndDate">
+                        </label>
+                    </div>
                     <label class="logs-search" for="logsSearch">
                         <i class="fas fa-search" aria-hidden="true"></i>
                         <input type="search" id="logsSearch" placeholder="Search by editor, page, or action" autocomplete="off">


### PR DESCRIPTION
## Summary
- add a date range selector to the logs activity controls
- filter the client-side dataset by the selected range and show the active window in the match count label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d803f988c883318d7840aa681ba05f