### PR TITLE
Add live social card preview to settings

### DIFF
--- a/CMS/modules/settings/settings.js
+++ b/CMS/modules/settings/settings.js
@@ -8,6 +8,11 @@ $(function(){
     const $ogPreview = $('#ogImagePreview');
     const $clearLogo = $('#clearLogo');
     const $clearOgImage = $('#clearOgImage');
+    const $socialPreviewImage = $('#socialPreviewImage');
+    const $socialPreviewFallback = $('#socialPreviewImageFallback');
+    const $socialPreviewTitle = $('#socialPreviewTitle');
+    const $socialPreviewDescription = $('#socialPreviewDescription');
+    const $socialPreviewDomain = $('#socialPreviewDomain');
 
     function formatTimestamp(value){
         if(!value){
@@ -73,11 +78,24 @@ $(function(){
         $('#settingsOverviewVisibility').text(visibility).attr('title', details.join(' • '));
     }
 
+    function setSocialPreviewImage(src){
+        if(src){
+            $socialPreviewImage.attr('src', src).removeAttr('hidden');
+            $socialPreviewFallback.attr('hidden', true);
+        } else {
+            $socialPreviewImage.attr('src', '').attr('hidden', true);
+            $socialPreviewFallback.removeAttr('hidden');
+        }
+    }
+
     function togglePreview($img, src){
         if(src){
             $img.attr('src', src).removeAttr('hidden');
         } else {
             $img.attr('src', '').attr('hidden', true);
+        }
+        if($img.is($ogPreview)){
+            setSocialPreviewImage(src);
         }
     }
 
@@ -111,6 +129,32 @@ $(function(){
     function getDefaultOgDescription(settings){
         const siteName = (settings.site_name || '').trim() || 'SparkCMS';
         return `Stay up to date with the latest updates from ${siteName}.`;
+    }
+
+    function resolveOgTitle(){
+        const ogTitleInput = $('#ogTitle').val().trim();
+        if(ogTitleInput){
+            return ogTitleInput;
+        }
+        return getDefaultOgTitle({
+            site_name: $('#site_name').val(),
+            tagline: $('#tagline').val()
+        });
+    }
+
+    function resolveOgDescription(){
+        const ogDescriptionInput = $('#ogDescription').val().trim();
+        if(ogDescriptionInput){
+            return ogDescriptionInput;
+        }
+        return getDefaultOgDescription({
+            site_name: $('#site_name').val()
+        });
+    }
+
+    function updateSocialPreviewText(){
+        $socialPreviewTitle.text(resolveOgTitle());
+        $socialPreviewDescription.text(resolveOgDescription());
     }
 
     function loadSettings(){
@@ -154,6 +198,10 @@ $(function(){
             $('#ogDescription').val(ogDescriptionValue || getDefaultOgDescription(data));
             setPreviewState($ogPreview, $clearOgImage, openGraph.image || '');
 
+            const hostname = (window.location && window.location.hostname) ? window.location.hostname : 'yourdomain.com';
+            $socialPreviewDomain.text(hostname);
+            updateSocialPreviewText();
+
             updateHeroMeta(data.last_updated || '');
             updateOverview();
         });
@@ -184,6 +232,10 @@ $(function(){
 
     $form.on('input change', 'input, textarea, select', function(){
         updateOverview();
+    });
+
+    $form.on('input change', '#ogTitle, #ogDescription, #site_name, #tagline', function(){
+        updateSocialPreviewText();
     });
 
     $form.on('submit', function(e){

--- a/CMS/modules/settings/view.php
+++ b/CMS/modules/settings/view.php
@@ -203,6 +203,27 @@
                         </div>
                         <div class="form-help">Upload a 1200 × 630px image for social sharing cards.</div>
                     </div>
+
+                    <div class="social-preview" id="socialSharePreview">
+                        <div class="social-preview-header">
+                            <h3 class="social-preview-heading">Live Share Preview</h3>
+                            <p class="social-preview-subheading">See how your default Open Graph content appears on social platforms.</p>
+                        </div>
+                        <div class="social-preview-card" role="presentation">
+                            <div class="social-preview-media">
+                                <img id="socialPreviewImage" alt="Social share image preview" hidden>
+                                <div class="social-preview-media__fallback" id="socialPreviewImageFallback">
+                                    <span class="social-preview-media__icon"><i class="fas fa-image" aria-hidden="true"></i></span>
+                                    <span class="social-preview-media__text">1200 × 630</span>
+                                </div>
+                            </div>
+                            <div class="social-preview-body">
+                                <span class="social-preview-domain" id="socialPreviewDomain"></span>
+                                <h4 class="social-preview-title" id="socialPreviewTitle">My Awesome Website</h4>
+                                <p class="social-preview-description" id="socialPreviewDescription">Give people a compelling reason to click.</p>
+                            </div>
+                        </div>
+                    </div>
                 </article>
             </section>
         </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -189,15 +189,125 @@
             color: #a0aec0;
         }
 
-        .notification-btn {
+.notification-btn {
+    position: relative;
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 8px;
+    transition: background 0.3s ease;
+}
+
+        .social-preview {
+            margin-top: 24px;
+            border-top: 1px solid #e2e8f0;
+            padding-top: 24px;
+        }
+
+        .social-preview-header {
+            margin-bottom: 16px;
+        }
+
+        .social-preview-heading {
+            font-size: 16px;
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        .social-preview-subheading {
+            margin-top: 4px;
+            font-size: 13px;
+            color: #64748b;
+        }
+
+        .social-preview-card {
+            display: flex;
+            align-items: stretch;
+            gap: 0;
+            background: #ffffff;
+            border-radius: 12px;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+            overflow: hidden;
+            max-width: 640px;
+        }
+
+        .social-preview-media {
             position: relative;
-            background: none;
-            border: none;
+            flex: 0 0 40%;
+            min-width: 180px;
+            background: linear-gradient(135deg, #cbd5f5, #e0f2fe);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            aspect-ratio: 1200 / 630;
+        }
+
+        .social-preview-media img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .social-preview-media__fallback {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            color: #334155;
+            font-weight: 500;
+            gap: 6px;
+        }
+
+        .social-preview-media__icon {
             font-size: 20px;
-            cursor: pointer;
-            padding: 8px;
-            border-radius: 8px;
-            transition: background 0.3s ease;
+            opacity: 0.7;
+        }
+
+        .social-preview-media__text {
+            font-size: 12px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .social-preview-body {
+            padding: 20px 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .social-preview-domain {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #64748b;
+        }
+
+        .social-preview-title {
+            font-size: 18px;
+            line-height: 1.3;
+            color: #0f172a;
+            font-weight: 600;
+        }
+
+        .social-preview-description {
+            font-size: 14px;
+            color: #475569;
+            line-height: 1.5;
+        }
+
+        @media (max-width: 768px) {
+            .social-preview-card {
+                flex-direction: column;
+            }
+
+            .social-preview-media {
+                width: 100%;
+                flex: none;
+            }
         }
 
 .notification-btn:hover {


### PR DESCRIPTION
## Summary
- add a live social sharing preview container after the default Open Graph fields
- update the settings module JavaScript to mirror title, description, and image edits into the preview
- style the preview card to mimic a lightweight social media share appearance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d803b33b488331b48e8d2e1da69538