### PR TITLE
Add sorting controls to speed dashboard

### DIFF
--- a/CMS/modules/speed/view.php
+++ b/CMS/modules/speed/view.php
@@ -596,6 +596,19 @@ $dashboardStats = [
                 <button type="button" class="a11y-filter-btn" data-speed-filter="monitor">Needs attention <span class="a11y-filter-count" data-count="monitor"><?php echo $filterCounts['monitor']; ?></span></button>
                 <button type="button" class="a11y-filter-btn" data-speed-filter="fast">Performing well <span class="a11y-filter-count" data-count="fast"><?php echo $filterCounts['fast']; ?></span></button>
             </div>
+            <div class="a11y-sort" role="group" aria-label="Sort results">
+                <label for="speedSortSelect">Sort by</label>
+                <select id="speedSortSelect">
+                    <option value="score" selected>Performance score</option>
+                    <option value="title">Title</option>
+                    <option value="alerts">Total alerts</option>
+                    <option value="weight">Estimated weight</option>
+                </select>
+                <button type="button" class="a11y-sort-direction" id="speedSortDirection" data-direction="desc" aria-label="Sort high to low" aria-pressed="true">
+                    <i class="fas fa-sort-amount-down-alt" aria-hidden="true"></i>
+                    <span class="a11y-sort-direction__text" id="speedSortDirectionLabel">High to low</span>
+                </button>
+            </div>
             <div class="a11y-view-toggle" role="group" aria-label="Toggle layout">
                 <button type="button" class="a11y-view-btn active" data-speed-view="grid" aria-label="Grid view">
                     <i class="fas fa-th-large" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- add a sort picker and direction toggle to the performance dashboard controls
- implement client-side sorting that works with existing filters and search results
- surface visual feedback for the active sort direction when users change ordering

## Testing
- php -l CMS/modules/speed/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d803d7923483318f00ff3d466c94bf