### PR TITLE
Add scheduler for automatic performance scans

### DIFF
--- a/CMS/data/speed_schedule.json
+++ b/CMS/data/speed_schedule.json
@@ -1,0 +1,9 @@
+{
+    "cadence": "manual",
+    "status": "manual",
+    "nextRun": null,
+    "queue": [],
+    "lastScheduledAt": null,
+    "updatedAt": null,
+    "cancelledAt": null
+}

--- a/CMS/modules/speed/manage_schedule.php
+++ b/CMS/modules/speed/manage_schedule.php
@@ -1,0 +1,119 @@
+<?php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/schedule_helpers.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'error' => 'Method not allowed']);
+    exit;
+}
+
+require_login();
+
+$action = isset($_POST['action']) ? sanitize_text($_POST['action']) : 'update';
+$now = new DateTimeImmutable('now');
+$scheduleFile = __DIR__ . '/../../data/speed_schedule.json';
+$schedule = speed_normalize_schedule(read_json_file($scheduleFile));
+
+function speed_save_schedule(string $file, array $schedule): bool
+{
+    return write_json_file($file, $schedule);
+}
+
+switch ($action) {
+    case 'update':
+        $cadence = isset($_POST['cadence']) ? sanitize_text($_POST['cadence']) : 'manual';
+        $allowed = speed_allowed_cadences();
+        if (!isset($allowed[$cadence])) {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'error' => 'Invalid cadence selected.']);
+            exit;
+        }
+
+        $schedule['cadence'] = $cadence;
+        $schedule['updatedAt'] = $now->format(DateTimeInterface::ATOM);
+
+        if ($cadence === 'manual') {
+            $schedule['nextRun'] = null;
+            $schedule['queue'] = [];
+            $schedule['status'] = 'manual';
+        } else {
+            $next = speed_calculate_next_run($cadence, $now);
+            if (!$next) {
+                http_response_code(500);
+                echo json_encode(['success' => false, 'error' => 'Unable to compute the next scan time.']);
+                exit;
+            }
+            $schedule['nextRun'] = $next->format(DateTimeInterface::ATOM);
+            $schedule['queue'] = [speed_build_queue_entry($cadence, $now, $next)];
+            $schedule['status'] = 'scheduled';
+            $schedule['lastScheduledAt'] = $now->format(DateTimeInterface::ATOM);
+        }
+
+        if (!speed_save_schedule($scheduleFile, $schedule)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to save schedule settings.']);
+            exit;
+        }
+
+        $schedule = speed_enrich_schedule($schedule);
+        echo json_encode(['success' => true, 'schedule' => $schedule]);
+        break;
+
+    case 'cancel':
+        $schedule['queue'] = [];
+        $schedule['nextRun'] = null;
+        $schedule['cancelledAt'] = $now->format(DateTimeInterface::ATOM);
+        $schedule['status'] = $schedule['cadence'] === 'manual' ? 'manual' : 'paused';
+        $schedule['updatedAt'] = $now->format(DateTimeInterface::ATOM);
+
+        if (!speed_save_schedule($scheduleFile, $schedule)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to cancel the scheduled scan.']);
+            exit;
+        }
+
+        $schedule = speed_enrich_schedule($schedule);
+        echo json_encode(['success' => true, 'schedule' => $schedule]);
+        break;
+
+    case 'reschedule':
+        $cadence = $schedule['cadence'] ?? 'manual';
+        if ($cadence === 'manual') {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'error' => 'Enable automatic scans to schedule the next run.']);
+            exit;
+        }
+
+        $next = speed_calculate_next_run($cadence, $now);
+        if (!$next) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to compute the next scan time.']);
+            exit;
+        }
+
+        $schedule['nextRun'] = $next->format(DateTimeInterface::ATOM);
+        $schedule['queue'] = [speed_build_queue_entry($cadence, $now, $next)];
+        $schedule['status'] = 'scheduled';
+        $schedule['lastScheduledAt'] = $now->format(DateTimeInterface::ATOM);
+        $schedule['updatedAt'] = $now->format(DateTimeInterface::ATOM);
+
+        if (!speed_save_schedule($scheduleFile, $schedule)) {
+            http_response_code(500);
+            echo json_encode(['success' => false, 'error' => 'Unable to reschedule the scan.']);
+            exit;
+        }
+
+        $schedule = speed_enrich_schedule($schedule);
+        echo json_encode(['success' => true, 'schedule' => $schedule]);
+        break;
+
+    default:
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Unsupported action.']);
+        break;
+}

--- a/CMS/modules/speed/schedule_helpers.php
+++ b/CMS/modules/speed/schedule_helpers.php
@@ -1,0 +1,167 @@
+<?php
+
+function speed_allowed_cadences(): array
+{
+    return [
+        'manual' => [
+            'label' => 'Manual (on demand)',
+            'interval' => null,
+        ],
+        'hourly' => [
+            'label' => 'Hourly',
+            'interval' => 'PT1H',
+        ],
+        'daily' => [
+            'label' => 'Daily',
+            'interval' => 'P1D',
+        ],
+        'weekly' => [
+            'label' => 'Weekly',
+            'interval' => 'P1W',
+        ],
+    ];
+}
+
+function speed_default_schedule(): array
+{
+    return [
+        'cadence' => 'manual',
+        'status' => 'manual',
+        'nextRun' => null,
+        'queue' => [],
+        'lastScheduledAt' => null,
+        'updatedAt' => null,
+        'cancelledAt' => null,
+    ];
+}
+
+function speed_normalize_schedule(array $schedule): array
+{
+    $defaults = speed_default_schedule();
+    $normalized = $defaults;
+    foreach ($schedule as $key => $value) {
+        if (array_key_exists($key, $defaults)) {
+            $normalized[$key] = $value;
+        } else {
+            $normalized[$key] = $value;
+        }
+    }
+
+    $allowedCadences = speed_allowed_cadences();
+    if (!isset($allowedCadences[$normalized['cadence']])) {
+        $normalized['cadence'] = 'manual';
+    }
+
+    if (!isset($normalized['queue']) || !is_array($normalized['queue'])) {
+        $normalized['queue'] = [];
+    }
+
+    $normalized['queue'] = array_values(array_filter($normalized['queue'], function ($entry) {
+        if (!is_array($entry)) {
+            return false;
+        }
+        return !empty($entry['scheduledFor']) && is_string($entry['scheduledFor']);
+    }));
+
+    usort($normalized['queue'], function ($a, $b) {
+        return strcmp($a['scheduledFor'], $b['scheduledFor']);
+    });
+
+    if (empty($normalized['nextRun']) && !empty($normalized['queue'])) {
+        $normalized['nextRun'] = $normalized['queue'][0]['scheduledFor'];
+    }
+
+    if ($normalized['cadence'] === 'manual') {
+        $normalized['status'] = 'manual';
+    } elseif (!empty($normalized['queue'])) {
+        $normalized['status'] = 'scheduled';
+    } elseif ($normalized['status'] !== 'paused') {
+        $normalized['status'] = 'pending';
+    }
+
+    return $normalized;
+}
+
+function speed_calculate_next_run(string $cadence, ?DateTimeImmutable $from = null): ?DateTimeImmutable
+{
+    $allowed = speed_allowed_cadences();
+    if (!isset($allowed[$cadence])) {
+        return null;
+    }
+
+    $intervalSpec = $allowed[$cadence]['interval'] ?? null;
+    if (!$intervalSpec) {
+        return null;
+    }
+
+    $from = $from ?: new DateTimeImmutable('now');
+
+    try {
+        $interval = new DateInterval($intervalSpec);
+    } catch (Exception $e) {
+        return null;
+    }
+
+    return $from->add($interval);
+}
+
+function speed_build_queue_entry(string $cadence, DateTimeImmutable $now, DateTimeImmutable $next): array
+{
+    return [
+        'id' => str_replace('.', '', uniqid('speed_', true)),
+        'status' => 'pending',
+        'cadence' => $cadence,
+        'createdAt' => $now->format(DateTimeInterface::ATOM),
+        'scheduledFor' => $next->format(DateTimeInterface::ATOM),
+    ];
+}
+
+function speed_format_schedule_time(?string $isoTimestamp): string
+{
+    if (empty($isoTimestamp)) {
+        return '';
+    }
+
+    try {
+        $date = new DateTimeImmutable($isoTimestamp);
+    } catch (Exception $e) {
+        return '';
+    }
+
+    return $date->setTimezone(new DateTimeZone(date_default_timezone_get()))->format('M j, Y g:i A');
+}
+
+function speed_enrich_schedule(array $schedule): array
+{
+    $schedule = speed_normalize_schedule($schedule);
+    $cadences = speed_allowed_cadences();
+    $cadenceLabel = $cadences[$schedule['cadence']]['label'] ?? ucfirst($schedule['cadence']);
+    $schedule['cadenceLabel'] = $cadenceLabel;
+    $schedule['nextRunHuman'] = speed_format_schedule_time($schedule['nextRun']);
+    $schedule['hasNextRun'] = $schedule['nextRunHuman'] !== '';
+
+    if ($schedule['cadence'] === 'manual') {
+        $schedule['status'] = 'manual';
+    } elseif (!empty($schedule['queue'])) {
+        $schedule['status'] = 'scheduled';
+    } elseif ($schedule['status'] !== 'paused') {
+        $schedule['status'] = 'pending';
+    }
+
+    switch ($schedule['status']) {
+        case 'manual':
+            $schedule['statusLabel'] = 'Manual';
+            break;
+        case 'paused':
+            $schedule['statusLabel'] = 'Paused';
+            break;
+        case 'scheduled':
+            $schedule['statusLabel'] = 'Scheduled';
+            break;
+        default:
+            $schedule['statusLabel'] = 'Pending';
+            break;
+    }
+
+    return $schedule;
+}

--- a/spark-cms.css
+++ b/spark-cms.css
@@ -110,3 +110,73 @@ body {
     cursor: not-allowed;
 }
 
+.speed-scan-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+@media (min-width: 768px) {
+    .speed-scan-actions {
+        flex-direction: row;
+        align-items: center;
+        gap: 0.75rem;
+    }
+}
+
+.speed-schedule-control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 180px;
+}
+
+.speed-schedule-control__label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: #475467;
+}
+
+.speed-schedule-control__select {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid #d0d5dd;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    color: #1d2939;
+    background-color: #ffffff;
+}
+
+.speed-schedule-summary {
+    margin-top: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    color: #475467;
+}
+
+.speed-schedule-summary__text {
+    font-weight: 500;
+}
+
+.speed-schedule-summary__actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.speed-schedule-summary__actions .a11y-btn {
+    font-size: 0.8125rem;
+    padding: 0.3rem 0.75rem;
+}
+
+@media (min-width: 768px) {
+    .speed-schedule-summary {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add reusable helpers and endpoint to persist speed scan schedules and queue next runs
- extend the performance dashboard UI with an automatic scan cadence selector, schedule status messaging, and cancel/reschedule actions
- wire up client-side schedule management and styling for the new controls

## Testing
- php -l CMS/modules/speed/view.php
- php -l CMS/modules/speed/manage_schedule.php
- php -l CMS/modules/speed/schedule_helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68d803c995608331873f50a775b6eb72