### PR TITLE
Set neutral speed delta value text to white

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2282,7 +2282,7 @@
 
         .speed-delta__value--neutral {
             background: rgba(148, 163, 184, 0.18);
-            color: #475569;
+            color: #ffffff;
         }
 
         .speed-delta__value--empty {


### PR DESCRIPTION
## Summary
- update the neutral speed delta value style to use white text for better contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8b7b0333c833183bafaae7e3d9d00