### PR TITLE
Remove redundant content label from pages hero

### DIFF
--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -57,7 +57,6 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
         <header class="a11y-hero pages-hero">
             <div class="a11y-hero-content pages-hero-content">
                 <div>
-                    <span class="pages-hero-label">Content</span>
                     <h2 class="a11y-hero-title pages-hero-title">Pages</h2>
                     <p class="a11y-hero-subtitle pages-hero-subtitle">Keep your site structure organised and publish updates with confidence.</p>
                 </div>


### PR DESCRIPTION
## Summary
- remove the content label span from the pages module hero header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ba6dd590833184c8975e5b6d61d1