### PR TITLE
Align SEO dashboard styling with existing admin modules

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -7901,77 +7901,118 @@
 }
 
 .seo-hero {
-    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    position: relative;
+    background: linear-gradient(135deg, #0f172a, #4338ca, #2563eb);
     color: #fff;
-    padding: 2.5rem;
+    padding: 32px;
     border-radius: 18px;
     display: grid;
-    gap: 2rem;
+    gap: 28px;
     box-shadow: 0 24px 48px rgba(37, 99, 235, 0.28);
+    overflow: hidden;
+}
+
+.seo-hero::before,
+.seo-hero::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.14);
+    filter: blur(1px);
+}
+
+.seo-hero::before {
+    width: 220px;
+    height: 220px;
+    top: -80px;
+    right: -60px;
+}
+
+.seo-hero::after {
+    width: 160px;
+    height: 160px;
+    bottom: -70px;
+    left: -40px;
 }
 
 .seo-hero-content {
+    position: relative;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 2rem;
+    gap: 24px;
 }
 
 .seo-hero-title {
-    font-size: 2rem;
-    margin: 0 0 0.5rem 0;
+    font-size: 30px;
+    font-weight: 700;
+    margin: 0 0 8px;
 }
 
 .seo-hero-subtitle {
     margin: 0;
-    font-size: 1rem;
+    font-size: 15px;
+    line-height: 1.6;
     max-width: 32rem;
-    color: rgba(255, 255, 255, 0.9);
+    color: rgba(255, 255, 255, 0.86);
 }
 
 .seo-hero-actions {
-    display: flex;
+    position: relative;
+    display: inline-flex;
     align-items: center;
-    gap: 1rem;
+    gap: 16px;
     flex-wrap: wrap;
 }
 
 .seo-hero-meta {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    font-weight: 600;
+    gap: 10px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.35);
+    color: rgba(255, 255, 255, 0.88);
+    font-size: 13px;
 }
 
 .seo-btn {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    border-radius: 999px;
+    justify-content: center;
+    gap: 10px;
+    border-radius: 12px;
     font-weight: 600;
+    font-size: 14px;
     border: none;
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    padding: 10px 18px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+    text-decoration: none;
+}
+
+.seo-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.35);
 }
 
 .seo-btn--primary {
-    background: #fff;
-    color: #1f2937;
-    padding: 0.85rem 1.6rem;
-    box-shadow: 0 12px 25px rgba(15, 23, 42, 0.25);
+    background: linear-gradient(135deg, #38bdf8, #2563eb);
+    color: #0f172a;
+    box-shadow: 0 16px 32px rgba(56, 189, 248, 0.32);
 }
 
 .seo-btn--primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.3);
+    box-shadow: 0 20px 36px rgba(56, 189, 248, 0.38);
 }
 
 .seo-btn--ghost {
-    padding: 0.75rem 1.4rem;
-    background: rgba(37, 99, 235, 0.1);
-    color: #1e3a8a;
-    border: 1px solid rgba(59, 130, 246, 0.4);
+    padding: 8px 16px;
+    background: rgba(37, 99, 235, 0.12);
+    color: #e0e7ff;
+    border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .seo-btn--ghost:hover {
@@ -7980,52 +8021,62 @@
 
 .seo-overview-grid {
     display: grid;
-    gap: 1.25rem;
+    gap: 20px;
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    margin-top: 12px;
 }
 
 .seo-overview-card {
-    background: rgba(15, 23, 42, 0.12);
-    padding: 1.5rem;
+    background: rgba(255, 255, 255, 0.16);
+    padding: 18px 20px;
     border-radius: 16px;
-    text-align: center;
+    backdrop-filter: blur(6px);
 }
 
 .seo-overview-value {
-    font-size: 2.2rem;
-    font-weight: 700;
+    font-size: 28px;
+    font-weight: 600;
 }
 
 .seo-overview-label {
-    margin-top: 0.4rem;
-    font-size: 0.95rem;
-    opacity: 0.85;
+    margin-top: 6px;
+    font-size: 12px;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.78);
 }
 
 .seo-controls {
     display: flex;
     flex-wrap: wrap;
-    gap: 1rem;
+    gap: 16px;
     align-items: center;
-    justify-content: space-between;
 }
 
 .seo-search {
-    background: #fff;
-    border: 1px solid #e5e7eb;
-    border-radius: 999px;
+    position: relative;
+    flex: 1 1 260px;
+    max-width: 420px;
     display: flex;
     align-items: center;
-    padding: 0.4rem 1rem;
-    gap: 0.5rem;
-    flex: 1 1 240px;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 10px 14px;
+    gap: 10px;
+    color: #64748b;
+}
+
+.seo-search i {
+    font-size: 15px;
 }
 
 .seo-search input {
     border: none;
     outline: none;
     flex: 1;
-    font-size: 0.95rem;
+    font-size: 14px;
+    color: #1f2937;
 }
 
 .seo-filter-group,
@@ -8033,32 +8084,116 @@
 .seo-view-toggle {
     display: inline-flex;
     align-items: center;
-    gap: 0.6rem;
     flex-wrap: wrap;
+    gap: 10px;
 }
 
-.seo-filter-btn,
-.seo-sort-btn,
-.seo-view-btn {
-    border: 1px solid #d1d5db;
-    background: #fff;
-    color: #1f2937;
-    padding: 0.5rem 1rem;
+.seo-filter-btn {
+    border: 1px solid #d6dcff;
+    background: #f5f7ff;
+    color: #334155;
+    padding: 8px 16px;
     border-radius: 999px;
+    font-size: 13px;
     font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.seo-filter-count {
+    background: #e0e7ff;
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+}
+
+.seo-filter-btn:hover,
+.seo-filter-btn.active {
+    background: linear-gradient(135deg, #4338ca, #2563eb);
+    color: #fff;
+    border-color: transparent;
+}
+
+.seo-filter-btn:hover .seo-filter-count,
+.seo-filter-btn.active .seo-filter-count {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.seo-sort-group {
+    padding: 6px;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    background: #fff;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+}
+
+.seo-sort-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border: none;
+    border-radius: 10px;
+    background: transparent;
+    color: #475569;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.seo-sort-btn i {
+    font-size: 14px;
+    color: #64748b;
+}
+
+.seo-sort-btn:hover,
+.seo-sort-btn:focus-visible {
+    background: rgba(59, 130, 246, 0.12);
+    color: #2563eb;
+    outline: none;
+}
+
+.seo-sort-btn:hover i,
+.seo-sort-btn:focus-visible i {
+    color: #2563eb;
+}
+
+.seo-sort-btn.active {
+    background: linear-gradient(135deg, #4338ca, #2563eb);
+    color: #fff;
+    box-shadow: 0 6px 10px -4px rgba(59, 130, 246, 0.4);
+}
+
+.seo-sort-btn.active i {
+    color: #fff;
+}
+
+.seo-view-toggle {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.seo-view-btn {
+    background: #fff;
+    border: none;
+    padding: 8px 14px;
+    color: #64748b;
     cursor: pointer;
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+    justify-content: center;
+    gap: 6px;
+    transition: background 0.2s ease, color 0.2s ease;
 }
 
-.seo-filter-btn.active,
-.seo-sort-btn.active,
 .seo-view-btn.active {
-    background: #1e40af;
+    background: #2563eb;
     color: #fff;
-    border-color: #1e3a8a;
 }
 
 .seo-page-grid {


### PR DESCRIPTION
## Summary
- restyle the SEO hero, metrics, and overview cards to mirror the gradients and layout used in the Accessibility and Analytics dashboards
- refresh the SEO controls with pill-style filters, toggles, and badges so they match the other modules
- enhance SEO action buttons with shared gradients and focus styling for a consistent admin experience

## Testing
- php -S 0.0.0.0:8000

------
https://chatgpt.com/codex/tasks/task_e_68d8c321a8988331b4924ccd5fa8f5b2