### PR TITLE
Fix Back to Performance Dashboard link in speed module

### DIFF
--- a/CMS/modules/speed/speed.js
+++ b/CMS/modules/speed/speed.js
@@ -646,6 +646,14 @@
         const $detailPage = $('#speedDetailPage');
         if ($detailPage.length) {
             const pageSlug = $detailPage.data('page-slug');
+            $('#speedBackToDashboard').on('click', function (event) {
+                event.preventDefault();
+                if (!loadSpeedModule('')) {
+                    if (stats.moduleUrl) {
+                        window.location.href = stats.moduleUrl;
+                    }
+                }
+            });
             const pageData = dataMap[pageSlug];
             const $rescanBtn = $detailPage.find('[data-speed-action="rescan-page"]');
             const $exportBtn = $detailPage.find('[data-speed-action="export-page-report"]');


### PR DESCRIPTION
## Summary
- ensure the speed detail view binds the Back to Performance Dashboard link to reload the dashboard via AJAX with a fallback to the full module URL

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8c78e5fc88331a57d0b336d3c926e