### PR TITLE
Align pages dashboard layout

### DIFF
--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -53,7 +53,7 @@ $filterCounts = [
 $pagesWord = $totalPages === 1 ? 'page' : 'pages';
 ?>
 <div class="content-section" id="pages">
-    <div class="pages-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES); ?>">
+    <div class="pages-dashboard a11y-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdatedDisplay, ENT_QUOTES); ?>">
         <header class="a11y-hero pages-hero">
             <div class="a11y-hero-content pages-hero-content">
                 <div>


### PR DESCRIPTION
## Summary
- add the shared `a11y-dashboard` class to the pages module wrapper to match other module layouts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8c9527e688331a9a3e04532998ef7