### PR TITLE
Use shared a11y button styles on pages module

### DIFF
--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -61,11 +61,11 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                     <p class="a11y-hero-subtitle pages-hero-subtitle">Keep your site structure organised and publish updates with confidence.</p>
                 </div>
                 <div class="a11y-hero-actions pages-hero-actions">
-                    <button type="button" class="pages-btn pages-btn--primary" id="newPageBtn">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="newPageBtn">
                         <i class="fa-solid fa-plus" aria-hidden="true"></i>
                         <span>New Page</span>
                     </button>
-                    <a class="pages-btn pages-btn--ghost" href="../" target="_blank" rel="noopener">
+                    <a class="a11y-btn a11y-btn--ghost" href="../" target="_blank" rel="noopener">
                         <i class="fa-solid fa-up-right-from-square" aria-hidden="true"></i>
                         <span>View Site</span>
                     </a>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1694,56 +1694,6 @@
             justify-content: flex-end;
         }
 
-        .pages-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 10px 20px;
-            border-radius: 999px;
-            border: 2px solid transparent;
-            font-weight: 600;
-            font-size: 14px;
-            color: inherit;
-            text-decoration: none;
-            cursor: pointer;
-            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-            background: rgba(255,255,255,0.18);
-            color: #fff;
-        }
-
-        .pages-btn i {
-            font-size: 14px;
-        }
-
-        .pages-btn span {
-            display: inline-block;
-        }
-
-        .pages-btn:focus-visible {
-            outline: 2px solid #fff;
-            outline-offset: 2px;
-        }
-
-        .pages-btn--primary {
-            background: linear-gradient(135deg, #f97316, #fb7185);
-            color: #fff;
-            box-shadow: 0 16px 36px rgba(251, 113, 133, 0.35);
-        }
-
-        .pages-btn--primary:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 20px 40px rgba(251, 113, 133, 0.45);
-        }
-
-        .pages-btn--ghost {
-            background: rgba(255,255,255,0.16);
-            border-color: rgba(255,255,255,0.45);
-        }
-
-        .pages-btn--ghost:hover {
-            background: rgba(255,255,255,0.26);
-        }
-
         .pages-hero-meta {
             display: inline-flex;
             align-items: center;


### PR DESCRIPTION
## Summary
- replace pages module button markup to use the shared a11y button styles
- remove the now-unused pages-specific button styles from the stylesheet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c9589d2c8331bc3ab8636599c15d