### PR TITLE
Wrap pages inventory table in card layout

### DIFF
--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -108,16 +108,16 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
             </div>
         </div>
 
-        <div class="pages-table-card">
-            <div class="pages-table-header">
-                <div>
-                    <h3 class="pages-table-title">Page inventory</h3>
-                    <p class="pages-table-subtitle">Manage publishing status, homepage selection, and metadata across all content.</p>
+        <section class="a11y-detail-card table-card pages-table-card" aria-labelledby="pagesInventoryTitle" aria-describedby="pagesInventoryDescription">
+            <header class="table-header pages-table-header">
+                <div class="table-header-text">
+                    <h3 class="table-title" id="pagesInventoryTitle">Page inventory</h3>
+                    <p class="table-description" id="pagesInventoryDescription">Manage publishing status, homepage selection, and metadata across all content.</p>
                 </div>
-                <div class="pages-table-meta" id="pagesVisibleCount">Showing <?php echo $totalPages . ' ' . $pagesWord; ?></div>
-            </div>
+                <span class="table-meta pages-table-meta" id="pagesVisibleCount" aria-live="polite">Showing <?php echo $totalPages . ' ' . $pagesWord; ?></span>
+            </header>
             <div class="pages-table-wrapper">
-                <table class="data-table pages-table" id="pagesTable">
+                <table class="data-table pages-table" id="pagesTable" aria-describedby="pagesInventoryDescription">
                     <thead>
                         <tr>
                             <th scope="col">Title</th>
@@ -178,7 +178,7 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                     </tbody>
                 </table>
             </div>
-        </div>
+        </section>
 
         <div class="pages-empty-state" id="pagesEmptyState" hidden>
             <i class="fa-solid fa-file-circle-question" aria-hidden="true"></i>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1876,12 +1876,10 @@
 
         .pages-table-card {
             background: #fff;
-            border-radius: 20px;
-            box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
-            padding: 24px;
-            display: flex;
-            flex-direction: column;
-            gap: 18px;
+            border-radius: 16px;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+            padding: 0;
         }
 
         .pages-table-header {
@@ -1892,27 +1890,38 @@
             flex-wrap: wrap;
         }
 
-        .pages-table-title {
-            margin: 0;
+        .pages-table-card .table-title {
             font-size: 20px;
-            font-weight: 600;
             color: #0f172a;
         }
 
-        .pages-table-subtitle {
+        .table-header-text {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .table-description {
             margin: 6px 0 0;
             font-size: 14px;
             color: #64748b;
             max-width: 520px;
         }
 
-        .pages-table-meta {
+        .table-meta {
             font-size: 13px;
             font-weight: 600;
             background: #f1f5f9;
             color: #475569;
             padding: 8px 14px;
             border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .pages-table-meta {
+            box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.4);
         }
 
         .pages-table-wrapper {


### PR DESCRIPTION
## Summary
- wrap the pages inventory table in the shared a11y detail/table card structure for consistency
- align headings, metadata markup, and aria wiring with other module cards
- adjust table card styling to reuse the shared table description/meta patterns

## Testing
- php -l CMS/modules/pages/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d8c95adb80833181192279d97494c7