### PR TITLE
Align SEO dashboard filters with accessibility styles

### DIFF
--- a/CMS/modules/seo/seo.js
+++ b/CMS/modules/seo/seo.js
@@ -121,7 +121,7 @@
         $root.find('#seoStatOptimized').text(stats.optimizedPages || 0);
         if (stats.filterCounts) {
             Object.keys(stats.filterCounts).forEach(function (key) {
-                $root.find('.seo-filter-count[data-count="' + key + '"]').text(stats.filterCounts[key]);
+                $root.find('.a11y-filter-count[data-count="' + key + '"]').text(stats.filterCounts[key]);
             });
         }
     }
@@ -167,20 +167,20 @@
 
         applyFilters();
 
-        $root.find('.seo-filter-btn').on('click', function () {
+        $root.find('.a11y-filter-btn').on('click', function () {
             var $btn = $(this);
             var filter = String($btn.data('seo-filter') || 'all');
             currentFilter = filter;
-            $root.find('.seo-filter-btn').removeClass('active').attr('aria-pressed', 'false');
+            $root.find('.a11y-filter-btn').removeClass('active').attr('aria-pressed', 'false');
             $btn.addClass('active').attr('aria-pressed', 'true');
             applyFilters();
         });
 
-        $root.find('.seo-sort-btn').on('click', function () {
+        $root.find('.a11y-sort-btn').on('click', function () {
             var $btn = $(this);
             var sortKey = String($btn.data('seo-sort') || 'score-desc');
             currentSort = sortKey;
-            $root.find('.seo-sort-btn').removeClass('active').attr('aria-pressed', 'false');
+            $root.find('.a11y-sort-btn').removeClass('active').attr('aria-pressed', 'false');
             $btn.addClass('active').attr('aria-pressed', 'true');
             applyFilters();
         });

--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -720,26 +720,26 @@ $dashboardStats = [
                 <i class="fas fa-search" aria-hidden="true"></i>
                 <input type="search" id="seoSearchInput" placeholder="Search pages by title, URL, or issue" aria-label="Search SEO results">
             </label>
-            <div class="seo-filter-group" role="group" aria-label="SEO filters">
-                <button type="button" class="seo-filter-btn active" data-seo-filter="all">All Pages <span class="seo-filter-count" data-count="all"><?php echo $filterCounts['all']; ?></span></button>
-                <button type="button" class="seo-filter-btn" data-seo-filter="critical">Critical Issues <span class="seo-filter-count" data-count="critical"><?php echo $filterCounts['critical']; ?></span></button>
-                <button type="button" class="seo-filter-btn" data-seo-filter="needs-work">Needs Work <span class="seo-filter-count" data-count="needs-work"><?php echo $filterCounts['needs-work']; ?></span></button>
-                <button type="button" class="seo-filter-btn" data-seo-filter="optimized">Optimised <span class="seo-filter-count" data-count="optimized"><?php echo $filterCounts['optimized']; ?></span></button>
+            <div class="a11y-filter-group" role="group" aria-label="SEO filters">
+                <button type="button" class="a11y-filter-btn active" data-seo-filter="all">All Pages <span class="a11y-filter-count" data-count="all"><?php echo $filterCounts['all']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-seo-filter="critical">Critical Issues <span class="a11y-filter-count" data-count="critical"><?php echo $filterCounts['critical']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-seo-filter="needs-work">Needs Work <span class="a11y-filter-count" data-count="needs-work"><?php echo $filterCounts['needs-work']; ?></span></button>
+                <button type="button" class="a11y-filter-btn" data-seo-filter="optimized">Optimised <span class="a11y-filter-count" data-count="optimized"><?php echo $filterCounts['optimized']; ?></span></button>
             </div>
-            <div class="seo-sort-group" role="group" aria-label="Sort pages">
-                <button type="button" class="seo-sort-btn active" data-seo-sort="score-desc">
+            <div class="a11y-sort-group" role="group" aria-label="Sort pages">
+                <button type="button" class="a11y-sort-btn active" data-seo-sort="score-desc">
                     <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
                     <span>Score (High–Low)</span>
                 </button>
-                <button type="button" class="seo-sort-btn" data-seo-sort="score-asc">
+                <button type="button" class="a11y-sort-btn" data-seo-sort="score-asc">
                     <i class="fas fa-sort-amount-up" aria-hidden="true"></i>
                     <span>Score (Low–High)</span>
                 </button>
-                <button type="button" class="seo-sort-btn" data-seo-sort="issues-desc">
+                <button type="button" class="a11y-sort-btn" data-seo-sort="issues-desc">
                     <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
                     <span>Most Issues</span>
                 </button>
-                <button type="button" class="seo-sort-btn" data-seo-sort="title-asc">
+                <button type="button" class="a11y-sort-btn" data-seo-sort="title-asc">
                     <i class="fas fa-sort-alpha-down" aria-hidden="true"></i>
                     <span>Title (A–Z)</span>
                 </button>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -8079,97 +8079,11 @@
     color: #1f2937;
 }
 
-.seo-filter-group,
-.seo-sort-group,
 .seo-view-toggle {
     display: inline-flex;
     align-items: center;
     flex-wrap: wrap;
     gap: 10px;
-}
-
-.seo-filter-btn {
-    border: 1px solid #d6dcff;
-    background: #f5f7ff;
-    color: #334155;
-    padding: 8px 16px;
-    border-radius: 999px;
-    font-size: 13px;
-    font-weight: 600;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.seo-filter-count {
-    background: #e0e7ff;
-    border-radius: 999px;
-    padding: 2px 10px;
-    font-size: 12px;
-}
-
-.seo-filter-btn:hover,
-.seo-filter-btn.active {
-    background: linear-gradient(135deg, #4338ca, #2563eb);
-    color: #fff;
-    border-color: transparent;
-}
-
-.seo-filter-btn:hover .seo-filter-count,
-.seo-filter-btn.active .seo-filter-count {
-    background: rgba(255, 255, 255, 0.2);
-}
-
-.seo-sort-group {
-    padding: 6px;
-    border: 1px solid #e2e8f0;
-    border-radius: 12px;
-    background: #fff;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
-}
-
-.seo-sort-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 14px;
-    border: none;
-    border-radius: 10px;
-    background: transparent;
-    color: #475569;
-    font-size: 13px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.seo-sort-btn i {
-    font-size: 14px;
-    color: #64748b;
-}
-
-.seo-sort-btn:hover,
-.seo-sort-btn:focus-visible {
-    background: rgba(59, 130, 246, 0.12);
-    color: #2563eb;
-    outline: none;
-}
-
-.seo-sort-btn:hover i,
-.seo-sort-btn:focus-visible i {
-    color: #2563eb;
-}
-
-.seo-sort-btn.active {
-    background: linear-gradient(135deg, #4338ca, #2563eb);
-    color: #fff;
-    box-shadow: 0 6px 10px -4px rgba(59, 130, 246, 0.4);
-}
-
-.seo-sort-btn.active i {
-    color: #fff;
 }
 
 .seo-view-toggle {
@@ -8546,14 +8460,14 @@
         flex-direction: column;
         align-items: stretch;
     }
-    .seo-filter-group,
-    .seo-sort-group,
+    .a11y-filter-group,
+    .a11y-sort-group,
     .seo-view-toggle {
         width: 100%;
         justify-content: flex-start;
     }
-    .seo-filter-btn,
-    .seo-sort-btn,
+    .a11y-filter-btn,
+    .a11y-sort-btn,
     .seo-view-btn {
         flex: 1 1 auto;
         justify-content: center;


### PR DESCRIPTION
## Summary
- swap the SEO dashboard filter and sort controls to the shared a11y button classes
- update the JavaScript selectors to reference the new class names
- remove redundant CSS for the old filter/sort styles and adjust responsive rules

## Testing
- php -l CMS/modules/seo/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d8c97562548331a3cb2244dd5d08f9