### PR TITLE
Rework search results card with shared detail layout

### DIFF
--- a/CMS/modules/search/view.php
+++ b/CMS/modules/search/view.php
@@ -38,6 +38,12 @@ if ($lower !== '') {
     }
 }
 $resultCount = count($results);
+$resultSummary = $resultCount === 1
+    ? 'Showing 1 result'
+    : 'Showing ' . number_format($resultCount) . ' results';
+$querySuffix = $q !== ''
+    ? ' for &ldquo;' . htmlspecialchars($q) . '&rdquo;'
+    : '';
 $typeCounts = [
     'Page' => 0,
     'Post' => 0,
@@ -61,7 +67,7 @@ foreach ($results as $entry) {
                 <div class="a11y-hero-actions search-hero-actions">
                     <span class="a11y-hero-meta search-hero-meta">
                         <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
-                        <?php echo $resultCount === 1 ? 'Showing 1 result' : 'Showing ' . number_format($resultCount) . ' results'; ?><?php if ($q !== ''): ?> for “<?php echo htmlspecialchars($q); ?>”<?php endif; ?>
+                        <?php echo $resultSummary . $querySuffix; ?>
                     </span>
                 </div>
             </div>
@@ -81,45 +87,51 @@ foreach ($results as $entry) {
             </div>
         </header>
 
-        <div class="table-card">
-            <div class="table-header">
-                <div class="table-title">Search Results<?php if($q!=='') echo ' for \''.htmlspecialchars($q).'\''; ?></div>
+        <section class="a11y-detail-card search-results-card">
+            <header class="search-results-card__header">
+                <div class="search-results-card__intro">
+                    <h3 class="search-results-card__title">Search results</h3>
+                    <p class="search-results-card__description">Review matches across pages, posts, and media.</p>
+                </div>
+                <span class="search-results-card__meta"><?php echo $resultSummary . $querySuffix; ?></span>
+            </header>
+            <div class="search-results-table">
+                <table class="data-table search-table">
+                    <thead>
+                        <tr><th scope="col">Type</th><th scope="col">Title</th><th scope="col">Slug</th><th scope="col">Status</th><th scope="col">Actions</th></tr>
+                    </thead>
+                    <tbody>
+                        <?php if ($results): ?>
+                            <?php foreach ($results as $r): ?>
+                                <?php
+                                    if(($r['type'] ?? '') === 'Post') {
+                                        $viewUrl = '../' . urlencode($r['slug']);
+                                        $status = ucfirst($r['status'] ?? 'draft');
+                                    } elseif(($r['type'] ?? '') === 'Media') {
+                                        $viewUrl = '../' . ltrim($r['file'], '/');
+                                        $status = !empty($r['size']) ? round($r['size']/1024).' KB' : '';
+                                    } else {
+                                        $viewUrl = '../?page=' . urlencode($r['slug']);
+                                        if(isset($_SESSION['user'])) {
+                                            $viewUrl = '../liveed/builder.php?id=' . urlencode($r['id']);
+                                        }
+                                        $status = !empty($r['published']) ? 'Published' : 'Draft';
+                                    }
+                                ?>
+                                <tr data-id="<?php echo $r['id']; ?>">
+                                    <td><?php echo htmlspecialchars($r['type'] ?? ''); ?></td>
+                                    <td><?php echo htmlspecialchars($r['title']); ?></td>
+                                    <td><?php echo htmlspecialchars($r['slug']); ?></td>
+                                    <td><?php echo htmlspecialchars($status); ?></td>
+                                    <td><a class="btn btn-secondary" href="<?php echo $viewUrl; ?>" target="_blank">View</a></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr><td colspan="5">No results found</td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
             </div>
-        <table class="data-table">
-            <thead>
-                <tr><th>Type</th><th>Title</th><th>Slug</th><th>Status</th><th>Actions</th></tr>
-            </thead>
-            <tbody>
-                <?php if ($results): ?>
-                    <?php foreach ($results as $r): ?>
-                        <?php
-                            if(($r['type'] ?? '') === 'Post') {
-                                $viewUrl = '../' . urlencode($r['slug']);
-                                $status = ucfirst($r['status'] ?? 'draft');
-                            } elseif(($r['type'] ?? '') === 'Media') {
-                                $viewUrl = '../' . ltrim($r['file'], '/');
-                                $status = !empty($r['size']) ? round($r['size']/1024).' KB' : '';
-                            } else {
-                                $viewUrl = '../?page=' . urlencode($r['slug']);
-                                if(isset($_SESSION['user'])) {
-                                    $viewUrl = '../liveed/builder.php?id=' . urlencode($r['id']);
-                                }
-                                $status = !empty($r['published']) ? 'Published' : 'Draft';
-                            }
-                        ?>
-                        <tr data-id="<?php echo $r['id']; ?>">
-                            <td><?php echo htmlspecialchars($r['type'] ?? ''); ?></td>
-                            <td><?php echo htmlspecialchars($r['title']); ?></td>
-                            <td><?php echo htmlspecialchars($r['slug']); ?></td>
-                            <td><?php echo htmlspecialchars($status); ?></td>
-                            <td><a class="btn btn-secondary" href="<?php echo $viewUrl; ?>" target="_blank">View</a></td>
-                        </tr>
-                    <?php endforeach; ?>
-                <?php else: ?>
-                    <tr><td colspan="5">No results found</td></tr>
-                <?php endif; ?>
-            </tbody>
-        </table>
-        </div>
+        </section>
     </div>
 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -436,6 +436,60 @@
             font-weight: 600;
         }
 
+        .search-results-card {
+            padding: 24px;
+            gap: 24px;
+        }
+
+        .search-results-card__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        .search-results-card__title {
+            margin: 0;
+            font-size: 20px;
+            line-height: 1.3;
+            color: #1f2937;
+            font-weight: 700;
+        }
+
+        .search-results-card__description {
+            margin: 0;
+            color: #4b5563;
+            font-size: 14px;
+        }
+
+        .search-results-card__meta {
+            font-size: 14px;
+            color: #334155;
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: #f1f5f9;
+        }
+
+        .search-results-table {
+            border-radius: 14px;
+            overflow: hidden;
+            box-shadow: inset 0 0 0 1px #e2e8f0;
+            background: #fff;
+        }
+
+        .search-results-table .data-table {
+            margin: 0;
+        }
+
+        .search-results-card .data-table th,
+        .search-results-card .data-table td {
+            padding: 14px 20px;
+        }
+
         /* Import/Export module */
         #import .import-dashboard {
             display: flex;


### PR DESCRIPTION
## Summary
- refactor the search module results table to use the shared a11y detail card structure and headings
- generate reusable summary text for the hero and results card based on the query
- add dedicated styling so the search results card header and table share consistent padding

## Testing
- php -l CMS/modules/search/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d8c96a080c8331829cda8f6f088cf3