### PR TITLE
Fix accessibility breakdown markup in dashboard view

### DIFF
--- a/CMS/modules/dashboard/view.php
+++ b/CMS/modules/dashboard/view.php
@@ -72,7 +72,7 @@
                     <div class="dashboard-overview-body">
                         <div class="a11y-overview-value" data-stat="accessibility-score">0%</div>
                         <div class="a11y-overview-label">Accessibility</div>
-                        <div class="dashboard-overview-meta" data-stat="accessibility-breakdown">Compliant: 0 • Needs review: 0</div>
+                        <div class="dashboard-overview-meta" data-stat="accessibility-breakdown">Compliant: 0 &bull; Needs review: 0</div>
                         <div class="dashboard-overview-meta" data-stat="accessibility-alt">Alt text issues: 0</div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- normalize the accessibility breakdown meta line so the closing div stays on the same line as its content
- swap in an HTML entity for the bullet to avoid encoding-related line breaks

## Testing
- php -l CMS/modules/dashboard/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d8c978229c8331b95a43909cc52b93