### PR TITLE
Align speed dashboard sort container class

### DIFF
--- a/CMS/modules/speed/view.php
+++ b/CMS/modules/speed/view.php
@@ -762,7 +762,7 @@ write_json_file($snapshotFile, $currentSnapshot);
                 <button type="button" class="a11y-filter-btn" data-speed-filter="monitor">Needs attention <span class="a11y-filter-count" data-count="monitor"><?php echo $filterCounts['monitor']; ?></span></button>
                 <button type="button" class="a11y-filter-btn" data-speed-filter="fast">Performing well <span class="a11y-filter-count" data-count="fast"><?php echo $filterCounts['fast']; ?></span></button>
             </div>
-            <div class="a11y-sort" role="group" aria-label="Sort results">
+            <div class="a11y-sort-group" role="group" aria-label="Sort results">
                 <label for="speedSortSelect">Sort by</label>
                 <select id="speedSortSelect">
                     <option value="score" selected>Performance score</option>


### PR DESCRIPTION
## Summary
- update the speed dashboard sort container to use the shared a11y sort group styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c97b8fe08331ac1c8546a5182452