### PR TITLE
Add accessibility hero module theming

### DIFF
--- a/CMS/modules/accessibility/view.php
+++ b/CMS/modules/accessibility/view.php
@@ -568,18 +568,18 @@ $dashboardStats = [
     </div>
 <?php else: ?>
     <div class="a11y-dashboard" data-last-scan="<?php echo htmlspecialchars($lastScan, ENT_QUOTES); ?>">
-        <header class="a11y-hero">
-            <div class="a11y-hero-content">
+        <header class="a11y-hero accessibility-hero">
+            <div class="a11y-hero-content accessibility-hero-content">
                 <div>
-                    <h2 class="a11y-hero-title">Accessibility Dashboard</h2>
-                    <p class="a11y-hero-subtitle">Monitor WCAG compliance and keep your experience inclusive for every visitor.</p>
+                    <h2 class="a11y-hero-title accessibility-hero-title">Accessibility Dashboard</h2>
+                    <p class="a11y-hero-subtitle accessibility-hero-subtitle">Monitor WCAG compliance and keep your experience inclusive for every visitor.</p>
                 </div>
-                <div class="a11y-hero-actions">
+                <div class="a11y-hero-actions accessibility-hero-actions">
                     <button type="button" id="scanAllPagesBtn" class="a11y-btn a11y-btn--primary" data-a11y-action="scan-all">
                         <i class="fas fa-universal-access" aria-hidden="true"></i>
                         <span>Scan All Pages</span>
                     </button>
-                    <span class="a11y-hero-meta">
+                    <span class="a11y-hero-meta accessibility-hero-meta">
                         <i class="fas fa-clock" aria-hidden="true"></i>
                         Last scan: <?php echo htmlspecialchars($lastScan); ?>
                     </span>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2151,6 +2151,78 @@
             font-size: 13px;
         }
 
+        #accessibility .accessibility-hero {
+            background: linear-gradient(135deg, #1e3a8a, #0891b2);
+            box-shadow: 0 28px 56px rgba(8, 145, 178, 0.32);
+        }
+
+        #accessibility .accessibility-hero::before,
+        #accessibility .accessibility-hero::after {
+            content: '';
+            position: absolute;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.14);
+            filter: blur(1px);
+        }
+
+        #accessibility .accessibility-hero::before {
+            width: 240px;
+            height: 240px;
+            top: -90px;
+            right: -70px;
+        }
+
+        #accessibility .accessibility-hero::after {
+            width: 180px;
+            height: 180px;
+            bottom: -80px;
+            left: -40px;
+        }
+
+        #accessibility .accessibility-hero-content {
+            position: relative;
+            z-index: 1;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 24px;
+            justify-content: space-between;
+        }
+
+        #accessibility .accessibility-hero-title {
+            font-weight: 700;
+            letter-spacing: -0.01em;
+        }
+
+        #accessibility .accessibility-hero-subtitle {
+            color: rgba(240, 253, 250, 0.85);
+            max-width: 560px;
+        }
+
+        #accessibility .accessibility-hero-actions {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+            position: relative;
+            z-index: 1;
+        }
+
+        #accessibility .accessibility-hero-meta {
+            background: rgba(15, 23, 42, 0.3);
+            color: rgba(224, 242, 254, 0.9);
+            letter-spacing: 0.02em;
+        }
+
+        .accessibility-hero .a11y-btn--primary {
+            background: linear-gradient(135deg, #a855f7, #2563eb);
+            box-shadow: 0 16px 32px rgba(37, 99, 235, 0.3);
+        }
+
+        .accessibility-hero .a11y-btn--primary:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 20px 36px rgba(8, 145, 178, 0.35);
+        }
+
         .a11y-btn {
             display: inline-flex;
             align-items: center;
@@ -7639,6 +7711,7 @@
             .import-hero,
             .seo-hero,
             .a11y-hero,
+            .accessibility-hero,
             .dashboard-hero) {
             position: relative;
             background: var(--module-hero-gradient);
@@ -7662,6 +7735,7 @@
             .import-hero,
             .seo-hero,
             .a11y-hero,
+            .accessibility-hero,
             .dashboard-hero)::before,
         :is(.analytics-hero,
             .menu-hero,
@@ -7673,6 +7747,7 @@
             .import-hero,
             .seo-hero,
             .a11y-hero,
+            .accessibility-hero,
             .dashboard-hero)::after {
             content: '';
             position: absolute;
@@ -7691,6 +7766,7 @@
             .import-hero,
             .seo-hero,
             .a11y-hero,
+            .accessibility-hero,
             .dashboard-hero)::before {
             width: 240px;
             height: 240px;
@@ -7708,6 +7784,7 @@
             .import-hero,
             .seo-hero,
             .a11y-hero,
+            .accessibility-hero,
             .dashboard-hero)::after {
             width: 180px;
             height: 180px;
@@ -7725,6 +7802,7 @@
             .import-hero-content,
             .seo-hero-content,
             .a11y-hero-content,
+            .accessibility-hero-content,
             .dashboard-hero-content) {
             position: relative;
             display: flex;
@@ -7743,6 +7821,7 @@
                 .import-hero-content,
                 .seo-hero-content,
                 .a11y-hero-content,
+                .accessibility-hero-content,
                 .dashboard-hero-content) {
                 flex-direction: row;
                 align-items: flex-start;
@@ -7761,6 +7840,7 @@
             .import-hero-title,
             .seo-hero-title,
             .a11y-hero-title,
+            .accessibility-hero-title,
             .dashboard-hero-title) {
             font-size: 32px;
             font-weight: 700;
@@ -7778,6 +7858,7 @@
             .import-hero-subtitle,
             .seo-hero-subtitle,
             .a11y-hero-subtitle,
+            .accessibility-hero-subtitle,
             .dashboard-hero-subtitle) {
             margin: 0;
             font-size: 16px;
@@ -7796,6 +7877,7 @@
             .import-hero-actions,
             .seo-hero-actions,
             .a11y-hero-actions,
+            .accessibility-hero-actions,
             .dashboard-hero-actions) {
             display: inline-flex;
             flex-wrap: wrap;
@@ -7814,6 +7896,7 @@
                 .import-hero-actions,
                 .seo-hero-actions,
                 .a11y-hero-actions,
+                .accessibility-hero-actions,
                 .dashboard-hero-actions) {
                 margin-left: auto;
             }
@@ -7827,7 +7910,8 @@
             .search-hero-meta,
             .import-hero-meta,
             .seo-hero-meta,
-            .a11y-hero-meta) {
+            .a11y-hero-meta,
+            .accessibility-hero-meta) {
             display: inline-flex;
             align-items: center;
             gap: 10px;


### PR DESCRIPTION
## Summary
- add module-scoped hero classes to the accessibility dashboard markup
- style the accessibility hero variant and register it with the shared hero layout selectors for consistent theming

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8c97cdf888331b4553ee80f4fa85d