### PR TITLE
Align logs dashboard with accessibility styling

### DIFF
--- a/CMS/modules/logs/view.php
+++ b/CMS/modules/logs/view.php
@@ -161,7 +161,7 @@ if ($uniqueUsersCount === 1) {
 }
 ?>
 <div class="content-section" id="logs">
-    <div class="logs-dashboard" data-logs="<?php echo $logsJson; ?>" data-endpoint="modules/logs/list_logs.php">
+    <div class="logs-dashboard a11y-dashboard" data-logs="<?php echo $logsJson; ?>" data-endpoint="modules/logs/list_logs.php">
         <header class="a11y-hero logs-hero">
             <div class="a11y-hero-content logs-hero-content">
                 <div>


### PR DESCRIPTION
## Summary
- add the shared a11y-dashboard class to the logs module container to match other dashboards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c9851fa08331bdb772252c4b85d3