### PR TITLE
Group logs hero meta chips

### DIFF
--- a/CMS/modules/logs/view.php
+++ b/CMS/modules/logs/view.php
@@ -173,16 +173,18 @@ if ($uniqueUsersCount === 1) {
                         <i class="fas fa-rotate" aria-hidden="true"></i>
                         <span>Refresh</span>
                     </button>
-                    <span class="a11y-hero-meta logs-hero-meta-item">
-                        <span class="logs-hero-meta__label">Last activity</span>
-                        <span class="logs-hero-meta__value" id="logsLastActivity" title="<?php echo htmlspecialchars($lastActivityExact, ENT_QUOTES, 'UTF-8'); ?>">
-                            <?php echo htmlspecialchars($lastActivityLabel, ENT_QUOTES, 'UTF-8'); ?>
+                    <div class="a11y-hero-meta-group logs-hero-meta-group">
+                        <span class="a11y-hero-meta logs-hero-meta-item">
+                            <span class="logs-hero-meta__label">Last activity</span>
+                            <span class="logs-hero-meta__value" id="logsLastActivity" title="<?php echo htmlspecialchars($lastActivityExact, ENT_QUOTES, 'UTF-8'); ?>">
+                                <?php echo htmlspecialchars($lastActivityLabel, ENT_QUOTES, 'UTF-8'); ?>
+                            </span>
                         </span>
-                    </span>
-                    <span class="a11y-hero-meta logs-hero-meta-item">
-                        <span class="logs-hero-meta__label">Past 24 hours</span>
-                        <span class="logs-hero-meta__value" id="logsPast24h"><?php echo $last24Hours; ?></span>
-                    </span>
+                        <span class="a11y-hero-meta logs-hero-meta-item">
+                            <span class="logs-hero-meta__label">Past 24 hours</span>
+                            <span class="logs-hero-meta__value" id="logsPast24h"><?php echo $last24Hours; ?></span>
+                        </span>
+                    </div>
                 </div>
             </div>
             <div class="a11y-overview-grid logs-overview-grid">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -352,6 +352,13 @@
             z-index: 1;
         }
 
+        .logs-hero-meta-group {
+            display: inline-flex;
+            align-items: stretch;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
         .logs-hero-meta-item {
             display: inline-flex;
             flex-direction: column;
@@ -2138,6 +2145,13 @@
             display: flex;
             align-items: center;
             gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        .a11y-hero-meta-group {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
             flex-wrap: wrap;
         }
 


### PR DESCRIPTION
## Summary
- wrap the logs hero meta spans in a grouped container for better structure
- add shared and module-specific styles so grouped meta chips align with other hero actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c98b9c088331bbe4d51eb9f2a27d