### PR TITLE
Ensure search module uses accessibility dashboard layout

### DIFF
--- a/CMS/modules/search/view.php
+++ b/CMS/modules/search/view.php
@@ -51,7 +51,7 @@ foreach ($results as $entry) {
 }
 ?>
 <div class="content-section" id="search" data-query="<?php echo htmlspecialchars($q); ?>">
-    <div class="search-dashboard">
+    <div class="search-dashboard a11y-dashboard">
         <header class="a11y-hero search-hero">
             <div class="a11y-hero-content search-hero-content">
                 <div>


### PR DESCRIPTION
## Summary
- add the shared `a11y-dashboard` class to the search dashboard container so it inherits the global accessibility layout styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8c98e2b748331aa1dd7156f5019c7