### PR TITLE
Add styled modal for renaming media folders

### DIFF
--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -158,6 +158,24 @@
                             </div>
                         </div>
                     </div>
+                    <div class="modal" id="renameFolderModal">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h2>Rename Folder</h2>
+                            </div>
+                            <div class="modal-body">
+                                <div class="form-group">
+                                    <label class="form-label" for="renameFolderName">New folder name</label>
+                                    <input type="text" id="renameFolderName" class="form-input" autocomplete="off">
+                                    <p class="form-help" id="renameFolderMessage" style="display:none;"></p>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button class="btn btn-secondary" id="cancelRenameFolderBtn">Cancel</button>
+                                <button class="btn btn-primary" id="confirmRenameFolderBtn">Rename</button>
+                            </div>
+                        </div>
+                    </div>
                     <div class="modal" id="imageInfoModal">
                         <div class="modal-content">
                             <div class="modal-header">


### PR DESCRIPTION
## Summary
- add a dedicated rename-folder modal to the media library view
- refactor the folder renaming logic to use the in-app modal with validation and shared reserved name checks

## Testing
- php -S 0.0.0.0:8000

------
https://chatgpt.com/codex/tasks/task_e_68d8cc89676c8331a3c55ab6878aef15