### PR TITLE
Add operational dashboard links for search, sitemap, and import/export

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -189,6 +189,42 @@ $(function(){
     $('#sidebar').removeClass('mobile-open');
     $(this).removeClass('active');
   });
+
+  var moduleTitles = {
+    search: 'Manage search index',
+    sitemap: 'Review sitemap',
+    import_export: 'Import & Export'
+  };
+
+  $(document).on('sparkcms:navigate', function(event, data){
+    if(!data || typeof data.section !== 'string'){ return; }
+    var section = data.section.trim();
+    if(section === ''){ return; }
+
+    var $targetNav = $(".nav-item[data-section='" + section + "']");
+    if($targetNav.length){
+      $targetNav.trigger('click');
+      return;
+    }
+
+    if(typeof loadModule !== 'function'){ return; }
+
+    $(".nav-item").removeClass("active");
+
+    var title = moduleTitles[section];
+    if(!title){
+      title = section.replace(/_/g, ' ');
+      title = title.replace(/\b\w/g, function(char){ return char.toUpperCase(); });
+    }
+    $('#pageTitle').text(title);
+
+    loadModule(section);
+
+    if(window.innerWidth <= 1024){
+      $('#sidebar').removeClass('mobile-open');
+      $('#sidebarOverlay').removeClass('active');
+    }
+  });
   loadModule("dashboard");
 });
     </script>

--- a/CMS/modules/sitemap/generate.php
+++ b/CMS/modules/sitemap/generate.php
@@ -1,35 +1,83 @@
 <?php
 // File: generate.php
 // Generate sitemap.xml listing all published pages
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
 
-$pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = read_json_file($pagesFile);
+header('Content-Type: application/json');
 
-$scheme = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
-$host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-$scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
-if (substr($scriptBase, -4) === '/CMS') {
-    $scriptBase = substr($scriptBase, 0, -4);
-}
-$scriptBase = rtrim($scriptBase, '/');
-$baseUrl = $scheme . '://' . $host . $scriptBase;
+try {
+    $pagesFile = __DIR__ . '/../../data/pages.json';
+    $pages = read_json_file($pagesFile);
+    if (!is_array($pages)) {
+        $pages = [];
+    }
 
-$dom = new DOMDocument('1.0', 'UTF-8');
-$urlset = $dom->createElement('urlset');
-$urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-foreach ($pages as $p) {
-    if (!empty($p['published'])) {
+    $published = array_values(array_filter($pages, function ($page) {
+        return !empty($page['published']);
+    }));
+
+    $scheme = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
+    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+    $scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+    if (substr($scriptBase, -4) === '/CMS') {
+        $scriptBase = substr($scriptBase, 0, -4);
+    }
+    $scriptBase = rtrim($scriptBase, '/');
+    $baseUrl = $scheme . '://' . $host . $scriptBase;
+
+    $dom = new DOMDocument('1.0', 'UTF-8');
+    $urlset = $dom->createElement('urlset');
+    $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+    $entries = [];
+    foreach ($published as $page) {
+        $slug = ltrim((string)($page['slug'] ?? ''), '/');
+        $lastModified = isset($page['last_modified']) ? (int)$page['last_modified'] : time();
+
         $url = $dom->createElement('url');
-        $loc = $dom->createElement('loc', $baseUrl . '/' . $p['slug']);
-        $lastmodDate = isset($p['last_modified']) ? date('Y-m-d', $p['last_modified']) : date('Y-m-d');
+        $loc = $dom->createElement('loc', $baseUrl . '/' . $slug);
+        $lastmodDate = date('Y-m-d', $lastModified);
         $lastmod = $dom->createElement('lastmod', $lastmodDate);
+
         $url->appendChild($loc);
         $url->appendChild($lastmod);
         $urlset->appendChild($url);
+
+        $entries[] = [
+            'title' => (string)($page['title'] ?? ''),
+            'slug' => $slug,
+            'url' => $baseUrl . '/' . $slug,
+            'lastmodHuman' => date('F j, Y', $lastModified),
+            'lastmod' => $lastmodDate,
+        ];
     }
+
+    $dom->appendChild($urlset);
+    $dom->formatOutput = true;
+    $sitemapPath = __DIR__ . '/../../../sitemap.xml';
+    if ($dom->save($sitemapPath) === false) {
+        throw new RuntimeException('Unable to write sitemap file.');
+    }
+
+    $generatedAt = filemtime($sitemapPath) ?: time();
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Sitemap regenerated successfully.',
+        'entryCount' => count($entries),
+        'generatedAt' => $generatedAt,
+        'generatedAtFormatted' => date('F j, Y g:i a', $generatedAt),
+        'entries' => $entries,
+        'sitemapUrl' => $baseUrl . '/sitemap.xml',
+    ]);
+} catch (Throwable $exception) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Failed to regenerate sitemap.',
+        'error' => $exception->getMessage(),
+    ]);
 }
-$dom->appendChild($urlset);
-$dom->formatOutput = true;
-$sitemapPath = __DIR__ . '/../../../sitemap.xml';
-$dom->save($sitemapPath);
 ?>

--- a/CMS/modules/sitemap/sitemap.js
+++ b/CMS/modules/sitemap/sitemap.js
@@ -1,0 +1,113 @@
+// File: modules/sitemap/sitemap.js
+$(function(){
+    const $section = $('#sitemap');
+    if(!$section.length){
+        return;
+    }
+
+    const endpoint = $section.data('endpoint');
+    const $regenerateButton = $('#sitemapRegenerate');
+    const $statusMessage = $('#sitemapStatusMessage');
+    const $entryCount = $('#sitemapEntryCount');
+    const $lastGenerated = $('#sitemapLastGenerated');
+    const $tableWrapper = $('.sitemap-table');
+    const $tableBody = $('#sitemapTableBody');
+    const $emptyMessage = $('#sitemapEmptyMessage');
+
+    $('#pageTitle').text('Review sitemap');
+
+    function setLoading(state){
+        if(!$regenerateButton.length){
+            return;
+        }
+        if(state){
+            $regenerateButton.prop('disabled', true).attr('aria-disabled', 'true').addClass('is-loading');
+            $statusMessage.text('Regenerating sitemap…');
+        } else {
+            $regenerateButton.prop('disabled', false).removeAttr('aria-disabled').removeClass('is-loading');
+        }
+    }
+
+    function renderEntries(entries){
+        if(!$tableBody.length){
+            return;
+        }
+
+        if(!Array.isArray(entries) || entries.length === 0){
+            if($tableBody.length){
+                $tableBody.empty();
+            }
+            if($tableWrapper.length){
+                $tableWrapper.hide();
+            }
+            if($emptyMessage.length){
+                $emptyMessage.text('No published pages are currently included in the sitemap.').show();
+            }
+            return;
+        }
+
+        if($emptyMessage.length){
+            $emptyMessage.hide();
+        }
+
+        if($tableWrapper.length){
+            $tableWrapper.show();
+        }
+
+        $tableBody.empty();
+        entries.forEach(function(entry){
+            const url = entry.url || '';
+            const title = entry.title || '';
+            const lastmod = entry.lastmodHuman || entry.lastmod || '';
+            const $row = $('<tr>');
+            $row.append($('<td>').text(title));
+            $row.append($('<td>').append(
+                $('<a>', {
+                    href: url,
+                    text: url,
+                    target: '_blank',
+                    rel: 'noopener'
+                })
+            ));
+            $row.append($('<td>').text(lastmod));
+            $tableBody.append($row);
+        });
+    }
+
+    if($regenerateButton.length && endpoint){
+        $regenerateButton.on('click', function(){
+            setLoading(true);
+            $.ajax({
+                url: endpoint,
+                method: 'POST',
+                dataType: 'json'
+            })
+                .done(function(response){
+                    if(!response){
+                        throw new Error('Empty response');
+                    }
+                    if(response.success){
+                        $statusMessage.text(response.message || 'Sitemap regenerated successfully.');
+                        if(response.entryCount !== undefined){
+                            $entryCount.text(response.entryCount.toLocaleString());
+                        }
+                        if(response.generatedAtFormatted){
+                            $lastGenerated.text(response.generatedAtFormatted);
+                        }
+                        if(Array.isArray(response.entries)){
+                            renderEntries(response.entries);
+                        }
+                    } else {
+                        const errorMessage = response.message || 'Unable to regenerate sitemap.';
+                        $statusMessage.text(errorMessage);
+                    }
+                })
+                .fail(function(){
+                    $statusMessage.text('Unable to regenerate sitemap.');
+                })
+                .always(function(){
+                    setLoading(false);
+                });
+        });
+    }
+});

--- a/CMS/modules/sitemap/view.php
+++ b/CMS/modules/sitemap/view.php
@@ -1,0 +1,116 @@
+<?php
+// File: modules/sitemap/view.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
+
+$pagesFile = __DIR__ . '/../../data/pages.json';
+$pages = read_json_file($pagesFile);
+if (!is_array($pages)) {
+    $pages = [];
+}
+
+$publishedPages = array_values(array_filter($pages, function ($page) {
+    return !empty($page['published']);
+}));
+
+$scheme = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
+$host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+$scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
+if (substr($scriptBase, -4) === '/CMS') {
+    $scriptBase = substr($scriptBase, 0, -4);
+}
+$scriptBase = rtrim($scriptBase, '/');
+$baseUrl = $scheme . '://' . $host . $scriptBase;
+
+$sitemapPath = __DIR__ . '/../../../sitemap.xml';
+$lastGenerated = is_file($sitemapPath) ? filemtime($sitemapPath) : null;
+$lastGeneratedLabel = $lastGenerated ? date('F j, Y g:i a', $lastGenerated) : 'Not generated yet';
+
+$entries = array_map(function ($page) use ($baseUrl) {
+    $slug = ltrim((string)($page['slug'] ?? ''), '/');
+    $lastModified = isset($page['last_modified']) ? (int)$page['last_modified'] : time();
+    return [
+        'title' => (string)($page['title'] ?? ''),
+        'slug' => $slug,
+        'url' => $baseUrl . '/' . $slug,
+        'lastmod' => date('F j, Y', $lastModified),
+    ];
+}, $publishedPages);
+
+$entryCount = count($entries);
+$statusMessage = $entryCount > 0
+    ? 'Sitemap currently lists ' . number_format($entryCount) . ' published page' . ($entryCount === 1 ? '' : 's') . '.'
+    : 'Publish pages to populate the sitemap.';
+?>
+<div class="content-section" id="sitemap" data-endpoint="modules/sitemap/generate.php">
+    <div class="sitemap-dashboard a11y-dashboard">
+        <header class="a11y-hero sitemap-hero">
+            <div class="a11y-hero-content sitemap-hero-content">
+                <div>
+                    <h2 class="a11y-hero-title sitemap-hero-title">Sitemap overview</h2>
+                    <p class="a11y-hero-subtitle sitemap-hero-subtitle">
+                        Review the URLs included in your sitemap and regenerate it after publishing new content.
+                    </p>
+                </div>
+                <div class="a11y-hero-actions sitemap-hero-actions">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="sitemapRegenerate">
+                        <i class="fas fa-rotate" aria-hidden="true"></i>
+                        <span>Regenerate sitemap</span>
+                    </button>
+                    <?php if ($entryCount > 0 && is_file($sitemapPath)): ?>
+                        <a class="a11y-btn a11y-btn--ghost" href="../sitemap.xml" target="_blank" rel="noopener">
+                            <i class="fas fa-up-right-from-square" aria-hidden="true"></i>
+                            <span>View sitemap.xml</span>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            </div>
+            <div class="a11y-overview-grid sitemap-overview-grid">
+                <div class="a11y-overview-card sitemap-overview-card">
+                    <div class="a11y-overview-label">Published URLs</div>
+                    <div class="a11y-overview-value" id="sitemapEntryCount"><?php echo number_format($entryCount); ?></div>
+                </div>
+                <div class="a11y-overview-card sitemap-overview-card">
+                    <div class="a11y-overview-label">Last generated</div>
+                    <div class="a11y-overview-value" id="sitemapLastGenerated"><?php echo htmlspecialchars($lastGeneratedLabel); ?></div>
+                </div>
+                <div class="a11y-overview-card sitemap-overview-card">
+                    <div class="a11y-overview-label">Sitemap URL</div>
+                    <div class="a11y-overview-value sitemap-overview-url" id="sitemapBaseUrl"><?php echo htmlspecialchars($baseUrl . '/sitemap.xml'); ?></div>
+                </div>
+            </div>
+        </header>
+
+        <section class="a11y-detail-card sitemap-status-card">
+            <header class="sitemap-status-card__header">
+                <div class="sitemap-status-card__intro">
+                    <h3 class="sitemap-status-card__title">Sitemap status</h3>
+                    <p class="sitemap-status-card__description">Keep search engines informed of your published content.</p>
+                </div>
+                <span class="sitemap-status-card__meta" id="sitemapStatusMessage"><?php echo htmlspecialchars($statusMessage); ?></span>
+            </header>
+            <div class="sitemap-status-card__body">
+                <div class="sitemap-table"<?php echo $entries ? '' : ' style="display:none;"'; ?>>
+                    <table class="data-table">
+                        <thead>
+                            <tr><th scope="col">Title</th><th scope="col">URL</th><th scope="col">Last modified</th></tr>
+                        </thead>
+                        <tbody id="sitemapTableBody">
+                            <?php if ($entries): ?>
+                                <?php foreach ($entries as $entry): ?>
+                                    <tr>
+                                        <td><?php echo htmlspecialchars($entry['title']); ?></td>
+                                        <td><a href="<?php echo htmlspecialchars($entry['url']); ?>" target="_blank" rel="noopener"><?php echo htmlspecialchars($entry['url']); ?></a></td>
+                                        <td><?php echo htmlspecialchars($entry['lastmod']); ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        </tbody>
+                    </table>
+                </div>
+                <p id="sitemapEmptyMessage"<?php echo $entries ? ' style="display:none;"' : ''; ?>>No published pages are currently included in the sitemap.</p>
+            </div>
+        </section>
+    </div>
+</div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -516,6 +516,112 @@
             font-size: 15px;
         }
 
+        /* Sitemap module */
+        #sitemap .sitemap-dashboard {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .sitemap-hero {
+            background: linear-gradient(135deg, #1e293b, #2563eb);
+            box-shadow: 0 24px 48px rgba(37, 99, 235, 0.32);
+        }
+
+        .sitemap-hero-subtitle {
+            color: rgba(226, 232, 240, 0.92);
+        }
+
+        .sitemap-overview-grid .a11y-overview-card {
+            background: rgba(30, 41, 59, 0.3);
+            border: 1px solid rgba(148, 163, 184, 0.25);
+        }
+
+        .sitemap-overview-grid .a11y-overview-value {
+            font-size: 22px;
+            font-weight: 600;
+        }
+
+        .sitemap-overview-url {
+            font-size: 16px;
+            word-break: break-all;
+        }
+
+        .sitemap-status-card {
+            padding: 24px;
+            gap: 24px;
+        }
+
+        .sitemap-status-card__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+
+        .sitemap-status-card__title {
+            margin: 0;
+            font-size: 20px;
+            font-weight: 700;
+            color: #1f2937;
+        }
+
+        .sitemap-status-card__description {
+            margin: 0;
+            color: #475569;
+            font-size: 14px;
+        }
+
+        .sitemap-status-card__meta {
+            display: inline-flex;
+            align-items: center;
+            font-size: 14px;
+            color: #1d4ed8;
+            background: rgba(37, 99, 235, 0.12);
+            padding: 8px 16px;
+            border-radius: 999px;
+            font-weight: 600;
+        }
+
+        .sitemap-status-card__body {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .sitemap-table {
+            background: #ffffff;
+            border-radius: 16px;
+            box-shadow: inset 0 0 0 1px #e2e8f0;
+            overflow: hidden;
+        }
+
+        .sitemap-table .data-table {
+            margin: 0;
+        }
+
+        .sitemap-table .data-table th,
+        .sitemap-table .data-table td {
+            padding: 14px 20px;
+        }
+
+        .sitemap-empty-message,
+        #sitemapEmptyMessage {
+            margin: 0;
+            color: #475569;
+            font-size: 15px;
+        }
+
+        .sitemap-hero-actions .a11y-btn.is-loading {
+            opacity: 0.7;
+            cursor: progress;
+        }
+
+        .sitemap-hero-actions .a11y-btn.is-loading i {
+            animation: logs-spin 0.9s linear infinite;
+        }
+
         @keyframes logs-spin {
             from { transform: rotate(0deg); }
             to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary
- wire dashboard CTA navigation through a new sparkcms:navigate handler so modules without sidebar entries (search, sitemap, import/export) open correctly
- add a sitemap management view and client-side controls for regenerating sitemap.xml directly from the dashboard
- update sitemap generation endpoint and styles to support the new management interface

## Testing
- php -l CMS/modules/sitemap/view.php
- php -l CMS/modules/sitemap/generate.php

------
https://chatgpt.com/codex/tasks/task_e_68d8ccc50728833182c61424ee5ed57d