### PR TITLE
Restyle SEO detail view

### DIFF
--- a/CMS/modules/seo/seo.js
+++ b/CMS/modules/seo/seo.js
@@ -222,8 +222,8 @@
     }
 
     function initDetail($root) {
-        var $issueCards = $root.find('.seo-issue-card');
-        var $buttons = $root.find('.seo-severity-btn');
+        var $issueCards = $root.find('[data-impact]');
+        var $buttons = $root.find('[data-seo-severity]');
         var $status = $('#seoIssueFilterStatus');
 
         function updateIssueVisibility(filter) {

--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -490,7 +490,13 @@ foreach ($pageEntries as $page) {
     }
 }
 
-$moduleUrl = $_SERVER['PHP_SELF'] . '?module=seo';
+$scriptPath = isset($_SERVER['PHP_SELF']) ? $_SERVER['PHP_SELF'] : '';
+$queryParams = is_array($_GET) ? $_GET : [];
+unset($queryParams['page']);
+$queryParams = array_merge(['module' => 'seo'], $queryParams);
+$moduleQuery = http_build_query($queryParams);
+$moduleUrl = $scriptPath . ($moduleQuery !== '' ? '?' . $moduleQuery : '');
+$moduleAnchorUrl = $moduleUrl . '#seo';
 $detailSlug = isset($_GET['page']) ? sanitize_text($_GET['page']) : null;
 $detailSlug = $detailSlug !== null ? trim($detailSlug) : null;
 
@@ -509,13 +515,13 @@ $dashboardStats = [
     'needsWork' => $needsWork,
     'filterCounts' => $filterCounts,
     'moduleUrl' => $moduleUrl,
-    'detailBaseUrl' => $moduleUrl . '&page=',
+    'detailBaseUrl' => $moduleUrl . (strpos($moduleUrl, '?') === false ? '?' : '&') . 'page=',
     'lastScan' => $lastScan,
 ];
 ?>
 <div class="content-section" id="seo">
 <?php if ($selectedPage): ?>
-    <div class="seo-detail-page" id="seoDetailPage" data-page-slug="<?php echo htmlspecialchars($selectedPage['slug'], ENT_QUOTES); ?>">
+    <div class="a11y-detail-page seo-detail-page" id="seoDetailPage" data-page-slug="<?php echo htmlspecialchars($selectedPage['slug'], ENT_QUOTES); ?>">
         <?php
             $currentScore = (int)($selectedPage['seoScore'] ?? 0);
             $previousScore = (int)($selectedPage['previousScore'] ?? $currentScore);
@@ -538,12 +544,12 @@ $dashboardStats = [
             }
             $issueDetailCount = array_sum($impactCounts);
         ?>
-        <header class="seo-detail-header">
-            <a href="<?php echo htmlspecialchars($moduleUrl, ENT_QUOTES); ?>" class="seo-back-link" id="seoBackToDashboard">
+        <header class="a11y-detail-header">
+            <a href="<?php echo htmlspecialchars($moduleAnchorUrl, ENT_QUOTES); ?>" class="a11y-back-link" id="seoBackToDashboard">
                 <i class="fas fa-arrow-left" aria-hidden="true"></i>
                 <span>Back to SEO Dashboard</span>
             </a>
-            <div class="seo-detail-actions">
+            <div class="a11y-detail-actions">
                 <button type="button" class="a11y-btn a11y-btn--ghost" data-seo-action="rescan-page">
                     <i class="fas fa-rotate" aria-hidden="true"></i>
                     <span>Rescan Page</span>
@@ -551,10 +557,10 @@ $dashboardStats = [
             </div>
         </header>
 
-        <section class="seo-health-card">
-            <div class="seo-health-score">
+        <section class="a11y-health-card">
+            <div class="a11y-health-score">
                 <div class="score-indicator score-indicator--hero">
-                    <div class="seo-health-score__value">
+                    <div class="a11y-health-score__value">
                         <span class="score-indicator__number"><?php echo $currentScore; ?></span><span>%</span>
                     </div>
                     <span class="score-delta <?php echo htmlspecialchars($deltaMeta['class'], ENT_QUOTES); ?>">
@@ -562,117 +568,122 @@ $dashboardStats = [
                         <span class="sr-only"><?php echo htmlspecialchars($deltaMeta['srText'], ENT_QUOTES); ?></span>
                     </span>
                 </div>
-                <div class="seo-health-score__label">SEO Score</div>
-                <span class="seo-health-score__badge level-<?php echo strtolower(str_replace(' ', '-', $selectedPage['optimizationLevel'])); ?>"><?php echo htmlspecialchars($selectedPage['optimizationLevel']); ?></span>
+                <div class="a11y-health-score__label">SEO Score</div>
+                <span class="a11y-health-score__badge level-<?php echo strtolower(str_replace(' ', '-', $selectedPage['optimizationLevel'])); ?>"><?php echo htmlspecialchars($selectedPage['optimizationLevel']); ?></span>
             </div>
-            <div class="seo-health-summary">
+            <div class="a11y-health-summary">
                 <h1><?php echo htmlspecialchars($selectedPage['title']); ?></h1>
-                <p class="seo-health-url"><?php echo htmlspecialchars($selectedPage['url']); ?></p>
+                <p class="a11y-health-url"><?php echo htmlspecialchars($selectedPage['url']); ?></p>
                 <p><?php echo htmlspecialchars($selectedPage['statusMessage']); ?></p>
-                <p class="seo-health-overview"><?php echo htmlspecialchars($selectedPage['summaryLine']); ?></p>
-                <div class="seo-quick-stats">
-                    <div class="seo-quick-stat">
-                        <div class="seo-quick-stat__value"><?php echo $selectedPage['metrics']['wordCount']; ?></div>
-                        <div class="seo-quick-stat__label">Words</div>
+                <p class="a11y-health-overview"><?php echo htmlspecialchars($selectedPage['summaryLine']); ?></p>
+                <div class="a11y-quick-stats">
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['wordCount']; ?></div>
+                        <div class="a11y-quick-stat__label">Words</div>
                     </div>
-                    <div class="seo-quick-stat">
-                        <div class="seo-quick-stat__value"><?php echo $selectedPage['metrics']['links']['internal']; ?></div>
-                        <div class="seo-quick-stat__label">Internal Links</div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['links']['internal']; ?></div>
+                        <div class="a11y-quick-stat__label">Internal Links</div>
                     </div>
-                    <div class="seo-quick-stat">
-                        <div class="seo-quick-stat__value">H1: <?php echo $selectedPage['metrics']['h1Count']; ?></div>
-                        <div class="seo-quick-stat__label">Heading Structure</div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value">H1: <?php echo $selectedPage['metrics']['h1Count']; ?></div>
+                        <div class="a11y-quick-stat__label">Heading Structure</div>
                     </div>
-                    <div class="seo-quick-stat">
-                        <div class="seo-quick-stat__value"><?php echo $selectedPage['metrics']['missingAlt']; ?></div>
-                        <div class="seo-quick-stat__label">Missing Alt</div>
+                    <div class="a11y-quick-stat">
+                        <div class="a11y-quick-stat__value"><?php echo $selectedPage['metrics']['missingAlt']; ?></div>
+                        <div class="a11y-quick-stat__label">Missing Alt</div>
                     </div>
                 </div>
             </div>
         </section>
 
-        <section class="seo-metric-grid" aria-labelledby="seoMetricsHeading">
-            <header class="seo-metric-grid__header">
-                <h2 id="seoMetricsHeading">Key SEO signals</h2>
-                <p>Focus on the fundamentals that influence crawlability, relevance, and click-through rate.</p>
-            </header>
-            <div class="seo-metric-grid__body">
-                <article class="seo-metric-card">
-                    <header><h3>Metadata</h3></header>
-                    <ul>
-                        <li><span>Title length</span><span><?php echo $selectedPage['metrics']['titleLength']; ?> characters</span></li>
-                        <li><span>Meta description</span><span><?php echo $selectedPage['metrics']['metaDescriptionLength']; ?> characters</span></li>
-                        <li><span>Canonical URL</span><span><?php echo $selectedPage['metrics']['hasCanonical'] ? 'Present' : 'Missing'; ?></span></li>
-                    </ul>
-                </article>
-                <article class="seo-metric-card">
-                    <header><h3>Content depth</h3></header>
-                    <ul>
-                        <li><span>Word count</span><span><?php echo $selectedPage['metrics']['wordCount']; ?></span></li>
-                        <li><span>H1 headings</span><span><?php echo $selectedPage['metrics']['h1Count']; ?></span></li>
-                        <li><span>Structured data</span><span><?php echo $selectedPage['metrics']['hasStructuredData'] ? 'Detected' : 'Not detected'; ?></span></li>
-                    </ul>
-                </article>
-                <article class="seo-metric-card">
-                    <header><h3>Media & sharing</h3></header>
-                    <ul>
-                        <li><span>Images</span><span><?php echo $selectedPage['metrics']['images']; ?></span></li>
-                        <li><span>Missing alt text</span><span><?php echo $selectedPage['metrics']['missingAlt']; ?></span></li>
-                        <li><span>Open Graph</span><span><?php echo $selectedPage['metrics']['hasOpenGraph'] ? 'Configured' : 'Missing'; ?></span></li>
-                    </ul>
-                </article>
-                <article class="seo-metric-card">
-                    <header><h3>Linking</h3></header>
-                    <ul>
-                        <li><span>Internal links</span><span><?php echo $selectedPage['metrics']['links']['internal']; ?></span></li>
-                        <li><span>External links</span><span><?php echo $selectedPage['metrics']['links']['external']; ?></span></li>
-                        <li><span>Robots directives</span><span><?php echo $selectedPage['metrics']['isNoindex'] ? 'Noindex' : 'Indexable'; ?></span></li>
-                    </ul>
-                </article>
-            </div>
+        <section class="a11y-detail-grid" aria-labelledby="seoMetricsHeading">
+            <article class="a11y-detail-card seo-detail-card">
+                <div class="seo-detail-card__header">
+                    <h2 id="seoMetricsHeading">Key SEO signals</h2>
+                    <p class="seo-detail-card__hint">Focus on the fundamentals that influence crawlability, relevance, and click-through rate.</p>
+                </div>
+                <div class="seo-detail-card__metrics">
+                    <div class="seo-metric-group">
+                        <h3>Metadata</h3>
+                        <ul class="seo-metric-list">
+                            <li><span>Title length</span><span><?php echo $selectedPage['metrics']['titleLength']; ?> characters</span></li>
+                            <li><span>Meta description</span><span><?php echo $selectedPage['metrics']['metaDescriptionLength']; ?> characters</span></li>
+                            <li><span>Canonical URL</span><span><?php echo $selectedPage['metrics']['hasCanonical'] ? 'Present' : 'Missing'; ?></span></li>
+                        </ul>
+                    </div>
+                    <div class="seo-metric-group">
+                        <h3>Content depth</h3>
+                        <ul class="seo-metric-list">
+                            <li><span>Word count</span><span><?php echo $selectedPage['metrics']['wordCount']; ?></span></li>
+                            <li><span>H1 headings</span><span><?php echo $selectedPage['metrics']['h1Count']; ?></span></li>
+                            <li><span>Structured data</span><span><?php echo $selectedPage['metrics']['hasStructuredData'] ? 'Detected' : 'Not detected'; ?></span></li>
+                        </ul>
+                    </div>
+                    <div class="seo-metric-group">
+                        <h3>Media &amp; sharing</h3>
+                        <ul class="seo-metric-list">
+                            <li><span>Images</span><span><?php echo $selectedPage['metrics']['images']; ?></span></li>
+                            <li><span>Missing alt text</span><span><?php echo $selectedPage['metrics']['missingAlt']; ?></span></li>
+                            <li><span>Open Graph</span><span><?php echo $selectedPage['metrics']['hasOpenGraph'] ? 'Configured' : 'Missing'; ?></span></li>
+                        </ul>
+                    </div>
+                    <div class="seo-metric-group">
+                        <h3>Linking</h3>
+                        <ul class="seo-metric-list">
+                            <li><span>Internal links</span><span><?php echo $selectedPage['metrics']['links']['internal']; ?></span></li>
+                            <li><span>External links</span><span><?php echo $selectedPage['metrics']['links']['external']; ?></span></li>
+                            <li><span>Robots directives</span><span><?php echo $selectedPage['metrics']['isNoindex'] ? 'Noindex' : 'Indexable'; ?></span></li>
+                        </ul>
+                    </div>
+                </div>
+            </article>
         </section>
 
-        <section class="seo-issues" aria-labelledby="seoIssuesHeading">
-            <header>
-                <h2 id="seoIssuesHeading">Actionable SEO fixes</h2>
-                <p>Address these issues to strengthen relevance signals and organic performance.</p>
+        <section class="a11y-detail-issues seo-detail-issues" aria-labelledby="seoIssuesHeading">
+            <header class="seo-detail-issues__header">
+                <div>
+                    <h2 id="seoIssuesHeading">Actionable SEO fixes</h2>
+                    <p>Address these issues to strengthen relevance signals and organic performance.</p>
+                </div>
+                <span class="seo-detail-issues__count"><?php echo $issueDetailCount; ?> <?php echo $issueDetailCount === 1 ? 'issue' : 'issues'; ?></span>
             </header>
             <?php if ($issueDetailCount > 0): ?>
-                <div class="seo-severity-filters" role="group" aria-label="Filter issues by severity">
-                    <button type="button" class="seo-severity-btn active" data-seo-severity="all" aria-pressed="true" aria-label="Show all issues (<?php echo $issueDetailCount; ?>)">
+                <div class="a11y-severity-filters" role="group" aria-label="Filter issues by severity">
+                    <button type="button" class="a11y-severity-btn active" data-seo-severity="all" aria-pressed="true" aria-label="Show all issues (<?php echo $issueDetailCount; ?>)">
                         All <span aria-hidden="true">(<?php echo $issueDetailCount; ?>)</span>
                     </button>
-                    <button type="button" class="seo-severity-btn" data-seo-severity="critical" aria-pressed="false" aria-label="Show critical issues (<?php echo $impactCounts['critical']; ?>)">
+                    <button type="button" class="a11y-severity-btn" data-seo-severity="critical" aria-pressed="false" aria-label="Show critical issues (<?php echo $impactCounts['critical']; ?>)">
                         Critical <span aria-hidden="true">(<?php echo $impactCounts['critical']; ?>)</span>
                     </button>
-                    <button type="button" class="seo-severity-btn" data-seo-severity="serious" aria-pressed="false" aria-label="Show serious issues (<?php echo $impactCounts['serious']; ?>)">
+                    <button type="button" class="a11y-severity-btn" data-seo-severity="serious" aria-pressed="false" aria-label="Show serious issues (<?php echo $impactCounts['serious']; ?>)">
                         Serious <span aria-hidden="true">(<?php echo $impactCounts['serious']; ?>)</span>
                     </button>
-                    <button type="button" class="seo-severity-btn" data-seo-severity="moderate" aria-pressed="false" aria-label="Show moderate issues (<?php echo $impactCounts['moderate']; ?>)">
+                    <button type="button" class="a11y-severity-btn" data-seo-severity="moderate" aria-pressed="false" aria-label="Show moderate issues (<?php echo $impactCounts['moderate']; ?>)">
                         Moderate <span aria-hidden="true">(<?php echo $impactCounts['moderate']; ?>)</span>
                     </button>
-                    <button type="button" class="seo-severity-btn" data-seo-severity="minor" aria-pressed="false" aria-label="Show minor issues (<?php echo $impactCounts['minor']; ?>)">
+                    <button type="button" class="a11y-severity-btn" data-seo-severity="minor" aria-pressed="false" aria-label="Show minor issues (<?php echo $impactCounts['minor']; ?>)">
                         Minor <span aria-hidden="true">(<?php echo $impactCounts['minor']; ?>)</span>
                     </button>
-                    <button type="button" class="seo-severity-btn" data-seo-severity="review" aria-pressed="false" aria-label="Show review issues (<?php echo $impactCounts['review']; ?>)">
+                    <button type="button" class="a11y-severity-btn" data-seo-severity="review" aria-pressed="false" aria-label="Show review issues (<?php echo $impactCounts['review']; ?>)">
                         Review <span aria-hidden="true">(<?php echo $impactCounts['review']; ?>)</span>
                     </button>
                 </div>
                 <div class="sr-only" id="seoIssueFilterStatus" role="status" aria-live="polite"></div>
-                <div class="seo-issue-list">
+                <div class="a11y-issue-list">
                     <?php foreach ($selectedPage['issues']['details'] as $issue): ?>
-                        <article class="seo-issue-card impact-<?php echo htmlspecialchars($issue['impact']); ?>" data-impact="<?php echo htmlspecialchars(strtolower($issue['impact'])); ?>">
+                        <article class="a11y-issue-card impact-<?php echo htmlspecialchars($issue['impact']); ?>" data-impact="<?php echo htmlspecialchars(strtolower($issue['impact'])); ?>">
                             <header>
                                 <h3><?php echo htmlspecialchars($issue['description']); ?></h3>
-                                <span class="seo-impact-badge impact-<?php echo htmlspecialchars($issue['impact']); ?>"><?php echo ucfirst($issue['impact']); ?></span>
+                                <span class="a11y-impact-badge impact-<?php echo htmlspecialchars($issue['impact']); ?>"><?php echo ucfirst($issue['impact']); ?></span>
                             </header>
                             <p><?php echo htmlspecialchars($issue['recommendation']); ?></p>
                         </article>
                     <?php endforeach; ?>
                 </div>
-                <p class="seo-detail-empty" id="seoNoIssuesMessage" hidden>No issues match this severity filter.</p>
+                <p class="a11y-detail-empty" id="seoNoIssuesMessage" hidden>No issues match this severity filter.</p>
             <?php else: ?>
-                <p class="seo-detail-success">This page passes the automated SEO checks with no outstanding issues.</p>
+                <p class="a11y-detail-success">This page passes the automated SEO checks with no outstanding issues.</p>
             <?php endif; ?>
         </section>
     </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -3353,6 +3353,9 @@
         .level-aa { background: #dbeafe; color: #1d4ed8; }
         .level-partial { background: #fef3c7; color: #92400e; }
         .level-failing { background: #fee2e2; color: #b91c1c; }
+        .level-optimised { background: #dcfce7; color: #047857; }
+        .level-needs-improvement { background: #fef3c7; color: #92400e; }
+        .level-critical { background: #fee2e2; color: #b91c1c; }
         .grade-a { background: #dcfce7; color: #047857; }
         .grade-b { background: #dbeafe; color: #1d4ed8; }
         .grade-c { background: #fef3c7; color: #92400e; }
@@ -8364,201 +8367,118 @@
     text-align: center;
 }
 
-.seo-detail-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-}
-
-.seo-back-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    text-decoration: none;
-    font-weight: 600;
-    color: #1e3a8a;
-}
-
-.seo-health-card {
+.seo-detail-card {
+    display: grid;
+    gap: 1.75rem;
     background: #fff;
     border-radius: 20px;
     border: 1px solid #e5e7eb;
-    padding: 2rem;
+    padding: 2.25rem;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+}
+
+.seo-detail-card__header {
     display: grid;
-    gap: 1.5rem;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    box-shadow: 0 25px 50px rgba(15, 23, 42, 0.08);
+    gap: 0.65rem;
 }
 
-.seo-health-score {
-    display: grid;
-    gap: 1rem;
-}
-
-.seo-health-score__value {
-    display: flex;
-    align-items: baseline;
-    gap: 0.3rem;
-    font-size: 2.5rem;
-    font-weight: 700;
-}
-
-.seo-health-score__badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.4rem 0.75rem;
-    border-radius: 999px;
-    font-size: 0.85rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    background: rgba(37, 99, 235, 0.12);
-    color: #1e3a8a;
-}
-
-.seo-health-summary {
-    display: grid;
-    gap: 0.75rem;
-}
-
-.seo-health-url {
+.seo-detail-card__header h2 {
     margin: 0;
-    font-weight: 600;
-    color: #2563eb;
+    font-size: 1.4rem;
+    color: #0f172a;
 }
 
-.seo-health-overview {
+.seo-detail-card__hint {
     margin: 0;
     color: #4b5563;
+    font-size: 0.95rem;
     line-height: 1.6;
 }
 
-.seo-quick-stats {
+.seo-detail-card__metrics {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 1rem;
-}
-
-.seo-quick-stat {
-    background: #f8fafc;
-    border-radius: 14px;
-    padding: 1rem;
-    text-align: center;
-}
-
-.seo-quick-stat__value {
-    font-weight: 700;
-    font-size: 1.4rem;
-}
-
-.seo-quick-stat__label {
-    font-size: 0.85rem;
-    color: #6b7280;
-}
-
-.seo-metric-grid {
-    background: #fff;
-    border-radius: 20px;
-    border: 1px solid #e5e7eb;
-    padding: 2rem;
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.07);
-    display: grid;
-    gap: 2rem;
-}
-
-.seo-metric-grid__body {
-    display: grid;
-    gap: 1.5rem;
+    gap: 1.25rem;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.seo-metric-card {
+.seo-metric-group {
     background: #f9fafb;
-    border-radius: 16px;
+    border: 1px solid #e5e7eb;
+    border-radius: 18px;
     padding: 1.5rem;
     display: grid;
-    gap: 0.75rem;
+    gap: 0.85rem;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
-.seo-metric-card ul {
+.seo-metric-group h3 {
+    margin: 0;
+    font-size: 1.05rem;
+    color: #1e293b;
+}
+
+.seo-metric-list {
     list-style: none;
     margin: 0;
     padding: 0;
     display: grid;
+    gap: 0.55rem;
+    font-size: 0.95rem;
+    color: #1f2937;
+}
+
+.seo-metric-list li {
+    display: flex;
+    justify-content: space-between;
     gap: 0.5rem;
 }
 
-.seo-metric-card li {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.95rem;
+.seo-metric-list span:last-child {
+    font-weight: 600;
+    color: #1e3a8a;
 }
 
-.seo-issues {
+.seo-detail-issues {
     background: #fff;
     border-radius: 20px;
     border: 1px solid #e5e7eb;
-    padding: 2rem;
+    padding: 2.25rem;
     display: grid;
     gap: 1.5rem;
     box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
 }
 
-.seo-severity-filters {
+.seo-detail-issues__header {
     display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
     flex-wrap: wrap;
-    gap: 0.75rem;
 }
 
-.seo-severity-btn {
-    border-radius: 999px;
-    border: 1px solid #d1d5db;
-    padding: 0.45rem 1rem;
-    font-weight: 600;
-    background: #fff;
-    cursor: pointer;
+.seo-detail-issues__header h2 {
+    margin: 0 0 0.25rem;
+    font-size: 1.35rem;
+    color: #111827;
 }
 
-.seo-severity-btn.active {
-    background: #1e40af;
-    color: #fff;
-    border-color: #1e3a8a;
+.seo-detail-issues__header p {
+    margin: 0;
+    color: #4b5563;
+    font-size: 0.95rem;
+    line-height: 1.6;
 }
 
-.seo-issue-list {
-    display: grid;
-    gap: 1rem;
-}
-
-.seo-issue-card {
-    border: 1px solid #e5e7eb;
-    border-radius: 16px;
-    padding: 1.25rem;
-    background: #f9fafb;
-}
-
-.seo-impact-badge {
+.seo-detail-issues__count {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
-    padding: 0.25rem 0.75rem;
+    gap: 0.4rem;
+    background: #eef2ff;
+    color: #3730a3;
+    padding: 0.4rem 0.8rem;
     border-radius: 999px;
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    font-weight: 700;
-}
-
-.impact-critical { background: rgba(239, 68, 68, 0.15); color: #b91c1c; }
-.impact-serious { background: rgba(249, 115, 22, 0.18); color: #c2410c; }
-.impact-moderate { background: rgba(234, 179, 8, 0.18); color: #b45309; }
-.impact-minor { background: rgba(59, 130, 246, 0.18); color: #1d4ed8; }
-.impact-review { background: rgba(16, 185, 129, 0.18); color: #047857; }
-
-.seo-detail-success,
-.seo-detail-empty {
-    font-size: 0.95rem;
-    color: #374151;
+    font-weight: 600;
+    font-size: 0.9rem;
 }
 
 @media (max-width: 900px) {
@@ -8587,9 +8507,9 @@
     .seo-page-card {
         padding: 1.5rem;
     }
-    .seo-health-card,
-    .seo-metric-grid,
-    .seo-issues {
+    .a11y-health-card,
+    .seo-detail-card,
+    .seo-detail-issues {
         padding: 1.5rem;
     }
     .seo-overview-grid {


### PR DESCRIPTION
## Summary
- replace the SEO detail template with the CMS-wide accessibility detail layout so the recommendations view uses consistent components
- fix the back navigation by rebuilding the module URL without the page parameter and include an anchor to return to the dashboard section
- refresh SEO-specific styles and selectors to match the new markup while keeping issue filtering functional

## Testing
- php -l CMS/modules/seo/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d8cc67bcb48331a33ca5d12a7c75ed