### PR TITLE
Add Import & Export module to admin navigation

### DIFF
--- a/CMS/admin.php
+++ b/CMS/admin.php
@@ -86,6 +86,10 @@ $settings = get_cached_json($settingsFile);
                         <div class="nav-icon"><i class="fas fa-cog"></i></div>
                         <div class="nav-text">Settings</div>
                     </div>
+                    <div class="nav-item" data-section="import_export">
+                        <div class="nav-icon"><i class="fas fa-file-import"></i></div>
+                        <div class="nav-text">Import &amp; Export</div>
+                    </div>
                 </div>
 
                 <div class="nav-section">


### PR DESCRIPTION
## Summary
- add an Import & Export entry to the admin navigation under the Administration section so the module is directly accessible

## Testing
- php -l CMS/admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d8d616e6508331a9906f6cbbcae0bb