### PR TITLE
Align SEO grid styling with accessibility cards

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -8530,41 +8530,56 @@
 
 .seo-page-grid {
     display: grid;
-    gap: 1.5rem;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+    gap: 20px;
 }
 
 .seo-page-card {
     background: #fff;
-    border-radius: 18px;
-    padding: 1.75rem;
-    border: 1px solid #e5e7eb;
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
-    display: grid;
-    gap: 1rem;
+    border-radius: 16px;
+    padding: 22px;
+    border: 1px solid #e2e8f0;
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.08);
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.seo-page-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 25px 50px rgba(15, 23, 42, 0.12);
+.seo-page-card:hover,
+.seo-page-card:focus-visible {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 32px rgba(37, 99, 235, 0.2);
+    outline: none;
 }
 
 .seo-page-card header {
     display: flex;
-    align-items: center;
     justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.seo-page-card h3 {
+    margin: 0;
+    font-size: 18px;
+    color: #1e293b;
 }
 
 .seo-page-score {
-    width: 72px;
-    height: 72px;
-    border-radius: 18px;
-    display: grid;
-    place-items: center;
-    font-size: 1.3rem;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
     font-weight: 700;
     color: #fff;
+    font-size: 18px;
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.15);
 }
 
 .seo-score--excellent { background: linear-gradient(135deg, #22c55e, #16a34a); }
@@ -8600,14 +8615,30 @@
     padding: 0;
     margin: 0;
     display: grid;
-    gap: 0.4rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
 }
 
 .seo-page-metrics li {
     display: flex;
-    justify-content: space-between;
-    font-size: 0.9rem;
-    color: #374151;
+    flex-direction: column;
+    gap: 4px;
+    padding: 12px;
+    border-radius: 12px;
+    background: #f8fafc;
+}
+
+.seo-page-metrics li span:first-child {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    color: #94a3b8;
+}
+
+.seo-page-metrics li span:last-child {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1f2937;
 }
 
 .seo-page-issues {


### PR DESCRIPTION
## Summary
- update the SEO dashboard grid to use the same spacing and card dimensions as the accessibility grid
- restyle the SEO card score, headings, and metrics to mirror the a11y card layout
- enhance hover and focus styles to keep the cards consistent and interactive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8d79f01608331995100c075b4dbde