### PR TITLE
Add working export flow for import/export module

### DIFF
--- a/CMS/modules/import_export/export.php
+++ b/CMS/modules/import_export/export.php
@@ -1,0 +1,72 @@
+<?php
+// File: export.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/settings.php';
+require_once __DIR__ . '/helpers.php';
+
+require_login();
+
+$dataDir = import_export_get_data_dir();
+$datasetMap = import_export_get_dataset_map();
+
+$export = [
+    'meta' => [
+        'generated_at' => gmdate('c'),
+        'format_version' => 1,
+    ],
+    'data' => [],
+];
+
+$settings = get_site_settings();
+if (!empty($settings['site_name'])) {
+    $export['meta']['site_name'] = (string) $settings['site_name'];
+}
+
+foreach ($datasetMap as $key => $filename) {
+    $path = $dataDir . '/' . $filename;
+    $export['data'][$key] = read_json_file($path);
+}
+
+$draftsDir = $dataDir . '/drafts';
+if (is_dir($draftsDir)) {
+    $draftFiles = glob($draftsDir . '/*.json');
+    if ($draftFiles !== false && count($draftFiles) > 0) {
+        $drafts = [];
+        foreach ($draftFiles as $draftFile) {
+            $drafts[basename($draftFile, '.json')] = read_json_file($draftFile);
+        }
+        $export['data']['drafts'] = $drafts;
+    }
+}
+
+$export['meta']['dataset_count'] = count($export['data']);
+$export['meta']['datasets'] = array_keys($export['data']);
+
+$json = json_encode($export, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+if ($json === false) {
+    http_response_code(500);
+    header('Content-Type: application/json; charset=UTF-8');
+    echo json_encode(['error' => 'Unable to generate export.']);
+    exit;
+}
+
+$filename = 'sparkcms-export-' . date('Ymd-His') . '.json';
+
+$statsFile = import_export_get_stats_file();
+$stats = read_json_file($statsFile);
+if (!is_array($stats)) {
+    $stats = [];
+}
+$stats['last_export_at'] = gmdate('c');
+$stats['last_export_file'] = $filename;
+$stats['export_count'] = isset($stats['export_count']) ? (int) $stats['export_count'] + 1 : 1;
+write_json_file($statsFile, $stats);
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+header('Pragma: no-cache');
+header('Expires: 0');
+
+echo $json;
+exit;

--- a/CMS/modules/import_export/helpers.php
+++ b/CMS/modules/import_export/helpers.php
@@ -1,0 +1,36 @@
+<?php
+// File: helpers.php
+
+if (!function_exists('import_export_get_data_dir')) {
+    function import_export_get_data_dir(): string
+    {
+        $path = __DIR__ . '/../../data';
+        $resolved = realpath($path);
+        return $resolved !== false ? $resolved : $path;
+    }
+}
+
+if (!function_exists('import_export_get_dataset_map')) {
+    function import_export_get_dataset_map(): array
+    {
+        return [
+            'settings' => 'settings.json',
+            'pages' => 'pages.json',
+            'page_history' => 'page_history.json',
+            'menus' => 'menus.json',
+            'media' => 'media.json',
+            'blog_posts' => 'blog_posts.json',
+            'forms' => 'forms.json',
+            'form_submissions' => 'form_submissions.json',
+            'users' => 'users.json',
+            'speed_snapshot' => 'speed_snapshot.json',
+        ];
+    }
+}
+
+if (!function_exists('import_export_get_stats_file')) {
+    function import_export_get_stats_file(): string
+    {
+        return import_export_get_data_dir() . '/import_export_status.json';
+    }
+}

--- a/CMS/modules/import_export/import_export.js
+++ b/CMS/modules/import_export/import_export.js
@@ -1,0 +1,209 @@
+// File: import_export.js
+$(function(){
+    const $exportBtn = $('#startExportBtn');
+    const $importLastRun = $('#importLastRun');
+    const $exportLastRun = $('#exportLastRun');
+    const $importProfilesCount = $('#importProfilesCount');
+    const $exportGeneratedCount = $('#exportGeneratedCount');
+    const $status = $('#importExportStatus');
+    const $datasetSection = $('#importDatasetSection');
+    const $datasetSummary = $('#importDatasetSummary');
+    const $datasetList = $('#importDatasetList');
+
+    function formatTimestamp(value){
+        if (!value) {
+            return '—';
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '—';
+        }
+        return date.toLocaleString(undefined, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        });
+    }
+
+    function formatDatasetLabel(key){
+        if (!key) {
+            return '';
+        }
+        return key
+            .split('_')
+            .map(function(part){
+                return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+            })
+            .join(' ');
+    }
+
+    function clearStatus(){
+        if (!$status.length) {
+            return;
+        }
+        $status.removeClass('import-status--success import-status--error import-status--info is-visible')
+            .attr('aria-hidden', 'true')
+            .empty();
+    }
+
+    function setStatus(message, type){
+        if (!$status.length) {
+            return;
+        }
+        $status.removeClass('import-status--success import-status--error import-status--info is-visible');
+        if (!message) {
+            $status.attr('aria-hidden', 'true').empty();
+            return;
+        }
+
+        let className = 'import-status--info';
+        if (type === 'success') {
+            className = 'import-status--success';
+        } else if (type === 'error') {
+            className = 'import-status--error';
+        }
+
+        $status
+            .addClass(className + ' is-visible')
+            .attr('aria-hidden', 'false')
+            .text(message);
+    }
+
+    function setButtonLoading($button, loading){
+        if (!$button.length) {
+            return;
+        }
+        const $label = $button.find('span').first();
+        const defaultLabel = $button.data('defaultLabel') || $label.text();
+        if (!$button.data('defaultLabel')) {
+            $button.data('defaultLabel', defaultLabel);
+        }
+
+        if (loading) {
+            $label.text('Generating…');
+            $button.addClass('is-loading').prop('disabled', true).attr('aria-busy', 'true');
+        } else {
+            $label.text($button.data('defaultLabel'));
+            $button.removeClass('is-loading').prop('disabled', false).removeAttr('aria-busy');
+        }
+    }
+
+    function renderDatasets(datasets){
+        if (!$datasetSection.length || !$datasetList.length) {
+            return;
+        }
+
+        if (!Array.isArray(datasets) || datasets.length === 0) {
+            $datasetSection.attr('hidden', 'hidden');
+            $datasetSummary.empty();
+            $datasetList.empty();
+            return;
+        }
+
+        $datasetSection.removeAttr('hidden');
+        $datasetList.empty();
+        datasets.forEach(function(key){
+            const label = formatDatasetLabel(key);
+            const $item = $('<li>', {
+                class: 'import-datasets__item',
+                text: label || key,
+            });
+            $datasetList.append($item);
+        });
+    }
+
+    function loadStatus(){
+        const request = $.getJSON('modules/import_export/status.php');
+        request.done(function(data){
+            if ($importLastRun.length) {
+                $importLastRun.text(formatTimestamp(data.last_import_at));
+            }
+            if ($exportLastRun.length) {
+                $exportLastRun.text(formatTimestamp(data.last_export_at));
+            }
+            if ($importProfilesCount.length) {
+                const profilesValue = Number(data.available_profiles);
+                const profiles = Number.isFinite(profilesValue) ? profilesValue : 0;
+                $importProfilesCount.text(profiles);
+            }
+            if ($exportGeneratedCount.length) {
+                const exportValue = Number(data.export_count);
+                const exports = Number.isFinite(exportValue) ? exportValue : 0;
+                $exportGeneratedCount.text(exports);
+            }
+            if ($datasetSummary.length && typeof data.dataset_count === 'number') {
+                const count = data.dataset_count;
+                if (count > 0) {
+                    const label = count === 1 ? '1 data set is included in exports.' : count.toLocaleString() + ' data sets are included in exports.';
+                    $datasetSummary.text(label);
+                } else {
+                    $datasetSummary.empty();
+                }
+            }
+            renderDatasets(data.datasets);
+        });
+        return request;
+    }
+
+    function triggerExport(){
+        clearStatus();
+        setButtonLoading($exportBtn, true);
+
+        $.ajax({
+            url: 'modules/import_export/export.php',
+            method: 'GET',
+            xhrFields: {
+                responseType: 'blob',
+            },
+        }).done(function(blob, _status, xhr){
+            try {
+                const disposition = xhr.getResponseHeader('Content-Disposition') || '';
+                let filename = 'sparkcms-export.json';
+                const utfMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+                if (utfMatch && utfMatch[1]) {
+                    filename = decodeURIComponent(utfMatch[1]);
+                } else {
+                    const asciiMatch = disposition.match(/filename="?([^";]+)"?/i);
+                    if (asciiMatch && asciiMatch[1]) {
+                        filename = asciiMatch[1];
+                    }
+                }
+
+                const url = window.URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = filename;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                window.URL.revokeObjectURL(url);
+
+                setStatus('Export generated successfully. Your download should begin automatically.', 'success');
+            } catch (error) {
+                console.error('Import/export download failed', error);
+                setStatus('The export was generated but the download could not be started. Please try again.', 'error');
+            }
+
+            loadStatus().fail(function(){
+                setStatus('Export generated, but the latest status could not be loaded.', 'info');
+            });
+        }).fail(function(jqXHR){
+            let message = 'Unable to generate an export right now. Please try again later.';
+            if (jqXHR.responseJSON && jqXHR.responseJSON.error) {
+                message = jqXHR.responseJSON.error;
+            }
+            setStatus(message, 'error');
+        }).always(function(){
+            setButtonLoading($exportBtn, false);
+        });
+    }
+
+    if ($exportBtn.length) {
+        $exportBtn.on('click', function(){
+            triggerExport();
+        });
+    }
+
+    loadStatus().fail(function(){
+        setStatus('Unable to load import/export status right now. Please try again later.', 'error');
+    });
+});

--- a/CMS/modules/import_export/status.php
+++ b/CMS/modules/import_export/status.php
@@ -1,0 +1,39 @@
+<?php
+// File: status.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/helpers.php';
+
+require_login();
+
+header('Content-Type: application/json; charset=UTF-8');
+
+$statsFile = import_export_get_stats_file();
+$stats = read_json_file($statsFile);
+if (!is_array($stats)) {
+    $stats = [];
+}
+
+$datasetMap = import_export_get_dataset_map();
+$datasets = array_keys($datasetMap);
+
+$dataDir = import_export_get_data_dir();
+$draftsDir = $dataDir . '/drafts';
+if (is_dir($draftsDir)) {
+    $draftFiles = glob($draftsDir . '/*.json');
+    if ($draftFiles !== false && count($draftFiles) > 0) {
+        $datasets[] = 'drafts';
+    }
+}
+
+$response = [
+    'last_export_at' => isset($stats['last_export_at']) && $stats['last_export_at'] !== '' ? $stats['last_export_at'] : null,
+    'last_import_at' => isset($stats['last_import_at']) && $stats['last_import_at'] !== '' ? $stats['last_import_at'] : null,
+    'export_count' => isset($stats['export_count']) ? (int) $stats['export_count'] : 0,
+    'available_profiles' => isset($stats['available_profiles']) ? (int) $stats['available_profiles'] : 0,
+    'datasets' => $datasets,
+    'dataset_count' => count($datasets),
+];
+
+echo json_encode($response);
+exit;

--- a/CMS/modules/import_export/view.php
+++ b/CMS/modules/import_export/view.php
@@ -38,7 +38,13 @@
                             </div>
                         </header>
                         <div class="import-placeholder">
-                            <p>Import or export CMS data.</p>
+                            <p id="importExportIntro">Import or export CMS data.</p>
+                            <div class="import-datasets" id="importDatasetSection" hidden>
+                                <div class="import-datasets__title">Included in export:</div>
+                                <div class="import-datasets__summary" id="importDatasetSummary"></div>
+                                <ul class="import-datasets__list" id="importDatasetList" aria-live="polite"></ul>
+                            </div>
+                            <div class="import-status" id="importExportStatus" role="status" aria-live="polite" aria-hidden="true"></div>
                         </div>
                     </div>
                 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -586,6 +586,74 @@
             font-size: 15px;
         }
 
+        .import-datasets {
+            margin-top: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .import-datasets__title {
+            font-weight: 600;
+            font-size: 14px;
+            color: #0f172a;
+        }
+
+        .import-datasets__summary {
+            font-size: 13px;
+            color: #334155;
+        }
+
+        .import-datasets__list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+
+        .import-datasets__item {
+            background: rgba(15, 118, 110, 0.14);
+            color: #0f766e;
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+
+        .import-status {
+            margin-top: 20px;
+            border-radius: 12px;
+            padding: 16px 18px;
+            font-size: 14px;
+            line-height: 1.6;
+            display: none;
+        }
+
+        .import-status.is-visible {
+            display: block;
+        }
+
+        .import-status--success {
+            background: rgba(16, 185, 129, 0.14);
+            color: #065f46;
+            border: 1px solid rgba(16, 185, 129, 0.32);
+        }
+
+        .import-status--error {
+            background: rgba(248, 113, 113, 0.14);
+            color: #991b1b;
+            border: 1px solid rgba(248, 113, 113, 0.32);
+        }
+
+        .import-status--info {
+            background: rgba(59, 130, 246, 0.14);
+            color: #1e40af;
+            border: 1px solid rgba(59, 130, 246, 0.28);
+        }
+
         /* Sitemap module */
         #sitemap .sitemap-dashboard {
             display: flex;


### PR DESCRIPTION
## Summary
- add PHP helpers and endpoints to package CMS data into a downloadable JSON export and persist export stats
- introduce an import/export module script that drives the export button, updates metrics, and handles download feedback
- extend the module view styling to surface dataset badges and real-time status messages for exports

## Testing
- php -l CMS/modules/import_export/export.php
- php -l CMS/modules/import_export/status.php
- php -l CMS/modules/import_export/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68d8d7ef8f1c8331ad616eae8bd895ee