### PR TITLE
Remove icons from Media Library hero section

### DIFF
--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -9,56 +9,41 @@
                                 </div>
                                 <div class="a11y-hero-actions media-hero-actions">
                                     <button type="button" class="media-btn media-btn--ghost" id="createFolderBtn">
-                                        <i class="fa-solid fa-folder-plus" aria-hidden="true"></i>
                                         <span>New Folder</span>
                                     </button>
                                     <button type="button" class="media-btn media-btn--primary is-disabled" id="uploadBtn" disabled aria-disabled="true">
-                                        <i class="fa-solid fa-cloud-arrow-up" aria-hidden="true"></i>
                                         <span>Upload Media</span>
                                     </button>
                                 </div>
                             </div>
                             <div class="media-hero-meta">
                                 <span class="media-hero-chip">
-                                    <i class="fa-solid fa-photo-film" aria-hidden="true"></i>
                                     <span>Rich asset management with previews, cropping, and tagging tools.</span>
                                 </span>
                                 <span class="media-hero-chip" id="mediaHeroFolderChip">
-                                    <i class="fa-solid fa-folder-tree" aria-hidden="true"></i>
                                     <span id="mediaHeroFolderName">No folder selected</span>
                                 </span>
                                 <span class="media-hero-chip" id="mediaHeroFolderMeta">
-                                    <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
                                     <span id="mediaHeroFolderInfo">Select a folder to see file details</span>
                                 </span>
                                 <span class="media-hero-chip">
-                                    <i class="fa-solid fa-database" aria-hidden="true"></i>
                                     <span id="mediaStorageSummary">0 used</span>
                                 </span>
                             </div>
                             <div class="a11y-overview-grid media-overview-grid">
                                 <div class="a11y-overview-card media-overview-card">
-                                    <div class="media-overview-icon" aria-hidden="true">
-                                        <i class="fa-solid fa-folder-open"></i>
-                                    </div>
                                     <div class="media-overview-content">
                                         <div class="a11y-overview-label media-overview-label">Folders</div>
                                         <div class="a11y-overview-value media-overview-value" id="totalFolders">0</div>
                                     </div>
                                 </div>
                                 <div class="a11y-overview-card media-overview-card">
-                                    <div class="media-overview-icon" aria-hidden="true">
-                                        <i class="fa-solid fa-images"></i>
-                                    </div>
                                     <div class="media-overview-content">
                                         <div class="a11y-overview-label media-overview-label">Files</div>
                                         <div class="a11y-overview-value media-overview-value" id="totalImages">0</div>
                                     </div>
                                 </div>
                                 <div class="a11y-overview-card media-overview-card">
-                                    <div class="media-overview-icon" aria-hidden="true">
-                                        <i class="fa-solid fa-database"></i>
-                                    </div>
                                     <div class="media-overview-content">
                                         <div class="a11y-overview-label media-overview-label">Storage Used</div>
                                         <div class="a11y-overview-value media-overview-value" id="totalSize">0</div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -6367,7 +6367,7 @@
 .media-btn {
     display: inline-flex;
     align-items: center;
-    gap: 10px;
+    justify-content: center;
     padding: 10px 20px;
     border-radius: 999px;
     border: none;
@@ -6376,10 +6376,6 @@
     cursor: pointer;
     transition: all 0.2s ease;
     text-decoration: none;
-}
-
-.media-btn i {
-    font-size: 16px;
 }
 
 .media-btn--ghost {
@@ -6422,7 +6418,6 @@
 .media-hero-chip {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
     padding: 8px 18px;
     border-radius: 999px;
     background: rgba(15,23,42,0.25);
@@ -6437,40 +6432,10 @@
 }
 
 .media-overview-card {
-    display: flex;
-    align-items: center;
-    gap: 16px;
     padding: 18px 20px;
     border-radius: 16px;
     background: rgba(255,255,255,0.14);
     backdrop-filter: blur(6px);
-}
-
-.media-overview-icon {
-    width: 54px;
-    height: 54px;
-    border-radius: 16px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 22px;
-    position: relative;
-    z-index: 1;
-}
-
-.media-overview-card:nth-child(1) .media-overview-icon {
-    background: linear-gradient(135deg, #ede9fe, #c7d2fe);
-    color: #5b21b6;
-}
-
-.media-overview-card:nth-child(2) .media-overview-icon {
-    background: linear-gradient(135deg, #fef3c7, #fde68a);
-    color: #b45309;
-}
-
-.media-overview-card:nth-child(3) .media-overview-icon {
-    background: linear-gradient(135deg, #d1fae5, #a7f3d0);
-    color: #047857;
 }
 
 .media-overview-content {


### PR DESCRIPTION
## Summary
- remove icon markup from the Media Library hero actions, chips, and overview cards
- streamline related button and card styles after removing the icon elements

## Testing
- php -l CMS/modules/media/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d8d86997548331bc8a0f72f346926d