### PR TITLE
Remove extra margin from menu hero meta badge

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -4588,7 +4588,6 @@
         }
 
         .menu-hero-meta {
-            margin-top: 18px;
             display: inline-flex;
             align-items: center;
             gap: 8px;


### PR DESCRIPTION
## Summary
- remove the top margin from the menu hero meta element so it sits flush with adjacent content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d94382948331966b3b194c5ec941