### PR TITLE
Update ghost button colors

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2507,12 +2507,13 @@
 
         .a11y-btn--ghost {
             background: transparent;
-            color: var(--color-text-primary);
+            color: #fff;
             border: 1px solid var(--color-border-strong);
         }
 
         .a11y-btn--ghost:hover {
             background: #e2e8f0;
+            color: #000;
         }
 
         .a11y-btn--icon {


### PR DESCRIPTION
## Summary
- set the default ghost button text color to white
- update the hover state to use black text for contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8d97cefd08331a5705d035a35195d