### PR TITLE
Add SEO insights and prioritize dashboard alerts

### DIFF
--- a/CMS/modules/dashboard/dashboard.js
+++ b/CMS/modules/dashboard/dashboard.js
@@ -174,7 +174,34 @@ $(function(){
             return;
         }
 
-        modules.forEach(function (module) {
+        const statusPriority = {
+            urgent: 0,
+            warning: 1,
+            ok: 2
+        };
+
+        const sortedModules = Array.isArray(modules)
+            ? modules.slice().sort(function (a, b) {
+                const statusA = String(a && a.status ? a.status : 'ok').toLowerCase();
+                const statusB = String(b && b.status ? b.status : 'ok').toLowerCase();
+                const priorityA = Object.prototype.hasOwnProperty.call(statusPriority, statusA)
+                    ? statusPriority[statusA]
+                    : statusPriority.ok;
+                const priorityB = Object.prototype.hasOwnProperty.call(statusPriority, statusB)
+                    ? statusPriority[statusB]
+                    : statusPriority.ok;
+
+                if (priorityA === priorityB) {
+                    const nameA = (a && (a.module || a.name || '')) || '';
+                    const nameB = (b && (b.module || b.name || '')) || '';
+                    return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' });
+                }
+
+                return priorityA - priorityB;
+            })
+            : modules;
+
+        sortedModules.forEach(function (module) {
             const id = module.id || module.module || module.name || '';
             const name = module.module || module.name || id || '';
             const primary = module.primary || '—';


### PR DESCRIPTION
## Summary
- add SEO metadata analysis to the dashboard data pipeline and expose SEO stats to the UI
- surface a new SEO module insight card alongside existing modules
- order dashboard module insights by severity so urgent issues appear first

## Testing
- php -l CMS/modules/dashboard/dashboard_data.php

------
https://chatgpt.com/codex/tasks/task_e_68d8da3b09508331a72839c0809f340b