### PR TITLE
Improve layout of accessibility controls

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2678,6 +2678,7 @@
             flex-wrap: wrap;
             gap: 16px;
             align-items: center;
+            justify-content: space-between;
         }
 
         .a11y-search {


### PR DESCRIPTION
## Summary
- apply `justify-content: space-between` to `.a11y-controls` to distribute items across the row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dad2525083319c76696cf593e64c