### PR TITLE
Remove padding and background from settings hero actions

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -4054,9 +4054,7 @@
         }
 
         .settings-hero-actions {
-            padding: 12px 18px;
             border-radius: 14px;
-            background: rgba(15, 23, 42, 0.22);
             box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
         }
 


### PR DESCRIPTION
## Summary
- remove the padding and translucent background from the settings hero actions container to leave just the existing shape styling

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8daf0927c8331bd9755431137231e