### PR TITLE
Improve speed dashboard baseline and sort styling

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2669,7 +2669,6 @@
 
         .speed-delta__value--baseline {
             background: rgba(59, 130, 246, 0.12);
-            color: #1d4ed8;
             font-weight: 500;
         }
 
@@ -2758,6 +2757,45 @@
             border-radius: 12px;
             background: #fff;
             box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+        }
+
+        .a11y-sort-group label {
+            font-size: 12px;
+            font-weight: 600;
+            color: #475569;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        #speedSortSelect {
+            appearance: none;
+            -webkit-appearance: none;
+            -moz-appearance: none;
+            border: 1px solid #cbd5f5;
+            border-radius: 10px;
+            background-color: #f8fafc;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%23475569' stroke-width='1.5'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M8 10l4 4 4-4'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 12px center;
+            background-size: 16px;
+            padding: 8px 38px 8px 12px;
+            font-size: 13px;
+            font-weight: 600;
+            color: #1e293b;
+            line-height: 1.4;
+            cursor: pointer;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        #speedSortSelect:hover {
+            border-color: #94a3b8;
+        }
+
+        #speedSortSelect:focus,
+        #speedSortSelect:focus-visible {
+            outline: none;
+            border-color: #2563eb;
+            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
         }
 
         .a11y-sort-btn {


### PR DESCRIPTION
## Summary
- remove the blue text color from the baseline speed delta badge so it inherits the neutral styling
- add dedicated styling for the speed dashboard sort selector to match the rest of the controls, including hover and focus states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dbfbe42883319f85fb697b7784b5