### PR TITLE
Close page settings modal after saving

### DIFF
--- a/CMS/modules/pages/pages.js
+++ b/CMS/modules/pages/pages.js
@@ -126,6 +126,8 @@ $(function(){
         $('#pageForm').on('submit', function(e){
             e.preventDefault();
             $.post('modules/pages/save_page.php', $(this).serialize(), function(){
+                closePageModal();
+                slugEdited = false;
                 location.reload();
             });
         });


### PR DESCRIPTION
## Summary
- close the page settings modal after a successful save request in the Pages module
- reset the slug edited flag when the modal closes after saving

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dcb1712c8331aa1df214874e8b88