### PR TITLE
Add canonical URL support to pages module

### DIFF
--- a/CMS/data/pages.json
+++ b/CMS/data/pages.json
@@ -13,7 +13,8 @@
     "og_title": "Home",
     "og_description": "Welcome to the Home Page",
     "og_image": "",
-    "access": "public"
+    "access": "public",
+    "canonical_url": ""
   },
   {
     "id": 2,
@@ -29,7 +30,8 @@
     "og_title": "About Us",
     "og_description": "Learn more about our company",
     "og_image": "",
-    "access": "public"
+    "access": "public",
+    "canonical_url": ""
   },
   {
     "id": 3,
@@ -45,7 +47,8 @@
     "og_title": "Services",
     "og_description": "Overview of the services we offer",
     "og_image": "",
-    "access": "public"
+    "access": "public",
+    "canonical_url": ""
   },
   {
     "id": 4,
@@ -61,7 +64,8 @@
     "og_title": "Blogs",
     "og_description": "Latest blog posts and updates",
     "og_image": "",
-    "access": "public"
+    "access": "public",
+    "canonical_url": ""
   },
   {
     "id": 5,
@@ -77,7 +81,8 @@
     "og_title": "Contact Us",
     "og_description": "Get in touch with us",
     "og_image": "",
-    "access": "public"
+    "access": "public",
+    "canonical_url": ""
   },
   {
     "id": 6,
@@ -93,7 +98,8 @@
     "published": true,
     "access": "public",
     "template": "page.php",
-    "views": 0
+    "views": 0,
+    "canonical_url": ""
   },
   {
     "id": 7,
@@ -109,7 +115,8 @@
     "published": true,
     "access": "public",
     "template": "page.php",
-    "views": 0
+    "views": 0,
+    "canonical_url": ""
   },
   {
     "id": 8,
@@ -125,7 +132,8 @@
     "published": true,
     "access": "public",
     "template": "page.php",
-    "views": 0
+    "views": 0,
+    "canonical_url": ""
   },
   {
     "id": 9,
@@ -141,6 +149,7 @@
     "published": true,
     "access": "public",
     "template": "page.php",
-    "views": 0
+    "views": 0,
+    "canonical_url": ""
   }
 ]

--- a/CMS/index.php
+++ b/CMS/index.php
@@ -203,6 +203,9 @@ if ($templateFile && (!$logged_in || $preview_mode)) {
 <?php if (!empty($page['meta_description'])): ?>
     <meta name="description" content="<?php echo htmlspecialchars($page['meta_description']); ?>">
 <?php endif; ?>
+<?php if (!empty($page['canonical_url'])): ?>
+    <link rel="canonical" href="<?php echo htmlspecialchars($page['canonical_url']); ?>">
+<?php endif; ?>
 <?php if (!empty($page['og_title'])): ?>
     <meta property="og:title" content="<?php echo htmlspecialchars($page['og_title']); ?>">
 <?php endif; ?>

--- a/CMS/modules/pages/pages.js
+++ b/CMS/modules/pages/pages.js
@@ -154,6 +154,7 @@ $(function(){
             $('#template').val(tmpl);
             $('#meta_title').val(row.data('meta_title'));
             $('#meta_description').val(row.data('meta_description'));
+            $('#canonical_url').val(row.data('canonical_url'));
             $('#og_title').val(row.data('og_title'));
             $('#og_description').val(row.data('og_description'));
             $('#og_image').val(row.data('og_image'));
@@ -168,6 +169,7 @@ $(function(){
             $('#pageId').val('');
             $('#pageForm')[0].reset();
             $('#published').prop('checked', false);
+            $('#canonical_url').val('');
             closePageModal();
             slugEdited = false;
         });
@@ -177,6 +179,7 @@ $(function(){
             $('#pageForm')[0].reset();
             $('#published').prop('checked', false);
             $('#content').val('');
+            $('#canonical_url').val('');
             $('#pageTabs').tabs('option', 'active', 0);
             $('#cancelEdit').hide();
             openPageModal();

--- a/CMS/modules/pages/save_page.php
+++ b/CMS/modules/pages/save_page.php
@@ -34,6 +34,7 @@ if ($template === '') {
 }
 $meta_title = sanitize_text($_POST['meta_title'] ?? '');
 $meta_description = sanitize_text($_POST['meta_description'] ?? '');
+$canonical_url = sanitize_url($_POST['canonical_url'] ?? '');
 $og_title = sanitize_text($_POST['og_title'] ?? '');
 $og_description = sanitize_text($_POST['og_description'] ?? '');
 $og_image = sanitize_url($_POST['og_image'] ?? '');
@@ -58,6 +59,7 @@ if ($id) {
             $p['template'] = $template;
             $p['meta_title'] = $meta_title;
             $p['meta_description'] = $meta_description;
+            $p['canonical_url'] = $canonical_url;
             $p['og_title'] = $og_title;
             $p['og_description'] = $og_description;
             $p['og_image'] = $og_image;
@@ -87,8 +89,11 @@ if ($id) {
         if ($old['meta_title'] !== $meta_title) {
             $details[] = 'Meta title updated';
         }
-        if ($old['meta_description'] !== $meta_description) {
+        if (($old['meta_description'] ?? '') !== $meta_description) {
             $details[] = 'Meta description updated';
+        }
+        if (($old['canonical_url'] ?? '') !== $canonical_url) {
+            $details[] = 'Canonical URL: ' . (($old['canonical_url'] ?? '') !== '' ? ($old['canonical_url'] ?? '') : 'none') . ' → ' . ($canonical_url !== '' ? $canonical_url : 'none');
         }
         if ($old['og_title'] !== $og_title) {
             $details[] = 'OG title: "' . $old['og_title'] . '" → "' . $og_title . '"';
@@ -125,6 +130,7 @@ if ($id) {
         'template' => $template,
         'meta_title' => $meta_title,
         'meta_description' => $meta_description,
+        'canonical_url' => $canonical_url,
         'og_title' => $og_title,
         'og_description' => $og_description,
         'og_image' => $og_image,

--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -139,6 +139,7 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
     data-template="<?php echo htmlspecialchars($p['template'] ?? '', ENT_QUOTES); ?>"
     data-meta_title="<?php echo htmlspecialchars($p['meta_title'] ?? '', ENT_QUOTES); ?>"
     data-meta_description="<?php echo htmlspecialchars($p['meta_description'] ?? '', ENT_QUOTES); ?>"
+    data-canonical_url="<?php echo htmlspecialchars($p['canonical_url'] ?? '', ENT_QUOTES); ?>"
     data-og_title="<?php echo htmlspecialchars($p['og_title'] ?? '', ENT_QUOTES); ?>"
     data-og_description="<?php echo htmlspecialchars($p['og_description'] ?? '', ENT_QUOTES); ?>"
     data-og_image="<?php echo htmlspecialchars($p['og_image'] ?? '', ENT_QUOTES); ?>"
@@ -253,6 +254,10 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                                 <div class="form-group">
                                     <label class="form-label" for="meta_description">Meta Description</label>
                                     <textarea class="form-textarea" name="meta_description" id="meta_description" rows="3"></textarea>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label" for="canonical_url">Canonical URL</label>
+                                    <input type="url" class="form-input" name="canonical_url" id="canonical_url" placeholder="https://example.com/your-page">
                                 </div>
                             </div>
                             <div id="tab-og" class="page-modal-panel">


### PR DESCRIPTION
## Summary
- add a canonical URL field to the page settings modal and load/reset it correctly
- persist canonical URLs for pages, default existing records, and include them in history tracking
- render the canonical link tag on the public page output when provided

## Testing
- php -l CMS/modules/pages/view.php
- php -l CMS/modules/pages/save_page.php
- php -l CMS/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d8dc86aa088331b7436a425eaf0dba