### PR TITLE
Remove background styling from accessibility hero meta

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2517,7 +2517,6 @@
         }
 
         #accessibility .accessibility-hero-meta {
-            background: rgba(15, 23, 42, 0.3);
             color: rgba(224, 242, 254, 0.9);
             letter-spacing: 0.02em;
         }


### PR DESCRIPTION
## Summary
- remove the translucent background from the accessibility hero meta badge so it no longer renders a tinted backdrop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dea9353883319cee479eaec0cecd