### PR TITLE
Remove border radius and shadow from settings hero actions

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -4092,11 +4092,6 @@
             max-width: 560px;
         }
 
-        .settings-hero-actions {
-            border-radius: 14px;
-            box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
-        }
-
         .settings-hero-meta {
             background: rgba(14, 165, 233, 0.2);
             color: rgba(255,255,255,0.92);


### PR DESCRIPTION
## Summary
- remove the settings hero action styling that applied rounded corners and a drop shadow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dee79b2c8331881f37390cb00aa4