### PR TITLE
Set hero meta text to white

### DIFF
--- a/spark-cms.css
+++ b/spark-cms.css
@@ -110,3 +110,7 @@ body {
     cursor: not-allowed;
 }
 
+:is(.analytics-hero-meta, .menu-hero-meta, .media-hero-meta, .pages-hero-meta, .blog-hero-meta, .search-hero-meta, .import-hero-meta, .seo-hero-meta, .a11y-hero-meta, .accessibility-hero-meta) {
+    color: #fff;
+}
+


### PR DESCRIPTION
## Summary
- add a CSS rule targeting hero meta variants via :is selector
- ensure hero meta text renders with white color

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8df1f6dec8331a4cd42034ec3b632