### PR TITLE
Fix SEO page score percent alignment

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -8633,7 +8633,7 @@
     height: 64px;
     border-radius: 50%;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
     justify-content: center;
     gap: 4px;


### PR DESCRIPTION
## Summary
- display the SEO page score percent symbol beside the score number on the card layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dfb226e483318ac65b4a8e6e8f4a