### PR TITLE
Remove Full SEO Audit button from SEO module

### DIFF
--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -851,12 +851,6 @@ $dashboardStats = [
                         <ul id="seoDetailIssues"></ul>
                     </div>
                 </div>
-                <footer class="a11y-detail-modal-footer">
-                    <button type="button" class="a11y-btn a11y-btn--primary" data-seo-action="full-audit">
-                        <i class="fas fa-chart-line" aria-hidden="true"></i>
-                        <span>Full SEO Audit</span>
-                    </button>
-                </footer>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- remove the Full SEO Audit button from the SEO modal footer in the SEO module view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dfd9b2c083318238a5d838d1f265