### PR TITLE
Remove icons from analytics modal

### DIFF
--- a/CMS/modules/analytics/analytics.css
+++ b/CMS/modules/analytics/analytics.css
@@ -129,13 +129,30 @@
 }
 
 .analytics-detail__close {
-    color: #94a3b8;
+    color: #1f2937;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 999px;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 6px 14px;
+    width: auto;
+    height: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
 }
 
 .analytics-detail__close:hover,
 .analytics-detail__close:focus-visible {
-    color: #1f2937;
+    color: #0f172a;
     background: #f1f5f9;
+    border-color: #cbd5f5;
+}
+
+.analytics-detail__close-text {
+    line-height: 1;
 }
 
 .analytics-detail__header {

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -270,7 +270,7 @@ $summaryComparisons = [
     <div class="a11y-page-detail analytics-detail" id="analyticsDetail" hidden role="dialog" aria-modal="true" aria-labelledby="analyticsDetailTitle">
         <div class="a11y-detail-content analytics-detail__content" role="document">
             <button type="button" class="a11y-detail-close analytics-detail__close" id="analyticsDetailClose" aria-label="Close page analytics">
-                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                <span class="analytics-detail__close-text">Close</span>
             </button>
             <header class="analytics-detail__header">
                 <div class="analytics-detail__title-group">
@@ -297,7 +297,6 @@ $summaryComparisons = [
             </div>
             <footer class="analytics-detail__footer">
                 <a id="analyticsDetailVisit" class="analytics-detail__link" href="/" target="_blank" rel="noopener">
-                    <i class="fa-solid fa-arrow-up-right-from-square" aria-hidden="true"></i>
                     <span>Open live page</span>
                 </a>
             </footer>


### PR DESCRIPTION
## Summary
- replace icon-based controls in the analytics detail modal with text labels
- update modal close button styling to match the new text-only design

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8e256070883318f2ad425a25af383