### PR TITLE
Align Module insights buttons with site styling

### DIFF
--- a/CMS/modules/dashboard/dashboard.js
+++ b/CMS/modules/dashboard/dashboard.js
@@ -266,7 +266,7 @@ $(function(){
 
             const $ctaButton = $('<button>', {
                 type: 'button',
-                class: 'dashboard-module-cta',
+                class: 'dashboard-module-cta a11y-btn a11y-btn--secondary',
                 text: cta
             });
 

--- a/CMS/modules/dashboard/view.php
+++ b/CMS/modules/dashboard/view.php
@@ -111,7 +111,7 @@
                     <p class="dashboard-module-secondary">Module metrics will appear here once data is available.</p>
                     <footer class="dashboard-module-card-footer">
                         <span class="dashboard-module-trend" aria-hidden="true">Preparing data</span>
-                        <button type="button" class="dashboard-module-cta" disabled aria-disabled="true">Loading</button>
+                        <button type="button" class="dashboard-module-cta a11y-btn a11y-btn--secondary" disabled aria-disabled="true">Loading</button>
                     </footer>
                 </article>
             </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1565,6 +1565,7 @@
             justify-content: space-between;
             align-items: center;
             gap: 12px;
+            margin-top: auto;
         }
 
         .dashboard-module-trend {
@@ -1573,24 +1574,11 @@
         }
 
         .dashboard-module-cta {
-            border: none;
-            border-radius: 12px;
-            padding: 10px 18px;
+            font-size: var(--font-size-base);
             font-weight: 600;
-            font-size: 14px;
-            background: linear-gradient(135deg, #4338ca, #2563eb);
-            color: #ffffff;
-            cursor: pointer;
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
 
-        .dashboard-module-cta:hover,
-        .dashboard-module-cta:focus {
-            transform: translateY(-1px);
-            box-shadow: 0 12px 30px -18px rgba(37, 99, 235, 0.4);
-        }
-
-        .dashboard-module-cta[disabled],
+        .dashboard-module-card .dashboard-module-cta[disabled],
         .dashboard-module-card.placeholder .dashboard-module-cta {
             background: #e2e8f0;
             color: #64748b;


### PR DESCRIPTION
## Summary
- apply the global button classes to Module insights card actions so they match the rest of the UI
- anchor module card footers to the bottom of each card for consistent CTA placement
- update the placeholder card markup and disabled state styles to use the shared button treatment

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8e5f018c483319a1a1c7002923223