### PR TITLE
Populate calendar module with 2025 categories and events

### DIFF
--- a/CMS/data/calendar_categories.json
+++ b/CMS/data/calendar_categories.json
@@ -1,1 +1,27 @@
-[]
+[
+  {
+    "id": 1,
+    "name": "Workshops",
+    "color": "#1abc9c"
+  },
+  {
+    "id": 2,
+    "name": "Webinars",
+    "color": "#3498db"
+  },
+  {
+    "id": 3,
+    "name": "Community Outreach",
+    "color": "#e67e22"
+  },
+  {
+    "id": 4,
+    "name": "Product Launches",
+    "color": "#9b59b6"
+  },
+  {
+    "id": 5,
+    "name": "Internal Operations",
+    "color": "#f1c40f"
+  }
+]

--- a/CMS/data/calendar_events.json
+++ b/CMS/data/calendar_events.json
@@ -1,1 +1,202 @@
-[]
+[
+  {
+    "id": 1,
+    "title": "Q4 Planning Kickoff",
+    "category": "Internal Operations",
+    "start_date": "2025-09-28T14:00:00+00:00",
+    "end_date": "2025-09-28T16:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Department heads align on priorities, milestones, and resource allocations for the final quarter."
+  },
+  {
+    "id": 2,
+    "title": "Customer Success Webinar: Onboarding Tips",
+    "category": "Webinars",
+    "start_date": "2025-10-01T16:00:00+00:00",
+    "end_date": "2025-10-01T17:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Live walkthrough showing new customers how to launch their first site with SparkCMS."
+  },
+  {
+    "id": 3,
+    "title": "Community Clean-up Drive",
+    "category": "Community Outreach",
+    "start_date": "2025-10-03T13:00:00+00:00",
+    "end_date": "2025-10-03T16:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Staff and volunteers gather to beautify the local riverside park and promote sustainability."
+  },
+  {
+    "id": 4,
+    "title": "Advanced SparkCMS Workshop",
+    "category": "Workshops",
+    "start_date": "2025-10-05T15:00:00+00:00",
+    "end_date": "2025-10-05T18:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Hands-on training covering automation rules, custom components, and advanced templating."
+  },
+  {
+    "id": 5,
+    "title": "Feature Release: Smart Templates",
+    "category": "Product Launches",
+    "start_date": "2025-10-08T10:00:00+00:00",
+    "end_date": "2025-10-08T11:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Public launch of the new AI-assisted template generator with live demo and Q&A."
+  },
+  {
+    "id": 6,
+    "title": "Weekly Operations Sync",
+    "category": "Internal Operations",
+    "start_date": "2025-10-10T14:00:00+00:00",
+    "end_date": "2025-10-10T15:00:00+00:00",
+    "recurring_interval": "weekly",
+    "recurring_end_date": "2025-12-19T15:00:00+00:00",
+    "description": "Cross-functional review of KPIs, blockers, and risk mitigations for the delivery teams."
+  },
+  {
+    "id": 7,
+    "title": "Partner Enablement Webinar",
+    "category": "Webinars",
+    "start_date": "2025-10-12T17:00:00+00:00",
+    "end_date": "2025-10-12T18:30:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Training session equipping agency partners with new collateral and co-marketing tactics."
+  },
+  {
+    "id": 8,
+    "title": "Nonprofit Outreach Strategy Session",
+    "category": "Community Outreach",
+    "start_date": "2025-10-15T14:00:00+00:00",
+    "end_date": "2025-10-15T16:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Planning discussion on expanding discounted services for mission-driven organizations."
+  },
+  {
+    "id": 9,
+    "title": "Content Strategy Workshop",
+    "category": "Workshops",
+    "start_date": "2025-10-18T09:00:00+00:00",
+    "end_date": "2025-10-18T13:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Interactive sprint to develop content calendars and automation workflows for 2026."
+  },
+  {
+    "id": 10,
+    "title": "Security Patch Release Briefing",
+    "category": "Product Launches",
+    "start_date": "2025-10-22T08:00:00+00:00",
+    "end_date": "2025-10-22T09:30:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Engineering walks through the critical security update and outlines deployment guidance."
+  },
+  {
+    "id": 11,
+    "title": "Volunteer Appreciation Dinner",
+    "category": "Community Outreach",
+    "start_date": "2025-10-24T23:00:00+00:00",
+    "end_date": "2025-10-25T01:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Evening celebration recognizing the contributions of community and user group volunteers."
+  },
+  {
+    "id": 12,
+    "title": "SparkCMS Certification Bootcamp",
+    "category": "Workshops",
+    "start_date": "2025-11-01T14:00:00+00:00",
+    "end_date": "2025-11-03T18:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Three-day intensive certification program with expert-led labs and assessments."
+  },
+  {
+    "id": 13,
+    "title": "Customer Feedback Webinar",
+    "category": "Webinars",
+    "start_date": "2025-11-05T15:00:00+00:00",
+    "end_date": "2025-11-05T16:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Monthly forum presenting key insights from NPS surveys and product usage analytics."
+  },
+  {
+    "id": 14,
+    "title": "Product Roadmap Reveal",
+    "category": "Product Launches",
+    "start_date": "2025-11-08T10:00:00+00:00",
+    "end_date": "2025-11-08T11:30:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Executive team unveils the 2026 product roadmap with customer advisory panel feedback."
+  },
+  {
+    "id": 15,
+    "title": "Data Governance Workshop",
+    "category": "Workshops",
+    "start_date": "2025-11-12T13:00:00+00:00",
+    "end_date": "2025-11-12T17:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Policy deep dive on access controls, retention practices, and compliance tooling."
+  },
+  {
+    "id": 16,
+    "title": "Regional Community Meetup",
+    "category": "Community Outreach",
+    "start_date": "2025-11-15T18:00:00+00:00",
+    "end_date": "2025-11-15T21:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "In-person gathering for users to share case studies and mentor new administrators."
+  },
+  {
+    "id": 17,
+    "title": "Infrastructure Maintenance Window",
+    "category": "Internal Operations",
+    "start_date": "2025-11-20T02:00:00+00:00",
+    "end_date": "2025-11-20T06:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Scheduled downtime to upgrade database clusters and apply operating system patches."
+  },
+  {
+    "id": 18,
+    "title": "Holiday Campaign Webinar",
+    "category": "Webinars",
+    "start_date": "2025-12-02T16:00:00+00:00",
+    "end_date": "2025-12-02T17:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Marketing team shares creative assets and automation tips for seasonal promotions."
+  },
+  {
+    "id": 19,
+    "title": "Year-End Hackathon",
+    "category": "Workshops",
+    "start_date": "2025-12-05T09:00:00+00:00",
+    "end_date": "2025-12-06T21:00:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Company-wide innovation sprint to build prototype integrations and experimental features."
+  },
+  {
+    "id": 20,
+    "title": "Q4 Product Release Showcase",
+    "category": "Product Launches",
+    "start_date": "2025-12-15T11:00:00+00:00",
+    "end_date": "2025-12-15T12:30:00+00:00",
+    "recurring_interval": "none",
+    "recurring_end_date": "",
+    "description": "Live stream highlighting the quarter's flagship releases and customer success stories."
+  }
+]


### PR DESCRIPTION
## Summary
- add five color-coded calendar categories for workshops, webinars, community outreach, product launches, and internal operations
- seed the calendar dataset with twenty events spanning late 2025, including a recurring weekly sync and varied descriptions across categories

## Testing
- not run (data update)

------
https://chatgpt.com/codex/tasks/task_e_68d8e9a577f08331937d67cd3c2c0d43