### PR TITLE
Add hero metrics and sync calendar dashboard stats

### DIFF
--- a/CMS/modules/calendar/api.php
+++ b/CMS/modules/calendar/api.php
@@ -2,6 +2,7 @@
 // File: modules/calendar/api.php
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/helpers.php';
 require_login();
 
 header('Content-Type: application/json');
@@ -55,6 +56,7 @@ function respond(array $payload, int $status = 200): void
 }
 
 [$events, $categories] = load_calendar_dataset($eventsFile, $categoriesFile);
+$metrics = compute_calendar_metrics($events, $categories);
 
 switch ($action) {
     case 'save_event':
@@ -155,11 +157,14 @@ switch ($action) {
 
         save_calendar_dataset($eventsFile, $categoriesFile, $events, $categories);
 
+        $metrics = compute_calendar_metrics($events, $categories);
+
         respond([
             'success' => true,
             'message' => $message,
             'events' => $events,
             'categories' => $categories,
+            'metrics' => $metrics,
         ]);
         break;
 
@@ -181,11 +186,14 @@ switch ($action) {
 
         save_calendar_dataset($eventsFile, $categoriesFile, $events, $categories);
 
+        $metrics = compute_calendar_metrics($events, $categories);
+
         respond([
             'success' => true,
             'message' => 'Event deleted.',
             'events' => $events,
             'categories' => $categories,
+            'metrics' => $metrics,
         ]);
         break;
 
@@ -226,11 +234,14 @@ switch ($action) {
 
         save_calendar_dataset($eventsFile, $categoriesFile, $events, $categories);
 
+        $metrics = compute_calendar_metrics($events, $categories);
+
         respond([
             'success' => true,
             'message' => 'Category added.',
             'events' => $events,
             'categories' => $categories,
+            'metrics' => $metrics,
         ]);
         break;
 
@@ -269,11 +280,14 @@ switch ($action) {
 
         save_calendar_dataset($eventsFile, $categoriesFile, $events, $categories);
 
+        $metrics = compute_calendar_metrics($events, $categories);
+
         respond([
             'success' => true,
             'message' => 'Category deleted.',
             'events' => $events,
             'categories' => $categories,
+            'metrics' => $metrics,
         ]);
         break;
 
@@ -282,5 +296,6 @@ switch ($action) {
             'success' => true,
             'events' => $events,
             'categories' => $categories,
+            'metrics' => $metrics,
         ]);
 }

--- a/CMS/modules/calendar/helpers.php
+++ b/CMS/modules/calendar/helpers.php
@@ -1,0 +1,64 @@
+<?php
+// File: modules/calendar/helpers.php
+
+if (!function_exists('compute_calendar_metrics')) {
+    /**
+     * Compute dashboard metrics for the calendar module.
+     *
+     * @param array $events
+     * @param array $categories
+     * @return array<string,mixed>
+     */
+    function compute_calendar_metrics(array $events, array $categories): array
+    {
+        $now = time();
+        $upcomingCount = 0;
+        $recurringCount = 0;
+        $nextEvent = null;
+
+        foreach ($events as $event) {
+            $startDate = isset($event['start_date']) ? (string) $event['start_date'] : '';
+            if ($startDate === '') {
+                continue;
+            }
+
+            $startTimestamp = strtotime($startDate);
+            if ($startTimestamp === false) {
+                continue;
+            }
+
+            if (isset($event['recurring_interval']) && (string) $event['recurring_interval'] !== 'none') {
+                $recurringCount++;
+            }
+
+            if ($startTimestamp >= $now) {
+                $upcomingCount++;
+                if ($nextEvent === null || $startTimestamp < $nextEvent['timestamp'] || (
+                    $startTimestamp === $nextEvent['timestamp'] && ((int) ($event['id'] ?? 0)) < $nextEvent['id']
+                )) {
+                    $nextEvent = [
+                        'id' => (int) ($event['id'] ?? 0),
+                        'title' => (string) ($event['title'] ?? ''),
+                        'start_date' => date('c', $startTimestamp),
+                        'timestamp' => $startTimestamp,
+                    ];
+                }
+            }
+        }
+
+        $metrics = [
+            'total_events' => count($events),
+            'upcoming_count' => $upcomingCount,
+            'recurring_count' => $recurringCount,
+            'category_count' => count($categories),
+        ];
+
+        if ($nextEvent !== null) {
+            $metrics['next_event'] = $nextEvent;
+        } else {
+            $metrics['next_event'] = null;
+        }
+
+        return $metrics;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared helper to compute calendar dashboard metrics and include them with API payloads
- refresh the calendar admin header into a hero with quick actions and server-rendered metric tiles
- keep hero counters and the next-event badge in sync after client-side updates to events and categories

## Testing
- php -l CMS/modules/calendar/helpers.php
- php -l CMS/modules/calendar/api.php
- php -l CMS/modules/calendar/view.php

------
https://chatgpt.com/codex/tasks/task_e_68d8ec259bb48331bf1ab1016aaf23c6