### PR TITLE
Fix blogs API endpoints missing data helper

### DIFF
--- a/CMS/modules/blogs/list_categories.php
+++ b/CMS/modules/blogs/list_categories.php
@@ -1,5 +1,7 @@
 <?php
 // File: list_categories.php
+require_once __DIR__ . '/../../includes/data.php';
+
 $postsFile = __DIR__ . '/../../data/blog_posts.json';
 $posts = read_json_file($postsFile);
 $categories = [];

--- a/CMS/modules/blogs/list_posts.php
+++ b/CMS/modules/blogs/list_posts.php
@@ -1,5 +1,7 @@
 <?php
 // File: list_posts.php
+require_once __DIR__ . '/../../includes/data.php';
+
 $postsFile = __DIR__ . '/../../data/blog_posts.json';
 $posts = read_json_file($postsFile);
 header('Content-Type: application/json');


### PR DESCRIPTION
## Summary
- ensure the blog posts and categories endpoints include the shared data helper so they can read blog JSON data

## Testing
- `php -S 0.0.0.0:8000 router.php` (manual verification while running)
- `curl -s http://127.0.0.1:8000/CMS/modules/blogs/list_posts.php | python -m json.tool`
- `curl -s http://127.0.0.1:8000/CMS/modules/blogs/list_categories.php | python -m json.tool`


------
https://chatgpt.com/codex/tasks/task_e_68d8f04e0a488331b53bccf4cde8b5cc