### PR TITLE
Fix calendar action buttons

### DIFF
--- a/CMS/modules/calendar/calendar.js
+++ b/CMS/modules/calendar/calendar.js
@@ -593,8 +593,14 @@
   }
 
   root.addEventListener('click', (event) => {
-    const target = event.target;
-    if (!(target instanceof HTMLElement)) {
+    const rawTarget = event.target;
+    if (!(rawTarget instanceof HTMLElement)) {
+      return;
+    }
+
+    const target = rawTarget.closest('[data-calendar-open], [data-calendar-close], [data-calendar-action]');
+
+    if (!target) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- ensure calendar toolbar buttons respond to clicks even when icons or labels are pressed by using closest matching element detection

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8f3aafae08331bf38b609d284c346