### PR TITLE
Adjust module insights button styling

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -1578,6 +1578,16 @@
             font-weight: 600;
         }
 
+        .dashboard-module-card .dashboard-module-cta:not([disabled]) {
+            background: var(--color-primary-strong);
+            color: #fff;
+        }
+
+        .dashboard-module-card .dashboard-module-cta:not([disabled]):hover {
+            background: var(--color-primary);
+            color: #fff;
+        }
+
         .dashboard-module-card .dashboard-module-cta[disabled],
         .dashboard-module-card.placeholder .dashboard-module-cta {
             background: #e2e8f0;


### PR DESCRIPTION
## Summary
- update the dashboard module call-to-action buttons to use the strong primary brand color with white text
- keep the disabled state styling while ensuring hover states remain consistent with the new palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8f402cc808331af699db267fab614