### PR TITLE
Improve blog media picker integration

### DIFF
--- a/CMS/modules/blogs/view.php
+++ b/CMS/modules/blogs/view.php
@@ -134,7 +134,7 @@
                     <div class="form-group blog-modal__field">
                         <label for="postImage">Featured Image</label>
                         <div class="blog-image-input">
-                            <input type="url" id="postImage" name="image" placeholder="Select an image from the Media Library" aria-describedby="postImageHint">
+                            <input type="text" id="postImage" name="image" placeholder="Select an image from the Media Library" aria-describedby="postImageHint">
                             <button type="button" class="blog-btn blog-btn--subtle" id="chooseFeaturedImage">
                                 <i class="fa-solid fa-images" aria-hidden="true"></i>
                                 <span>Select from Media Library</span>
@@ -244,6 +244,30 @@
                 <button type="button" class="blog-modal__button blog-modal__button--secondary" id="closePreviewBtn">Close</button>
                 <button type="button" class="blog-modal__button blog-modal__button--primary" id="editPreviewBtn">Edit</button>
             </footer>
+        </div>
+    </div>
+</div>
+
+<div class="modal blog-modal" id="mediaPickerModal" role="dialog" aria-modal="true" aria-labelledby="mediaPickerTitle">
+    <div class="modal-content">
+        <div class="blog-modal__surface">
+            <button type="button" class="blog-modal__close" id="closeMediaPickerModal" aria-label="Close">
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
+            <header class="blog-modal__header">
+                <span class="blog-modal__subtitle">Media library</span>
+                <h2 class="blog-modal__title" id="mediaPickerTitle">Select a featured image</h2>
+                <p class="blog-modal__description">Choose from the media library to quickly set a featured image for your post.</p>
+            </header>
+            <div class="blog-modal__body blog-media-picker">
+                <div class="blog-media-picker__toolbar">
+                    <label class="blog-media-picker__search" for="mediaPickerSearch">
+                        <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+                        <input type="search" id="mediaPickerSearch" placeholder="Search media by name or tag" aria-label="Search media">
+                    </label>
+                </div>
+                <div id="mediaPickerGrid" class="blog-media-picker__grid" role="listbox" aria-label="Media library images" aria-live="polite"></div>
+            </div>
         </div>
     </div>
 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -6213,7 +6213,7 @@
     gap: 12px;
 }
 
-.blog-image-input input[type="url"] {
+.blog-image-input input {
     flex: 1;
 }
 
@@ -6245,6 +6245,123 @@
     height: auto;
     display: block;
     border-radius: 12px;
+}
+
+.blog-media-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.blog-media-picker__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.blog-media-picker__search {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border: 1px solid #d7e3f4;
+    border-radius: 12px;
+    background: #f8fafc;
+    color: #475569;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    flex: 1 1 280px;
+}
+
+.blog-media-picker__search:focus-within {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+    background: #ffffff;
+}
+
+.blog-media-picker__search i {
+    color: #6366f1;
+    font-size: 15px;
+}
+
+.blog-media-picker__search input {
+    border: none;
+    outline: none;
+    background: transparent;
+    flex: 1;
+    font-size: 14px;
+    color: #0f172a;
+}
+
+.blog-media-picker__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 18px;
+}
+
+.blog-media-picker__item {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: flex-start;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    padding: 12px;
+    background: #ffffff;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    text-align: left;
+    color: inherit;
+}
+
+.blog-media-picker__item:hover,
+.blog-media-picker__item:focus-visible {
+    border-color: #6366f1;
+    box-shadow: 0 18px 38px rgba(99, 102, 241, 0.22);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.blog-media-picker__thumb {
+    position: relative;
+    width: 100%;
+    padding-top: 62%;
+    border-radius: 10px;
+    overflow: hidden;
+    background: #f1f5f9;
+}
+
+.blog-media-picker__thumb img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.blog-media-picker__name {
+    font-weight: 600;
+    font-size: 14px;
+    color: #1e293b;
+    line-height: 1.4;
+}
+
+.blog-media-picker__status {
+    padding: 36px 18px;
+    text-align: center;
+    border-radius: 14px;
+    border: 1px dashed rgba(99, 102, 241, 0.35);
+    background: rgba(226, 232, 240, 0.45);
+    font-size: 14px;
+    color: #475569;
+}
+
+.blog-media-picker__status--error {
+    color: #b91c1c;
+    border-color: rgba(239, 68, 68, 0.35);
+    background: rgba(254, 226, 226, 0.5);
 }
 
 .blog-modal__editor {


### PR DESCRIPTION
## Summary
- allow post settings to accept relative image paths by normalizing selected URLs
- replace the featured image popup with an inline media library modal fed from the media API
- add styling for the new media picker layout and controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8fbd8efa0833196fe273170ab7b97