### PR TITLE
Add hero eyebrow styling across module dashboards

### DIFF
--- a/CMS/modules/accessibility/view.php
+++ b/CMS/modules/accessibility/view.php
@@ -571,6 +571,7 @@ $dashboardStats = [
         <header class="a11y-hero accessibility-hero">
             <div class="a11y-hero-content accessibility-hero-content">
                 <div>
+                    <span class="hero-eyebrow accessibility-hero-eyebrow">Accessibility Snapshot</span>
                     <h2 class="a11y-hero-title accessibility-hero-title">Accessibility Dashboard</h2>
                     <p class="a11y-hero-subtitle accessibility-hero-subtitle">Monitor WCAG compliance and keep your experience inclusive for every visitor.</p>
                 </div>

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -85,6 +85,7 @@ $summaryComparisons = [
         <header class="a11y-hero analytics-hero">
             <div class="a11y-hero-content analytics-hero-content">
                 <div class="analytics-hero-text">
+                    <span class="hero-eyebrow analytics-hero-eyebrow">Insights Summary</span>
                     <h2 class="a11y-hero-title analytics-hero-title">Analytics Dashboard</h2>
                     <p class="a11y-hero-subtitle analytics-hero-subtitle">Monitor traffic trends, understand what resonates, and uncover pages that need promotion.</p>
                 </div>

--- a/CMS/modules/blogs/view.php
+++ b/CMS/modules/blogs/view.php
@@ -4,6 +4,7 @@
         <header class="a11y-hero blog-hero">
             <div class="a11y-hero-content blog-hero-content">
                 <div>
+                    <span class="hero-eyebrow blog-hero-eyebrow">Publishing Pipeline</span>
                     <h2 class="a11y-hero-title blog-hero-title">Editorial Dashboard</h2>
                     <p class="a11y-hero-subtitle blog-hero-subtitle">Plan, publish, and measure the health of your content pipeline.</p>
                 </div>

--- a/CMS/modules/calendar/view.php
+++ b/CMS/modules/calendar/view.php
@@ -85,7 +85,7 @@ $initialPayload = [
     <header class="a11y-hero calendar-hero">
         <div class="a11y-hero-content calendar-hero-content">
             <div class="calendar-hero-text">
-                <span class="calendar-hero-eyebrow">Calendar Overview</span>
+                <span class="hero-eyebrow calendar-hero-eyebrow">Calendar Overview</span>
                 <h2 class="a11y-hero-title calendar-hero-title">Manage Calendar Data</h2>
                 <p class="a11y-hero-subtitle calendar-hero-subtitle">
                     Coordinate upcoming events, recurring schedules, and categories without leaving the dashboard.

--- a/CMS/modules/dashboard/view.php
+++ b/CMS/modules/dashboard/view.php
@@ -4,6 +4,7 @@
         <header class="a11y-hero dashboard-hero">
             <div class="a11y-hero-content dashboard-hero-content">
                 <div>
+                    <span class="hero-eyebrow dashboard-hero-eyebrow">Operations Overview</span>
                     <h2 class="a11y-hero-title">Operations Dashboard</h2>
                     <p class="a11y-hero-subtitle">
                         Monitor the health of your content, media, and optimisation efforts from one polished overview.

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -83,6 +83,7 @@ $lastSubmissionLabel = $latestSubmission > 0
         <header class="a11y-hero forms-hero">
             <div class="a11y-hero-content">
                 <div>
+                    <span class="hero-eyebrow forms-hero-eyebrow">Submission Health</span>
                     <h2 class="a11y-hero-title">Form Builder &amp; Intake</h2>
                     <p class="a11y-hero-subtitle">Design conversion-ready forms, monitor submissions, and manage intake without leaving the dashboard.</p>
                 </div>

--- a/CMS/modules/import_export/view.php
+++ b/CMS/modules/import_export/view.php
@@ -4,6 +4,7 @@
                         <header class="a11y-hero import-hero">
                             <div class="a11y-hero-content import-hero-content">
                                 <div>
+                                    <span class="hero-eyebrow import-hero-eyebrow">Transfer Toolkit</span>
                                     <h2 class="a11y-hero-title import-hero-title">Import &amp; Export</h2>
                                     <p class="a11y-hero-subtitle import-hero-subtitle">Transfer site content, menus, media, and settings between environments with confidence.</p>
                                 </div>

--- a/CMS/modules/logs/view.php
+++ b/CMS/modules/logs/view.php
@@ -165,6 +165,7 @@ if ($uniqueUsersCount === 1) {
         <header class="a11y-hero logs-hero">
             <div class="a11y-hero-content logs-hero-content">
                 <div>
+                    <span class="hero-eyebrow logs-hero-eyebrow">Activity Timeline</span>
                     <h2 class="a11y-hero-title logs-hero-title">Activity Logs</h2>
                     <p class="a11y-hero-subtitle logs-hero-subtitle">Monitor publishing events, workflow actions, and page edits from a single, friendly timeline.</p>
                 </div>

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -4,6 +4,7 @@
                         <header class="a11y-hero media-hero">
                             <div class="a11y-hero-content media-hero-content">
                                 <div>
+                                    <span class="hero-eyebrow media-hero-eyebrow">Library Overview</span>
                                     <h2 class="a11y-hero-title media-hero-title">Media Library</h2>
                                     <p class="a11y-hero-subtitle media-hero-subtitle">Keep your images, documents, and videos organised with a modern, visual workspace that mirrors the accessibility dashboard experience.</p>
                                 </div>

--- a/CMS/modules/menus/view.php
+++ b/CMS/modules/menus/view.php
@@ -93,6 +93,7 @@ $filterCounts = [
         <header class="a11y-hero menu-hero">
             <div class="a11y-hero-content menu-hero-content">
                 <div>
+                    <span class="hero-eyebrow menu-hero-eyebrow">Navigation Health</span>
                     <h2 class="a11y-hero-title menu-hero-title">Navigation Menus</h2>
                     <p class="a11y-hero-subtitle menu-hero-subtitle">Craft intuitive navigation experiences and keep every menu in sync with your site's structure.</p>
                 </div>

--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -57,6 +57,7 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
         <header class="a11y-hero pages-hero">
             <div class="a11y-hero-content pages-hero-content">
                 <div>
+                    <span class="hero-eyebrow pages-hero-eyebrow">Content Inventory</span>
                     <h2 class="a11y-hero-title pages-hero-title">Pages</h2>
                     <p class="a11y-hero-subtitle pages-hero-subtitle">Keep your site structure organised and publish updates with confidence.</p>
                 </div>

--- a/CMS/modules/search/view.php
+++ b/CMS/modules/search/view.php
@@ -61,6 +61,7 @@ foreach ($results as $entry) {
         <header class="a11y-hero search-hero">
             <div class="a11y-hero-content search-hero-content">
                 <div>
+                    <span class="hero-eyebrow search-hero-eyebrow">Unified Index</span>
                     <h2 class="a11y-hero-title search-hero-title">Unified Search</h2>
                     <p class="a11y-hero-subtitle search-hero-subtitle">Surface pages, posts, and media without leaving the dashboard.</p>
                 </div>

--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -692,6 +692,7 @@ $dashboardStats = [
         <header class="seo-hero">
             <div class="seo-hero-content">
                 <div>
+                    <span class="hero-eyebrow seo-hero-eyebrow">Optimisation Signals</span>
                     <h2 class="seo-hero-title">SEO Optimisation Dashboard</h2>
                     <p class="seo-hero-subtitle">Measure on-page signals and prioritise fixes that improve organic visibility.</p>
                 </div>

--- a/CMS/modules/settings/view.php
+++ b/CMS/modules/settings/view.php
@@ -5,6 +5,7 @@
             <header class="a11y-hero settings-hero">
                 <div class="a11y-hero-content settings-hero-content">
                     <div>
+                        <span class="hero-eyebrow settings-hero-eyebrow">Configuration Hub</span>
                         <h2 class="a11y-hero-title settings-hero-title">Site Settings</h2>
                         <p class="a11y-hero-subtitle settings-hero-subtitle">Fine-tune your brand voice, analytics, and sharing defaults from a single, polished workspace.</p>
                     </div>

--- a/CMS/modules/sitemap/view.php
+++ b/CMS/modules/sitemap/view.php
@@ -48,6 +48,7 @@ $statusMessage = $entryCount > 0
         <header class="a11y-hero sitemap-hero">
             <div class="a11y-hero-content sitemap-hero-content">
                 <div>
+                    <span class="hero-eyebrow sitemap-hero-eyebrow">Index Coverage</span>
                     <h2 class="a11y-hero-title sitemap-hero-title">Sitemap overview</h2>
                     <p class="a11y-hero-subtitle sitemap-hero-subtitle">
                         Review the URLs included in your sitemap and regenerate it after publishing new content.

--- a/CMS/modules/speed/view.php
+++ b/CMS/modules/speed/view.php
@@ -704,6 +704,7 @@ write_json_file($snapshotFile, $currentSnapshot);
         <header class="a11y-hero">
             <div class="a11y-hero-content">
                 <div>
+                    <span class="hero-eyebrow speed-hero-eyebrow">Performance Pulse</span>
                     <h2 class="a11y-hero-title">Performance &amp; Speed Dashboard</h2>
                     <p class="a11y-hero-subtitle">Track asset weight, script usage, and rendering health across every published page.</p>
                 </div>

--- a/CMS/modules/users/view.php
+++ b/CMS/modules/users/view.php
@@ -4,6 +4,7 @@
         <header class="a11y-hero users-hero">
             <div class="a11y-hero-content">
                 <div>
+                    <span class="hero-eyebrow users-hero-eyebrow">Team Directory</span>
                     <h2 class="a11y-hero-title">Team access &amp; permissions</h2>
                     <p class="a11y-hero-subtitle">Review account health, monitor roles, and invite new collaborators from a single, polished dashboard.</p>
                 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2472,6 +2472,16 @@
             flex-wrap: wrap;
         }
 
+        .hero-eyebrow {
+            display: block;
+            font-size: var(--font-size-xs);
+            text-transform: uppercase;
+            letter-spacing: 0.18em;
+            font-weight: 600;
+            color: rgba(224, 231, 255, 0.88);
+            margin-bottom: 6px;
+        }
+
         .a11y-hero-title {
             font-size: var(--font-size-2xl);
             font-weight: 600;


### PR DESCRIPTION
## Summary
- add hero eyebrow labels to every module hero header for clearer section context
- introduce a shared hero-eyebrow style so all dashboards render the new labels consistently

## Testing
- for f in CMS/modules/accessibility/view.php CMS/modules/analytics/view.php CMS/modules/blogs/view.php CMS/modules/calendar/view.php CMS/modules/dashboard/view.php CMS/modules/forms/view.php CMS/modules/import_export/view.php CMS/modules/logs/view.php CMS/modules/media/view.php CMS/modules/menus/view.php CMS/modules/pages/view.php CMS/modules/search/view.php CMS/modules/seo/view.php CMS/modules/settings/view.php CMS/modules/sitemap/view.php CMS/modules/speed/view.php CMS/modules/users/view.php; do php -l "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68d8fdd91d508331b658162c4dc5bdcd