### PR TITLE
Convert SEO card link text to button

### DIFF
--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -800,10 +800,10 @@ $dashboardStats = [
                         <?php endforeach; ?>
                     </div>
                     <footer>
-                        <span class="seo-card-link" aria-hidden="true">
-                            View detailed recommendations
+                        <button type="button" class="seo-card-link" aria-label="See detailed SEO guidance for <?php echo htmlspecialchars($page['title']); ?>">
+                            <span>See detailed SEO guidance</span>
                             <i class="fas fa-arrow-right" aria-hidden="true"></i>
-                        </span>
+                        </button>
                         <span class="sr-only">Press Enter to open SEO details for <?php echo htmlspecialchars($page['title']); ?>.</span>
                     </footer>
                 </article>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -9477,15 +9477,20 @@ body.calendar-modal-open {
 }
 
 .seo-card-link {
+    background: none;
+    border: none;
     color: #1e40af;
+    font: inherit;
     font-weight: 600;
-    text-decoration: none;
+    padding: 0;
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
+    cursor: pointer;
 }
 
-.seo-card-link:hover {
+.seo-card-link:hover,
+.seo-card-link:focus-visible {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- replace the SEO card footer text with an accessible button labeled “See detailed SEO guidance”
- update the SEO card link styles so the new button retains the existing visual treatment and focus styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8c4f69008331b9364a3187af89fb