### PR TITLE
Redesign forms submissions UI

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -4,6 +4,9 @@ $(function(){
 
     let currentField = null;
     let currentFormId = null;
+    let currentFormName = '';
+    let currentSubmissions = [];
+    let lastSubmissionTrigger = null;
     let formsCache = [];
 
     const FIELD_TYPE_LABELS = {
@@ -206,11 +209,18 @@ $(function(){
 
     function resetSubmissionsCard(message){
         currentFormId = null;
+        currentFormName = '';
+        currentSubmissions = [];
+        closeSubmissionModal();
         const text = message || 'Select a form to view submissions';
-        const rowMessage = /[.!?]$/.test(text) ? text : text + '.';
+        const placeholder = /[.!?]$/.test(text) ? text : text + '.';
         $('#formsTable tbody tr').removeClass('selected');
         $('#selectedFormName').text(text);
-        $('#formSubmissionsTable tbody').html('<tr class="placeholder-row"><td colspan="2">'+escapeHtml(rowMessage)+'</td></tr>');
+        $('#formSubmissionsCount').text('—');
+        $('#formSubmissionsList')
+            .attr('data-state', 'empty')
+            .attr('aria-busy', 'false')
+            .html('<div class="forms-submissions-empty">'+escapeHtml(placeholder)+'</div>');
     }
 
     function formatSubmissionDate(value){
@@ -264,53 +274,201 @@ $(function(){
         return String(value);
     }
 
+    function normalizeSubmissionRecord(submission){
+        const submittedAt = formatSubmissionDate(submission && (submission.submitted_at || submission.created_at || submission.timestamp));
+        const fields = submission && submission.data && typeof submission.data === 'object' ? submission.data : {};
+        const meta = submission && submission.meta && typeof submission.meta === 'object' ? Object.assign({}, submission.meta) : {};
+        if(submission && submission.source && !meta.source){
+            meta.source = submission.source;
+        }
+        if(submission && submission.id && !meta.id){
+            meta.id = submission.id;
+        }
+        const fieldEntries = Object.keys(fields)
+            .sort((a, b) => a.localeCompare(b))
+            .map(function(key){
+                return { key: key, value: normalizeSubmissionValue(fields[key]) };
+            });
+        const metaEntries = Object.keys(meta)
+            .sort((a, b) => a.localeCompare(b))
+            .map(function(key){
+                return { key: key, value: normalizeSubmissionValue(meta[key]) };
+            });
+        const identifierEntry = metaEntries.find(function(entry){
+            return entry.key && entry.key.toLowerCase() === 'id';
+        });
+        const sourceEntry = metaEntries.find(function(entry){
+            return entry.key && entry.key.toLowerCase() === 'source';
+        });
+        return {
+            submittedAt: submittedAt,
+            fieldEntries: fieldEntries,
+            metaEntries: metaEntries,
+            identifier: identifierEntry ? identifierEntry.value : (submission && submission.id ? normalizeSubmissionValue(submission.id) : ''),
+            source: sourceEntry ? sourceEntry.value : (submission && submission.source ? normalizeSubmissionValue(submission.source) : ''),
+            raw: submission || {}
+        };
+    }
+
     function loadFormSubmissions(formId, formName){
         currentFormId = formId;
+        currentFormName = formName;
+        currentSubmissions = [];
         $('#formsTable tbody tr').removeClass('selected');
         $('#formsTable tbody tr').filter(function(){ return $(this).data('id') == formId; }).addClass('selected');
         $('#selectedFormName').text(formName);
-        const tbody = $('#formSubmissionsTable tbody').empty();
-        tbody.append('<tr class="loading-row"><td colspan="2">Loading submissions...</td></tr>');
+        $('#formSubmissionsCount').text('—');
+        const $list = $('#formSubmissionsList');
+        $list
+            .attr('data-state', 'loading')
+            .attr('aria-busy', 'true')
+            .html('<div class="forms-submissions-empty">Loading submissions...</div>');
         $.getJSON('modules/forms/list_submissions.php', { form_id: formId }, function(data){
-            tbody.empty();
             const submissions = Array.isArray(data) ? data : [];
-            if(!submissions.length){
-                tbody.append('<tr class="empty-row"><td colspan="2">No submissions yet.</td></tr>');
+            currentSubmissions = submissions.map(normalizeSubmissionRecord);
+            if(!currentSubmissions.length){
+                $('#formSubmissionsCount').text('0 submissions');
+                $list
+                    .attr('data-state', 'empty')
+                    .attr('aria-busy', 'false')
+                    .html('<div class="forms-submissions-empty">No submissions yet.</div>');
                 return;
             }
-            submissions.forEach(function(submission){
-                const submittedAt = formatSubmissionDate(submission.submitted_at || submission.created_at || submission.timestamp);
-                const fields = submission.data && typeof submission.data === 'object' ? submission.data : {};
-                const meta = submission.meta && typeof submission.meta === 'object' ? Object.assign({}, submission.meta) : {};
-                if(submission.source && !meta.source){
-                    meta.source = submission.source;
+            const countLabel = currentSubmissions.length === 1 ? '1 submission' : currentSubmissions.length + ' submissions';
+            $('#formSubmissionsCount').text(countLabel);
+            $list.attr('data-state', 'ready').attr('aria-busy', 'false').empty();
+            currentSubmissions.forEach(function(record, index){
+                const $card = $('<article class="forms-submission-card" role="listitem"></article>');
+                const $header = $('<div class="forms-submission-card__header"></div>');
+                $header.append('<span class="forms-submission-card__timestamp">'+escapeHtml(record.submittedAt || 'Unknown')+'</span>');
+                const $badges = $('<div class="forms-submission-card__badges"></div>');
+                const identifier = record.identifier && String(record.identifier).trim();
+                const source = record.source && String(record.source).trim();
+                if(identifier){
+                    $badges.append('<span class="forms-submission-card__badge forms-submission-card__badge--id">ID '+escapeHtml(identifier)+'</span>');
                 }
-                if(submission.id && !meta.id){
-                    meta.id = submission.id;
+                if(source){
+                    $badges.append('<span class="forms-submission-card__badge">'+escapeHtml(source)+'</span>');
                 }
-                const fieldKeys = Object.keys(fields).sort();
-                const metaKeys = Object.keys(meta).sort();
-                const details = [];
-                fieldKeys.forEach(function(key){
-                    const value = normalizeSubmissionValue(fields[key]);
-                    details.push('<div class="submission-detail"><div class="submission-label">'+escapeHtml(key)+'</div><div class="submission-value">'+escapeHtml(value)+'</div></div>');
-                });
-                if(metaKeys.length){
-                    details.push('<div class="submission-meta-group"><div class="submission-meta-title">Metadata</div>');
-                    metaKeys.forEach(function(key){
-                        const value = normalizeSubmissionValue(meta[key]);
-                        details.push('<div class="submission-detail"><div class="submission-label">'+escapeHtml(key)+'</div><div class="submission-value">'+escapeHtml(value)+'</div></div>');
+                if(!$badges.children().length){
+                    $badges.append('<span class="forms-submission-card__badge forms-submission-card__badge--muted">Submission '+escapeHtml(String(index + 1))+'</span>');
+                }
+                $header.append($badges);
+                $card.append($header);
+
+                const $preview = $('<div class="forms-submission-card__preview"></div>');
+                const previewFields = record.fieldEntries.slice(0, 3);
+                if(previewFields.length){
+                    previewFields.forEach(function(entry){
+                        const $field = $('<div class="forms-submission-card__field"></div>');
+                        $field.append('<span class="forms-submission-card__field-label">'+escapeHtml(entry.key)+'</span>');
+                        $field.append('<span class="forms-submission-card__field-value">'+escapeHtml(entry.value)+'</span>');
+                        $preview.append($field);
                     });
-                    details.push('</div>');
+                    if(record.fieldEntries.length > 3){
+                        const remaining = record.fieldEntries.length - 3;
+                        $preview.append('<span class="forms-submission-card__more">+'+escapeHtml(String(remaining))+' more field'+(remaining === 1 ? '' : 's')+'</span>');
+                    }
+                } else {
+                    $preview.append('<div class="forms-submission-card__empty">No submission data provided.</div>');
                 }
-                if(!details.length){
-                    details.push('<div class="submission-detail"><div class="submission-label">Details</div><div class="submission-value"><em>No submission data provided.</em></div></div>');
-                }
-                tbody.append('<tr><td class="submitted">'+escapeHtml(submittedAt)+'</td><td class="details">'+details.join('')+'</td></tr>');
+                $card.append($preview);
+
+                const $actions = $('<div class="forms-submission-card__actions"></div>');
+                const $button = $('<button type="button" class="a11y-btn a11y-btn--ghost forms-submission-view"><i class="fa-solid fa-eye" aria-hidden="true"></i><span>View details</span></button>');
+                $button.on('click', function(){
+                    openSubmissionModal(index, this);
+                });
+                $actions.append($button);
+                $card.append($actions);
+
+                $list.append($card);
             });
         }).fail(function(){
-            tbody.empty().append('<tr class="error-row"><td colspan="2">Unable to load submissions.</td></tr>');
+            $('#formSubmissionsCount').text('—');
+            $list
+                .attr('data-state', 'error')
+                .attr('aria-busy', 'false')
+                .html('<div class="forms-submissions-empty">Unable to load submissions.</div>');
         });
+    }
+
+    function buildModalDescription(record){
+        const segments = [];
+        if(currentFormName){
+            segments.push('Form: ' + currentFormName);
+        }
+        if(record && record.submittedAt && record.submittedAt !== 'Unknown'){
+            segments.push('Submitted ' + record.submittedAt);
+        }
+        return segments.join(' • ');
+    }
+
+    function openSubmissionModal(index, trigger){
+        if(!currentSubmissions[index]){
+            return;
+        }
+        const record = currentSubmissions[index];
+        lastSubmissionTrigger = trigger ? $(trigger) : null;
+        const $modal = $('#submissionDetailModal');
+        const $body = $('#submissionModalBody').empty();
+        const identifier = record.identifier && String(record.identifier).trim();
+        $('#submissionModalTitle').text(identifier ? 'Submission ID ' + identifier : 'Submission details');
+        $('#submissionModalDescription').text(buildModalDescription(record));
+
+        if(record.fieldEntries.length){
+            const $fieldsSection = $('<section class="forms-submission-modal__section"></section>');
+            $fieldsSection.append('<h3 class="forms-submission-modal__section-title">Submitted fields</h3>');
+            const $fieldList = $('<dl class="forms-submission-modal__details"></dl>');
+            record.fieldEntries.forEach(function(entry){
+                const $item = $('<div class="forms-submission-modal__detail"></div>');
+                $item.append('<dt>'+escapeHtml(entry.key)+'</dt>');
+                $item.append('<dd>'+escapeHtml(entry.value)+'</dd>');
+                $fieldList.append($item);
+            });
+            $fieldsSection.append($fieldList);
+            $body.append($fieldsSection);
+        }
+
+        if(record.metaEntries.length){
+            const $metaSection = $('<section class="forms-submission-modal__section"></section>');
+            $metaSection.append('<h3 class="forms-submission-modal__section-title">Metadata</h3>');
+            const $metaList = $('<dl class="forms-submission-modal__details"></dl>');
+            record.metaEntries.forEach(function(entry){
+                const $item = $('<div class="forms-submission-modal__detail"></div>');
+                $item.append('<dt>'+escapeHtml(entry.key)+'</dt>');
+                $item.append('<dd>'+escapeHtml(entry.value)+'</dd>');
+                $metaList.append($item);
+            });
+            $metaSection.append($metaList);
+            $body.append($metaSection);
+        }
+
+        if(!$body.children().length){
+            $body.append('<div class="forms-submission-modal__empty">No additional information available for this submission.</div>');
+        }
+
+        $modal.addClass('active').attr('aria-hidden', 'false');
+        setTimeout(function(){
+            $('#submissionModalClose').trigger('focus');
+        }, 0);
+    }
+
+    function closeSubmissionModal(){
+        const $modal = $('#submissionDetailModal');
+        if(!$modal.hasClass('active')){
+            return;
+        }
+        $modal.removeClass('active').attr('aria-hidden', 'true');
+        $('#submissionModalTitle').text('Submission details');
+        $('#submissionModalDescription').text('');
+        $('#submissionModalBody')
+            .empty()
+            .append('<div class="forms-submission-modal__empty">Select a form submission to view the collected data.</div>');
+        if(lastSubmissionTrigger && lastSubmissionTrigger.length){
+            lastSubmissionTrigger.trigger('focus');
+        }
+        lastSubmissionTrigger = null;
     }
 
     function updatePreview($li){
@@ -811,6 +969,22 @@ $(function(){
 
     $('#fieldSettings').on('input change', '.field-body input, .field-body textarea', function(){
         if(currentField) updatePreview(currentField);
+    });
+
+    $('#submissionModalClose').on('click', function(){
+        closeSubmissionModal();
+    });
+
+    $('#submissionDetailModal').on('click', function(event){
+        if(event.target === this){
+            closeSubmissionModal();
+        }
+    });
+
+    $(document).on('keydown.formsSubmissionModal', function(event){
+        if(event.key === 'Escape'){
+            closeSubmissionModal();
+        }
     });
 
     bootstrapStatsFromDataset();

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -141,26 +141,19 @@ $lastSubmissionLabel = $latestSubmission > 0
             </section>
 
             <section class="a11y-detail-card forms-submissions-card" id="formSubmissionsCard">
-                <header class="forms-card-header">
+                <header class="forms-card-header forms-submissions-header">
                     <div>
                         <h3>Submission activity</h3>
                         <p id="selectedFormName" class="form-submissions-label">Select a form to view submissions</p>
                     </div>
+                    <div class="forms-submissions-meta">
+                        <span class="forms-submissions-count" id="formSubmissionsCount">—</span>
+                    </div>
                 </header>
-                <div class="forms-table-wrapper">
-                    <table class="data-table forms-table" id="formSubmissionsTable">
-                        <thead>
-                            <tr>
-                                <th>Submitted</th>
-                                <th>Details</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr class="placeholder-row">
-                                <td colspan="2">Select a form to view submissions.</td>
-                            </tr>
-                        </tbody>
-                    </table>
+                <div class="forms-submissions-container">
+                    <div class="forms-submissions-list" id="formSubmissionsList" role="list" aria-live="polite">
+                        <div class="forms-submissions-empty">Select a form to view submissions.</div>
+                    </div>
                 </div>
             </section>
         </div>
@@ -209,5 +202,20 @@ $lastSubmissionLabel = $latestSubmission > 0
                 </div>
             </form>
         </section>
+    </div>
+    <div class="modal forms-submission-modal" id="submissionDetailModal" role="dialog" aria-modal="true" aria-labelledby="submissionModalTitle" aria-describedby="submissionModalDescription" aria-hidden="true">
+        <div class="modal-content">
+            <button type="button" class="modal-close" id="submissionModalClose" aria-label="Close submission details">
+                <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+            </button>
+            <header class="modal-header forms-submission-modal__header">
+                <span class="forms-submission-modal__eyebrow" id="submissionModalEyebrow">Submission details</span>
+                <h2 class="forms-submission-modal__title" id="submissionModalTitle">Submission details</h2>
+                <p class="forms-submission-modal__meta" id="submissionModalDescription"></p>
+            </header>
+            <div class="modal-body forms-submission-modal__body" id="submissionModalBody">
+                <div class="forms-submission-modal__empty">Select a form submission to view the collected data.</div>
+            </div>
+        </div>
     </div>
 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -8567,6 +8567,11 @@ body.calendar-modal-open {
     margin: 0;
 }
 
+.forms-table-card .data-table th,
+.forms-table-card .data-table td {
+    background: transparent;
+}
+
 .forms-actions {
     display: flex;
     flex-wrap: wrap;
@@ -8616,19 +8621,293 @@ body.calendar-modal-open {
     background: rgba(254, 226, 226, 0.6);
 }
 
-.forms-table-card .data-table th,
-.forms-table-card .data-table td,
-.forms-submissions-card .data-table th,
-.forms-submissions-card .data-table td {
-    background: transparent;
+
+.forms-submissions-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 16px;
 }
 
-.forms-submissions-card .data-table tbody tr:nth-child(odd) td {
-    background: rgba(248, 250, 252, 0.6);
+.forms-submissions-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
 }
 
-.forms-submissions-card .data-table tbody tr:nth-child(even) td {
-    background: rgba(255, 255, 255, 0.9);
+.forms-submissions-count {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 600;
+    background: rgba(148, 163, 184, 0.2);
+    color: #334155;
+}
+
+.forms-submissions-container {
+    background: linear-gradient(180deg, rgba(248, 250, 252, 0.92), #ffffff);
+    border-radius: 16px;
+    border: 1px solid #e2e8f0;
+    padding: 20px;
+}
+
+.forms-submissions-list {
+    display: grid;
+    gap: 16px;
+}
+
+.forms-submissions-list[data-state="loading"] .forms-submissions-empty::before {
+    content: '\f110';
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    margin-right: 8px;
+    display: inline-block;
+    animation: formsSubmissionSpin 1s linear infinite;
+}
+
+@keyframes formsSubmissionSpin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.forms-submissions-empty {
+    padding: 32px 16px;
+    text-align: center;
+    color: #64748b;
+    font-style: italic;
+}
+
+.forms-submission-card {
+    background: #ffffff;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
+    padding: 18px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.forms-submission-card__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.forms-submission-card__timestamp {
+    font-weight: 600;
+    color: #1f2937;
+    font-size: 15px;
+}
+
+.forms-submission-card__badges {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.forms-submission-card__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #334155;
+    background: rgba(226, 232, 240, 0.9);
+}
+
+.forms-submission-card__badge--id {
+    background: rgba(59, 130, 246, 0.15);
+    color: #1d4ed8;
+}
+
+.forms-submission-card__badge--muted {
+    background: rgba(148, 163, 184, 0.2);
+    color: #475569;
+}
+
+.forms-submission-card__preview {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.forms-submission-card__field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: #f8fafc;
+    border-radius: 10px;
+    padding: 10px 12px;
+    min-width: 140px;
+    flex: 1 1 160px;
+}
+
+.forms-submission-card__field-label {
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+.forms-submission-card__field-value {
+    font-weight: 600;
+    color: #1f2937;
+    word-break: break-word;
+}
+
+.forms-submission-card__more {
+    align-self: center;
+    font-size: 12px;
+    font-weight: 600;
+    color: #475569;
+}
+
+.forms-submission-card__empty {
+    width: 100%;
+    padding: 14px 16px;
+    border-radius: 10px;
+    background: #f8fafc;
+    color: #64748b;
+    text-align: center;
+    font-style: italic;
+}
+
+.forms-submission-card__actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.forms-submission-card__actions .a11y-btn {
+    gap: 6px;
+    font-size: 13px;
+}
+
+.forms-submission-modal .modal-content {
+    max-width: 640px;
+    width: min(640px, 94vw);
+    padding: 32px 36px;
+    border-radius: 18px;
+    box-shadow: 0 28px 54px rgba(15, 23, 42, 0.22);
+    position: relative;
+}
+
+.forms-submission-modal__header {
+    padding-right: 40px;
+}
+
+.forms-submission-modal__eyebrow {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #6366f1;
+    margin-bottom: 6px;
+}
+
+.forms-submission-modal__title {
+    margin: 0;
+    font-size: 24px;
+    color: #1f2937;
+    font-weight: 700;
+}
+
+.forms-submission-modal__meta {
+    margin: 6px 0 0;
+    color: #475569;
+    font-size: 14px;
+}
+
+.forms-submission-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.forms-submission-modal__section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.forms-submission-modal__section-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.forms-submission-modal__details {
+    display: grid;
+    gap: 12px;
+}
+
+.forms-submission-modal__detail {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 6px 24px;
+    align-items: baseline;
+}
+
+.forms-submission-modal__detail dt {
+    margin: 0;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+.forms-submission-modal__detail dd {
+    margin: 0;
+    color: #1f2937;
+    font-weight: 600;
+    word-break: break-word;
+    white-space: pre-wrap;
+}
+
+.forms-submission-modal__empty {
+    text-align: center;
+    padding: 28px 16px;
+    color: #64748b;
+    font-style: italic;
+}
+
+@media (max-width: 900px) {
+    .forms-submissions-header {
+        align-items: flex-start;
+    }
+}
+
+@media (max-width: 720px) {
+    .forms-submissions-container {
+        padding: 16px;
+    }
+
+    .forms-submission-card {
+        padding: 16px;
+    }
+
+    .forms-submission-modal__detail {
+        grid-template-columns: 1fr;
+        gap: 4px 0;
+    }
+
+    .forms-submission-card__preview {
+        flex-direction: column;
+    }
+
+    .forms-submission-card__field {
+        width: 100%;
+    }
 }
 
 .forms-builder-card {
@@ -8728,56 +9007,6 @@ body.calendar-modal-open {
 .form-submissions-label {
     font-size: 14px;
     color: #6b7280;
-}
-
-#formSubmissionsTable .submission-detail {
-    display: grid;
-    grid-template-columns: 160px 1fr;
-    gap: 4px 16px;
-    margin-bottom: 8px;
-}
-
-#formSubmissionsTable .submission-detail:last-child {
-    margin-bottom: 0;
-}
-
-#formSubmissionsTable .submission-meta-group .submission-detail:last-child {
-    margin-bottom: 0;
-}
-
-#formSubmissionsTable .submission-label {
-    font-weight: 600;
-    color: #1f2937;
-    word-break: break-word;
-}
-
-#formSubmissionsTable .submission-value {
-    color: #374151;
-    word-break: break-word;
-    white-space: pre-wrap;
-}
-
-#formSubmissionsTable .submission-meta-group {
-    margin-top: 16px;
-    padding-top: 12px;
-    border-top: 1px solid #e5e7eb;
-}
-
-#formSubmissionsTable .submission-meta-title {
-    font-size: 12px;
-    font-weight: 600;
-    color: #4b5563;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-bottom: 6px;
-}
-
-#formSubmissionsTable tbody .loading-row td,
-#formSubmissionsTable tbody .empty-row td,
-#formSubmissionsTable tbody .error-row td,
-#formSubmissionsTable tbody .placeholder-row td {
-    color: #6b7280;
-    font-style: italic;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- restyle the form submissions panel to show entries as cards with a refreshed header and count badge
- add a modal workflow for viewing full submission details and metadata without leaving the card grid
- update styling to support the new card layout, loading/empty states, and responsive behaviors

## Testing
- php -l CMS/modules/forms/view.php

------
https://chatgpt.com/codex/tasks/task_e_68daa0ee51c0833187083921f5ddc5e0