### PR TITLE
Organize settings into tabbed sections

### DIFF
--- a/CMS/modules/settings/settings.js
+++ b/CMS/modules/settings/settings.js
@@ -7,6 +7,11 @@ $(function(){
     const $logoPreview = $('#logoPreview');
     const $faviconPreview = $('#faviconPreview');
     const $ogPreview = $('#ogImagePreview');
+    const $tabs = $('.settings-tab');
+    const $tabPanels = $('.settings-tab-panel');
+    const $logoFileLabel = $('#logoFileName');
+    const $faviconFileLabel = $('#faviconFileName');
+    const $ogImageFileLabel = $('#ogImageFileName');
     const $clearLogo = $('#clearLogo');
     const $clearFavicon = $('#clearFavicon');
     const $clearOgImage = $('#clearOgImage');
@@ -33,6 +38,89 @@ $(function(){
             message: 'Enter a valid Facebook Pixel ID using 15-16 digits.'
         }
     ];
+
+    function activateTab($tab, options = {}){
+        if(!$tab || !$tab.length){
+            return;
+        }
+
+        const targetId = $tab.attr('data-tab-target');
+        if(!targetId){
+            return;
+        }
+
+        const shouldFocus = Boolean(options.focus);
+
+        $tabs.each(function(){
+            const $button = $(this);
+            const isActive = $button.is($tab);
+            $button.attr('aria-selected', isActive ? 'true' : 'false')
+                .attr('tabindex', isActive ? '0' : '-1')
+                .toggleClass('is-active', isActive);
+        });
+
+        $tabPanels.each(function(){
+            const $panel = $(this);
+            if($panel.attr('id') === targetId){
+                $panel.removeAttr('hidden');
+            } else {
+                $panel.attr('hidden', true);
+            }
+        });
+
+        if(shouldFocus){
+            $tab.trigger('focus');
+        }
+    }
+
+    function focusAdjacentTab(currentIndex, direction){
+        if(!$tabs.length){
+            return;
+        }
+        const total = $tabs.length;
+        let nextIndex = (currentIndex + direction + total) % total;
+        const $next = $tabs.eq(nextIndex);
+        activateTab($next, { focus: true });
+    }
+
+    function extractFileName(value){
+        if(!value){
+            return '';
+        }
+        if(/^data:/i.test(value)){
+            return 'Uploaded image';
+        }
+        const cleaned = value.split('?')[0];
+        const parts = cleaned.split(/[\\/]/);
+        const candidate = parts.pop();
+        return candidate || value;
+    }
+
+    function getDefaultFileLabel($label){
+        return ($label && $label.data('default')) ? String($label.data('default')) : 'No file selected';
+    }
+
+    function getRemovalFileLabel($label){
+        return ($label && $label.data('remove')) ? String($label.data('remove')) : 'Marked for removal';
+    }
+
+    function refreshFileLabel($checkbox, $label){
+        if(!$label || !$label.length){
+            return;
+        }
+        if($checkbox && $checkbox.is(':checked')){
+            $label.text(getRemovalFileLabel($label));
+            return;
+        }
+        const fileName = $checkbox ? ($checkbox.data('fileName') || '') : '';
+        const fileSource = $checkbox ? ($checkbox.data('fileSource') || 'stored') : 'stored';
+        if(fileName){
+            const prefix = fileSource === 'selected' ? 'Selected' : 'Current';
+            $label.text(`${prefix}: ${fileName}`);
+        } else {
+            $label.text(getDefaultFileLabel($label));
+        }
+    }
 
     function clearFieldError($field){
         if(!$field || !$field.length){
@@ -182,14 +270,16 @@ $(function(){
         }
     }
 
-    function setPreviewState($preview, $checkbox, src){
+    function setPreviewState($preview, $checkbox, src, fileName = '', source = 'stored'){
         const hasSrc = Boolean(src);
         $checkbox.data('previewSrc', hasSrc ? src : '');
+        $checkbox.data('fileName', hasSrc ? fileName : '');
+        $checkbox.data('fileSource', hasSrc ? source : '');
         $checkbox.prop('checked', false).prop('disabled', !hasSrc);
         togglePreview($preview, src);
     }
 
-    function bindClearToggle($checkbox, $preview){
+    function bindClearToggle($checkbox, $preview, $label){
         $checkbox.on('change', function(){
             if(this.checked){
                 togglePreview($preview, '');
@@ -197,12 +287,15 @@ $(function(){
                 const stored = $checkbox.data('previewSrc') || '';
                 togglePreview($preview, stored);
             }
+            if($label){
+                refreshFileLabel($checkbox, $label);
+            }
         });
     }
 
-    bindClearToggle($clearLogo, $logoPreview);
-    bindClearToggle($clearFavicon, $faviconPreview);
-    bindClearToggle($clearOgImage, $ogPreview);
+    bindClearToggle($clearLogo, $logoPreview, $logoFileLabel);
+    bindClearToggle($clearFavicon, $faviconPreview, $faviconFileLabel);
+    bindClearToggle($clearOgImage, $ogPreview, $ogImageFileLabel);
 
     function getDefaultOgTitle(settings){
         const siteName = (settings.site_name || '').trim() || 'SparkCMS';
@@ -248,8 +341,8 @@ $(function(){
             $('#tagline').val(data.tagline || '');
             $('#admin_email').val(data.admin_email || '');
 
-            setPreviewState($logoPreview, $clearLogo, data.logo || '');
-            setPreviewState($faviconPreview, $clearFavicon, data.favicon || '');
+            setPreviewState($logoPreview, $clearLogo, data.logo || '', extractFileName(data.logo), 'stored');
+            setPreviewState($faviconPreview, $clearFavicon, data.favicon || '', extractFileName(data.favicon), 'stored');
 
             $('#timezone').val(data.timezone || 'America/Denver');
             $('#googleAnalytics').val(data.googleAnalytics || '');
@@ -281,7 +374,15 @@ $(function(){
             const ogDescriptionValue = (openGraph.description || '').trim();
             $('#ogTitle').val(ogTitleValue || getDefaultOgTitle(data));
             $('#ogDescription').val(ogDescriptionValue || getDefaultOgDescription(data));
-            setPreviewState($ogPreview, $clearOgImage, openGraph.image || '');
+            setPreviewState($ogPreview, $clearOgImage, openGraph.image || '', extractFileName(openGraph.image), 'stored');
+
+            $('#logoFile').val('');
+            $('#faviconFile').val('');
+            $('#ogImageFile').val('');
+
+            refreshFileLabel($clearLogo, $logoFileLabel);
+            refreshFileLabel($clearFavicon, $faviconFileLabel);
+            refreshFileLabel($clearOgImage, $ogImageFileLabel);
 
             const hostname = (window.location && window.location.hostname) ? window.location.hostname : 'yourdomain.com';
             $socialPreviewDomain.text(hostname);
@@ -298,10 +399,13 @@ $(function(){
         if(file){
             const reader = new FileReader();
             reader.onload = function(e){
-                setPreviewState($logoPreview, $clearLogo, e.target.result);
+                setPreviewState($logoPreview, $clearLogo, e.target.result, file.name, 'selected');
+                refreshFileLabel($clearLogo, $logoFileLabel);
                 updateOverview();
             };
             reader.readAsDataURL(file);
+        } else {
+            refreshFileLabel($clearLogo, $logoFileLabel);
         }
     });
 
@@ -310,9 +414,12 @@ $(function(){
         if(file){
             const reader = new FileReader();
             reader.onload = function(e){
-                setPreviewState($faviconPreview, $clearFavicon, e.target.result);
+                setPreviewState($faviconPreview, $clearFavicon, e.target.result, file.name, 'selected');
+                refreshFileLabel($clearFavicon, $faviconFileLabel);
             };
             reader.readAsDataURL(file);
+        } else {
+            refreshFileLabel($clearFavicon, $faviconFileLabel);
         }
     });
 
@@ -321,11 +428,53 @@ $(function(){
         if(file){
             const reader = new FileReader();
             reader.onload = function(e){
-                setPreviewState($ogPreview, $clearOgImage, e.target.result);
+                setPreviewState($ogPreview, $clearOgImage, e.target.result, file.name, 'selected');
+                refreshFileLabel($clearOgImage, $ogImageFileLabel);
             };
             reader.readAsDataURL(file);
+        } else {
+            refreshFileLabel($clearOgImage, $ogImageFileLabel);
         }
     });
+
+    $('.settings-file-trigger').on('click', function(event){
+        event.preventDefault();
+        const targetId = $(this).attr('data-input-target');
+        if(!targetId){
+            return;
+        }
+        const $targetInput = $(`#${targetId}`);
+        if($targetInput.length){
+            $targetInput.trigger('click');
+        }
+    });
+
+    if($tabs.length){
+        const $initialTab = $tabs.filter('[aria-selected="true"]').first();
+        activateTab($initialTab.length ? $initialTab : $tabs.first());
+
+        $tabs.on('click', function(){
+            activateTab($(this));
+        });
+
+        $tabs.on('keydown', function(event){
+            const key = event.key;
+            const index = $tabs.index(this);
+            if(key === 'ArrowRight' || key === 'ArrowDown'){
+                event.preventDefault();
+                focusAdjacentTab(index, 1);
+            } else if(key === 'ArrowLeft' || key === 'ArrowUp'){
+                event.preventDefault();
+                focusAdjacentTab(index, -1);
+            } else if(key === 'Home'){
+                event.preventDefault();
+                activateTab($tabs.first(), { focus: true });
+            } else if(key === 'End'){
+                event.preventDefault();
+                activateTab($tabs.last(), { focus: true });
+            }
+        });
+    }
 
     $form.on('input change', 'input, textarea, select', function(){
         clearFieldError($(this));

--- a/CMS/modules/settings/view.php
+++ b/CMS/modules/settings/view.php
@@ -40,206 +40,280 @@
                 </div>
             </header>
 
-            <section class="a11y-detail-grid settings-grid" aria-label="Settings sections">
-                <article class="a11y-detail-card">
-                    <h2>Branding &amp; Basics</h2>
-                    <p class="settings-card-description">Control the essentials that shape how your site appears to visitors.</p>
-                    <div class="form-group">
-                        <label class="form-label" for="site_name">Site Name</label>
-                        <input type="text" class="form-input" name="site_name" id="site_name" autocomplete="organization">
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="tagline">Tagline</label>
-                        <input type="text" class="form-input" name="tagline" id="tagline" autocomplete="off">
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="admin_email">Admin Email</label>
-                        <input type="email" class="form-input" name="admin_email" id="admin_email" autocomplete="email">
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="logoFile">Site Logo</label>
-                        <div class="settings-file-input">
-                            <input type="file" class="form-input" id="logoFile" name="logo" accept="image/*">
-                            <img id="logoPreview" class="settings-file-preview" src="" alt="Logo preview" hidden>
-                        </div>
-                        <div class="form-option">
-                            <label class="form-checkbox">
-                                <input type="checkbox" id="clearLogo" name="clear_logo" value="1">
-                                <span>Remove current logo</span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="faviconFile">Site Favicon</label>
-                        <div class="settings-file-input">
-                            <input type="file" class="form-input" id="faviconFile" name="favicon" accept="image/png,image/jpeg,image/gif,image/webp,image/x-icon,image/vnd.microsoft.icon,image/svg+xml,.ico">
-                            <img id="faviconPreview" class="settings-file-preview" src="" alt="Favicon preview" hidden>
-                        </div>
-                        <div class="form-option">
-                            <label class="form-checkbox">
-                                <input type="checkbox" id="clearFavicon" name="clear_favicon" value="1">
-                                <span>Remove current favicon</span>
-                            </label>
-                        </div>
-                        <div class="form-help">Upload a square image (PNG, ICO, or SVG) at least 32×32 pixels.</div>
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="timezone">Timezone</label>
-                        <select class="form-select" id="timezone" name="timezone">
-                            <option value="America/New_York">Eastern Time (ET)</option>
-                            <option value="America/Chicago">Central Time (CT)</option>
-                            <option value="America/Denver" selected>Mountain Time (MT)</option>
-                            <option value="America/Los_Angeles">Pacific Time (PT)</option>
-                            <option value="UTC">UTC</option>
-                        </select>
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="googleAnalytics">Google Analytics ID</label>
-                        <input type="text" class="form-input" id="googleAnalytics" name="googleAnalytics" placeholder="G-XXXXXXXXXX or UA-XXXXXXXX-X">
-                        <div class="form-help">Your Google Analytics measurement ID.</div>
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="googleSearchConsole">Google Search Console Verification Code</label>
-                        <input type="text" class="form-input" id="googleSearchConsole" name="googleSearchConsole" placeholder="google-site-verification=...">
-                        <div class="form-help">Meta tag verification code from Google Search Console.</div>
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="facebookPixel">Facebook Pixel ID</label>
-                        <input type="text" class="form-input" id="facebookPixel" name="facebookPixel" placeholder="1234567890123456">
-                        <div class="form-help">Your Facebook Pixel ID for conversion tracking.</div>
-                    </div>
-                    <div class="settings-toggle-group" role="group" aria-label="Search visibility preferences">
-                        <label class="settings-toggle">
-                            <input type="checkbox" id="generateSitemap" name="generateSitemap" checked>
-                            <div>
-                                <span class="settings-toggle__title">Auto-generate XML sitemap</span>
-                                <p class="settings-toggle__description">Keep search engines in sync with your latest pages.</p>
-                            </div>
-                        </label>
-                        <label class="settings-toggle">
-                            <input type="checkbox" id="allowIndexing" name="allowIndexing" checked>
-                            <div>
-                                <span class="settings-toggle__title">Allow search indexing</span>
-                                <p class="settings-toggle__description">Let search engines discover and list your site.</p>
-                            </div>
-                        </label>
-                    </div>
-                </article>
+            <section class="settings-layout" aria-label="Settings sections">
+                <nav class="settings-tabs" role="tablist" aria-label="Settings categories">
+                    <button type="button" class="a11y-btn a11y-btn--secondary settings-tab" role="tab" aria-selected="true" aria-controls="settings-tab-branding" id="settings-tab-branding-tab" data-tab-target="settings-tab-branding">
+                        <i class="fas fa-palette" aria-hidden="true"></i>
+                        <span>Branding</span>
+                    </button>
+                    <button type="button" class="a11y-btn a11y-btn--secondary settings-tab" role="tab" aria-selected="false" aria-controls="settings-tab-seo" id="settings-tab-seo-tab" data-tab-target="settings-tab-seo" tabindex="-1">
+                        <i class="fas fa-share-alt" aria-hidden="true"></i>
+                        <span>SEO &amp; Social</span>
+                    </button>
+                    <button type="button" class="a11y-btn a11y-btn--secondary settings-tab" role="tab" aria-selected="false" aria-controls="settings-tab-analytics" id="settings-tab-analytics-tab" data-tab-target="settings-tab-analytics" tabindex="-1">
+                        <i class="fas fa-chart-line" aria-hidden="true"></i>
+                        <span>Analytics</span>
+                    </button>
+                </nav>
 
-                <article class="a11y-detail-card">
-                    <h2>Social Profiles</h2>
-                    <p class="settings-card-description">Connect your brand channels to power sharing and automation.</p>
-                    <div class="settings-social-grid">
-                        <div class="form-group">
-                            <label class="form-label" for="facebookLink">Facebook</label>
-                            <input type="url" class="form-input" id="facebookLink" name="facebook" placeholder="https://facebook.com/yourpage">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="twitterLink">Twitter</label>
-                            <input type="url" class="form-input" id="twitterLink" name="twitter" placeholder="https://twitter.com/youraccount">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="instagramLink">Instagram</label>
-                            <input type="url" class="form-input" id="instagramLink" name="instagram" placeholder="https://instagram.com/youraccount">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="linkedinLink">LinkedIn</label>
-                            <input type="url" class="form-input" id="linkedinLink" name="linkedin" placeholder="https://linkedin.com/company/yourcompany">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="youtubeLink">YouTube</label>
-                            <input type="url" class="form-input" id="youtubeLink" name="youtube" placeholder="https://youtube.com/c/yourchannel">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="tiktokLink">TikTok</label>
-                            <input type="url" class="form-input" id="tiktokLink" name="tiktok" placeholder="https://tiktok.com/@youraccount">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="pinterestLink">Pinterest</label>
-                            <input type="url" class="form-input" id="pinterestLink" name="pinterest" placeholder="https://pinterest.com/yourprofile">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="snapchatLink">Snapchat</label>
-                            <input type="url" class="form-input" id="snapchatLink" name="snapchat" placeholder="https://snapchat.com/add/yourusername">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="redditLink">Reddit</label>
-                            <input type="url" class="form-input" id="redditLink" name="reddit" placeholder="https://reddit.com/u/yourusername">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="threadsLink">Threads</label>
-                            <input type="url" class="form-input" id="threadsLink" name="threads" placeholder="https://threads.net/@yourusername">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="mastodonLink">Mastodon</label>
-                            <input type="url" class="form-input" id="mastodonLink" name="mastodon" placeholder="https://mastodon.social/@yourusername">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="githubLink">GitHub</label>
-                            <input type="url" class="form-input" id="githubLink" name="github" placeholder="https://github.com/yourusername">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="dribbbleLink">Dribbble</label>
-                            <input type="url" class="form-input" id="dribbbleLink" name="dribbble" placeholder="https://dribbble.com/yourprofile">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="twitchLink">Twitch</label>
-                            <input type="url" class="form-input" id="twitchLink" name="twitch" placeholder="https://twitch.tv/yourchannel">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-label" for="whatsappLink">WhatsApp</label>
-                            <input type="url" class="form-input" id="whatsappLink" name="whatsapp" placeholder="https://wa.me/yourphonenumber">
-                        </div>
-                    </div>
-                </article>
+                <div class="settings-tab-panels">
+                    <section id="settings-tab-branding" class="settings-tab-panel" role="tabpanel" aria-labelledby="settings-tab-branding-tab">
+                        <article class="a11y-detail-card">
+                            <h2>Branding &amp; Basics</h2>
+                            <p class="settings-card-description">Control the essentials that shape how your site appears to visitors.</p>
 
-                <article class="a11y-detail-card">
-                    <h2>Open Graph Defaults</h2>
-                    <p class="settings-card-description">Define how your pages look when shared across social platforms.</p>
-                    <div class="form-group">
-                        <label class="form-label" for="ogTitle">Default Share Title</label>
-                        <input type="text" class="form-input" id="ogTitle" name="ogTitle" placeholder="My Awesome Website">
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="ogDescription">Default Share Description</label>
-                        <textarea class="form-textarea" id="ogDescription" name="ogDescription" rows="4" placeholder="Give people a compelling reason to click."></textarea>
-                    </div>
-                    <div class="form-group">
-                        <label class="form-label" for="ogImageFile">Default Share Image</label>
-                        <div class="settings-file-input">
-                            <input type="file" id="ogImageFile" name="ogImage" accept="image/*">
-                            <img id="ogImagePreview" class="settings-file-preview" src="" alt="Open graph image preview" hidden>
-                        </div>
-                        <div class="form-option">
-                            <label class="form-checkbox">
-                                <input type="checkbox" id="clearOgImage" name="clear_og_image" value="1">
-                                <span>Remove current image</span>
-                            </label>
-                        </div>
-                        <div class="form-help">Upload a 1200 × 630px image for social sharing cards.</div>
-                    </div>
-
-                    <div class="social-preview" id="socialSharePreview">
-                        <div class="social-preview-header">
-                            <h3 class="social-preview-heading">Live Share Preview</h3>
-                            <p class="social-preview-subheading">See how your default Open Graph content appears on social platforms.</p>
-                        </div>
-                        <div class="social-preview-card" role="presentation">
-                            <div class="social-preview-media">
-                                <img id="socialPreviewImage" alt="Social share image preview" hidden>
-                                <div class="social-preview-media__fallback" id="socialPreviewImageFallback">
-                                    <span class="social-preview-media__icon"><i class="fas fa-image" aria-hidden="true"></i></span>
-                                    <span class="social-preview-media__text">1200 × 630</span>
+                            <details class="settings-accordion" open>
+                                <summary>Brand identity</summary>
+                                <div class="settings-accordion__body">
+                                    <div class="form-group">
+                                        <label class="form-label" for="site_name">Site Name</label>
+                                        <input type="text" class="form-input" name="site_name" id="site_name" autocomplete="organization">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="tagline">Tagline</label>
+                                        <input type="text" class="form-input" name="tagline" id="tagline" autocomplete="off">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="admin_email">Admin Email</label>
+                                        <input type="email" class="form-input" name="admin_email" id="admin_email" autocomplete="email">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="timezone">Timezone</label>
+                                        <select class="form-select" id="timezone" name="timezone">
+                                            <option value="America/New_York">Eastern Time (ET)</option>
+                                            <option value="America/Chicago">Central Time (CT)</option>
+                                            <option value="America/Denver" selected>Mountain Time (MT)</option>
+                                            <option value="America/Los_Angeles">Pacific Time (PT)</option>
+                                            <option value="UTC">UTC</option>
+                                        </select>
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="social-preview-body">
-                                <span class="social-preview-domain" id="socialPreviewDomain"></span>
-                                <h4 class="social-preview-title" id="socialPreviewTitle">My Awesome Website</h4>
-                                <p class="social-preview-description" id="socialPreviewDescription">Give people a compelling reason to click.</p>
-                            </div>
-                        </div>
-                    </div>
-                </article>
+                            </details>
+
+                            <details class="settings-accordion" open>
+                                <summary>Brand assets</summary>
+                                <div class="settings-accordion__body">
+                                    <div class="form-group">
+                                        <label class="form-label" for="logoFile">Site Logo</label>
+                                        <div class="settings-file-input">
+                                            <input type="file" class="settings-file-input__field" id="logoFile" name="logo" accept="image/*">
+                                            <button type="button" class="a11y-btn a11y-btn--secondary settings-file-trigger" data-input-target="logoFile">
+                                                <i class="fas fa-upload" aria-hidden="true"></i>
+                                                <span>Select logo</span>
+                                            </button>
+                                            <span class="settings-file-name" id="logoFileName" data-default="No file selected" data-remove="Marked for removal">No file selected</span>
+                                            <img id="logoPreview" class="settings-file-preview" src="" alt="Logo preview" hidden>
+                                        </div>
+                                        <div class="form-option">
+                                            <label class="form-checkbox">
+                                                <input type="checkbox" id="clearLogo" name="clear_logo" value="1">
+                                                <span>Remove current logo</span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="faviconFile">Site Favicon</label>
+                                        <div class="settings-file-input">
+                                            <input type="file" class="settings-file-input__field" id="faviconFile" name="favicon" accept="image/png,image/jpeg,image/gif,image/webp,image/x-icon,image/vnd.microsoft.icon,image/svg+xml,.ico">
+                                            <button type="button" class="a11y-btn a11y-btn--secondary settings-file-trigger" data-input-target="faviconFile">
+                                                <i class="fas fa-upload" aria-hidden="true"></i>
+                                                <span>Select favicon</span>
+                                            </button>
+                                            <span class="settings-file-name" id="faviconFileName" data-default="No file selected" data-remove="Marked for removal">No file selected</span>
+                                            <img id="faviconPreview" class="settings-file-preview" src="" alt="Favicon preview" hidden>
+                                        </div>
+                                        <div class="form-option">
+                                            <label class="form-checkbox">
+                                                <input type="checkbox" id="clearFavicon" name="clear_favicon" value="1">
+                                                <span>Remove current favicon</span>
+                                            </label>
+                                        </div>
+                                        <div class="form-help">Upload a square image (PNG, ICO, or SVG) at least 32×32 pixels.</div>
+                                    </div>
+                                </div>
+                            </details>
+                        </article>
+                    </section>
+
+                    <section id="settings-tab-seo" class="settings-tab-panel" role="tabpanel" aria-labelledby="settings-tab-seo-tab" hidden>
+                        <article class="a11y-detail-card">
+                            <h2>SEO &amp; Social</h2>
+                            <p class="settings-card-description">Connect your brand channels to power sharing and automation.</p>
+
+                            <details class="settings-accordion" open>
+                                <summary>Search optimization</summary>
+                                <div class="settings-accordion__body">
+                                    <div class="form-group">
+                                        <label class="form-label" for="googleSearchConsole">Google Search Console Verification Code</label>
+                                        <input type="text" class="form-input" id="googleSearchConsole" name="googleSearchConsole" placeholder="google-site-verification=...">
+                                        <div class="form-help">Meta tag verification code from Google Search Console.</div>
+                                    </div>
+                                    <div class="settings-toggle-group" role="group" aria-label="Search visibility preferences">
+                                        <label class="settings-toggle">
+                                            <input type="checkbox" id="generateSitemap" name="generateSitemap" checked>
+                                            <div>
+                                                <span class="settings-toggle__title">Auto-generate XML sitemap</span>
+                                                <p class="settings-toggle__description">Keep search engines in sync with your latest pages.</p>
+                                            </div>
+                                        </label>
+                                        <label class="settings-toggle">
+                                            <input type="checkbox" id="allowIndexing" name="allowIndexing" checked>
+                                            <div>
+                                                <span class="settings-toggle__title">Allow search indexing</span>
+                                                <p class="settings-toggle__description">Let search engines discover and list your site.</p>
+                                            </div>
+                                        </label>
+                                    </div>
+                                </div>
+                            </details>
+
+                            <details class="settings-accordion">
+                                <summary>Social profiles</summary>
+                                <div class="settings-accordion__body">
+                                    <div class="settings-social-grid">
+                                        <div class="form-group">
+                                            <label class="form-label" for="facebookLink">Facebook</label>
+                                            <input type="url" class="form-input" id="facebookLink" name="facebook" placeholder="https://facebook.com/yourpage">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="twitterLink">Twitter</label>
+                                            <input type="url" class="form-input" id="twitterLink" name="twitter" placeholder="https://twitter.com/youraccount">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="instagramLink">Instagram</label>
+                                            <input type="url" class="form-input" id="instagramLink" name="instagram" placeholder="https://instagram.com/youraccount">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="linkedinLink">LinkedIn</label>
+                                            <input type="url" class="form-input" id="linkedinLink" name="linkedin" placeholder="https://linkedin.com/company/yourcompany">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="youtubeLink">YouTube</label>
+                                            <input type="url" class="form-input" id="youtubeLink" name="youtube" placeholder="https://youtube.com/c/yourchannel">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="tiktokLink">TikTok</label>
+                                            <input type="url" class="form-input" id="tiktokLink" name="tiktok" placeholder="https://tiktok.com/@youraccount">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="pinterestLink">Pinterest</label>
+                                            <input type="url" class="form-input" id="pinterestLink" name="pinterest" placeholder="https://pinterest.com/yourprofile">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="snapchatLink">Snapchat</label>
+                                            <input type="url" class="form-input" id="snapchatLink" name="snapchat" placeholder="https://snapchat.com/add/yourusername">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="redditLink">Reddit</label>
+                                            <input type="url" class="form-input" id="redditLink" name="reddit" placeholder="https://reddit.com/u/yourusername">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="threadsLink">Threads</label>
+                                            <input type="url" class="form-input" id="threadsLink" name="threads" placeholder="https://threads.net/@yourusername">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="mastodonLink">Mastodon</label>
+                                            <input type="url" class="form-input" id="mastodonLink" name="mastodon" placeholder="https://mastodon.social/@yourusername">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="githubLink">GitHub</label>
+                                            <input type="url" class="form-input" id="githubLink" name="github" placeholder="https://github.com/yourusername">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="dribbbleLink">Dribbble</label>
+                                            <input type="url" class="form-input" id="dribbbleLink" name="dribbble" placeholder="https://dribbble.com/yourprofile">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="twitchLink">Twitch</label>
+                                            <input type="url" class="form-input" id="twitchLink" name="twitch" placeholder="https://twitch.tv/yourchannel">
+                                        </div>
+                                        <div class="form-group">
+                                            <label class="form-label" for="whatsappLink">WhatsApp</label>
+                                            <input type="url" class="form-input" id="whatsappLink" name="whatsapp" placeholder="https://wa.me/yourphonenumber">
+                                        </div>
+                                    </div>
+                                </div>
+                            </details>
+
+                            <details class="settings-accordion" open>
+                                <summary>Share defaults</summary>
+                                <div class="settings-accordion__body">
+                                    <div class="form-group">
+                                        <label class="form-label" for="ogTitle">Default Share Title</label>
+                                        <input type="text" class="form-input" id="ogTitle" name="ogTitle" placeholder="My Awesome Website">
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="ogDescription">Default Share Description</label>
+                                        <textarea class="form-textarea" id="ogDescription" name="ogDescription" rows="4" placeholder="Give people a compelling reason to click."></textarea>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="ogImageFile">Default Share Image</label>
+                                        <div class="settings-file-input">
+                                            <input type="file" id="ogImageFile" name="ogImage" class="settings-file-input__field" accept="image/*">
+                                            <button type="button" class="a11y-btn a11y-btn--secondary settings-file-trigger" data-input-target="ogImageFile">
+                                                <i class="fas fa-upload" aria-hidden="true"></i>
+                                                <span>Select image</span>
+                                            </button>
+                                            <span class="settings-file-name" id="ogImageFileName" data-default="No file selected" data-remove="Marked for removal">No file selected</span>
+                                            <img id="ogImagePreview" class="settings-file-preview" src="" alt="Open graph image preview" hidden>
+                                        </div>
+                                        <div class="form-option">
+                                            <label class="form-checkbox">
+                                                <input type="checkbox" id="clearOgImage" name="clear_og_image" value="1">
+                                                <span>Remove current image</span>
+                                            </label>
+                                        </div>
+                                        <div class="form-help">Upload a 1200 × 630px image for social sharing cards.</div>
+                                    </div>
+
+                                    <div class="social-preview" id="socialSharePreview">
+                                        <div class="social-preview-header">
+                                            <h3 class="social-preview-heading">Live Share Preview</h3>
+                                            <p class="social-preview-subheading">See how your default Open Graph content appears on social platforms.</p>
+                                        </div>
+                                        <div class="social-preview-card" role="presentation">
+                                            <div class="social-preview-media">
+                                                <img id="socialPreviewImage" alt="Social share image preview" hidden>
+                                                <div class="social-preview-media__fallback" id="socialPreviewImageFallback">
+                                                    <span class="social-preview-media__icon"><i class="fas fa-image" aria-hidden="true"></i></span>
+                                                    <span class="social-preview-media__text">1200 × 630</span>
+                                                </div>
+                                            </div>
+                                            <div class="social-preview-body">
+                                                <span class="social-preview-domain" id="socialPreviewDomain"></span>
+                                                <h4 class="social-preview-title" id="socialPreviewTitle">My Awesome Website</h4>
+                                                <p class="social-preview-description" id="socialPreviewDescription">Give people a compelling reason to click.</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </details>
+                        </article>
+                    </section>
+
+                    <section id="settings-tab-analytics" class="settings-tab-panel" role="tabpanel" aria-labelledby="settings-tab-analytics-tab" hidden>
+                        <article class="a11y-detail-card">
+                            <h2>Analytics &amp; Tracking</h2>
+                            <p class="settings-card-description">Centralize your analytics IDs and tracking pixels for quick management.</p>
+
+                            <details class="settings-accordion" open>
+                                <summary>Analytics providers</summary>
+                                <div class="settings-accordion__body">
+                                    <div class="form-group">
+                                        <label class="form-label" for="googleAnalytics">Google Analytics ID</label>
+                                        <input type="text" class="form-input" id="googleAnalytics" name="googleAnalytics" placeholder="G-XXXXXXX-XX or UA-XXXXXXXX-X">
+                                        <div class="form-help">Your Google Analytics measurement ID.</div>
+                                    </div>
+                                    <div class="form-group">
+                                        <label class="form-label" for="facebookPixel">Facebook Pixel ID</label>
+                                        <input type="text" class="form-input" id="facebookPixel" name="facebookPixel" placeholder="1234567890123456">
+                                        <div class="form-help">Your Facebook Pixel ID for conversion tracking.</div>
+                                    </div>
+                                </div>
+                            </details>
+                        </article>
+                    </section>
+                </div>
             </section>
         </div>
     </form>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -4300,11 +4300,131 @@
             font-size: 14px;
         }
 
+        .settings-layout {
+            display: grid;
+            gap: 24px;
+        }
+
+        .settings-tabs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        .settings-tab {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            border-radius: 999px;
+            padding-inline: 18px;
+            transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+        }
+
+        .settings-tab[aria-selected="true"] {
+            background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+            color: var(--color-text-inverse);
+            box-shadow: 0 12px 32px rgba(99, 102, 241, 0.24);
+        }
+
+        .settings-tab[aria-selected="true"]:hover {
+            transform: translateY(-1px);
+        }
+
+        .settings-tab-panel {
+            display: block;
+        }
+
+        .settings-tab-panel[hidden] {
+            display: none;
+        }
+
+        .settings-accordion {
+            border: 1px solid #e2e8f0;
+            border-radius: 16px;
+            margin: 16px 0;
+            background: #fff;
+            overflow: hidden;
+        }
+
+        .settings-accordion:first-of-type {
+            margin-top: 0;
+        }
+
+        .settings-accordion:last-of-type {
+            margin-bottom: 0;
+        }
+
+        .settings-accordion > summary {
+            cursor: pointer;
+            list-style: none;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 18px 24px;
+            font-weight: 600;
+            color: #0f172a;
+        }
+
+        .settings-accordion > summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .settings-accordion > summary::after {
+            content: "\f107";
+            font-family: "Font Awesome 5 Free";
+            font-weight: 900;
+            font-size: 14px;
+            color: #64748b;
+            transition: transform 0.2s ease;
+        }
+
+        .settings-accordion[open] > summary::after {
+            transform: rotate(180deg);
+        }
+
+        .settings-accordion__body {
+            padding: 0 24px 24px;
+            display: grid;
+            gap: 18px;
+        }
+
         .settings-file-input {
             display: flex;
             align-items: center;
             gap: 16px;
             flex-wrap: wrap;
+        }
+
+        .settings-file-input__field {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            border: 0;
+            clip: rect(0 0 0 0);
+            clip-path: inset(50%);
+            overflow: hidden;
+            white-space: nowrap;
+        }
+
+        .settings-file-trigger {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+        }
+
+        .settings-file-trigger:hover,
+        .settings-file-trigger:focus-visible {
+            background: #e2e8f0;
+            color: #0f172a;
+        }
+
+        .settings-file-name {
+            font-size: 13px;
+            color: #475569;
         }
 
         .settings-file-preview {


### PR DESCRIPTION
## Summary
- group the settings dashboard into tabbed panels with collapsible accordions
- add custom call-to-action file upload buttons with live filename feedback and previews
- update settings scripts to drive tab switching, file label state, and new triggers

## Testing
- php -S 0.0.0.0:8000


------
https://chatgpt.com/codex/tasks/task_e_68daa0f51b84833193f9dea93d4355b1