### PR TITLE
Align forms library card actions with other modules

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -628,21 +628,12 @@ $(function(){
                 $card.data('formName', formName);
 
                 const $header = $('<div class="forms-card__header"></div>');
+                const $heading = $('<div class="forms-card__heading"></div>');
                 const $title = $('<h4 class="forms-card__title"></h4>').text(formName);
                 const $badge = $('<span class="forms-card__badge" aria-label="'+escapeHtml(fieldLabel)+'"></span>');
                 $badge.append('<i class="fas fa-layer-group" aria-hidden="true"></i>');
                 $badge.append('<span>'+escapeHtml(fieldLabel)+'</span>');
-                $header.append($title).append($badge);
-                $card.append($header);
-
-                if(f.id){
-                    const $meta = $('<div class="forms-card__meta"></div>');
-                    const $metaItem = $('<span class="forms-card__meta-item"></span>');
-                    $metaItem.append('<i class="fas fa-hashtag" aria-hidden="true"></i>');
-                    $metaItem.append('<span>Form ID '+escapeHtml(String(f.id))+'</span>');
-                    $meta.append($metaItem);
-                    $card.append($meta);
-                }
+                $heading.append($title).append($badge);
 
                 const $actions = $('<div class="forms-card__actions" role="group" aria-label="Form actions"></div>');
                 const $viewBtn = $('<button type="button" class="a11y-btn a11y-btn--ghost forms-card__action" data-action="view-submissions"></button>');
@@ -655,7 +646,18 @@ $(function(){
                 $deleteBtn.append('<i class="fas fa-trash" aria-hidden="true"></i>');
                 $deleteBtn.append('<span>Delete</span>');
                 $actions.append($viewBtn, $editBtn, $deleteBtn);
-                $card.append($actions);
+
+                $header.append($heading).append($actions);
+                $card.append($header);
+
+                if(f.id){
+                    const $meta = $('<div class="forms-card__meta"></div>');
+                    const $metaItem = $('<span class="forms-card__meta-item"></span>');
+                    $metaItem.append('<i class="fas fa-hashtag" aria-hidden="true"></i>');
+                    $metaItem.append('<span>Form ID '+escapeHtml(String(f.id))+'</span>');
+                    $meta.append($metaItem);
+                    $card.append($meta);
+                }
 
                 if($formsGrid.length){
                     $formsGrid.append($card);

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -9232,7 +9232,14 @@ body.calendar-modal-open {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    gap: 16px;
+    gap: 24px;
+}
+
+.forms-card__heading {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-width: 0;
 }
 
 .forms-card__title {
@@ -9292,7 +9299,9 @@ body.calendar-modal-open {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
-    margin-top: 18px;
+    margin-top: 0;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .forms-card__action {
@@ -9332,7 +9341,9 @@ body.calendar-modal-open {
     }
 
     .forms-card__actions {
+        justify-content: flex-start;
         width: 100%;
+        margin-top: 12px;
     }
 
     .forms-card__actions .a11y-btn {


### PR DESCRIPTION
## Summary
- move the forms library card actions into the card header so the primary controls stay in a consistent spot
- update the card layout styles to support the new action placement and responsive spacing

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dade6881a88331a0b8c394a7a5318c