### PR TITLE
Remove extra styling from accessibility sort group

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -3283,10 +3283,10 @@
             align-items: center;
             gap: 6px;
             padding: 6px;
-            border: 1px solid #e2e8f0;
+            border: none;
             border-radius: 12px;
-            background: #fff;
-            box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+            background: transparent;
+            box-shadow: none;
         }
 
         .a11y-sort-group label {


### PR DESCRIPTION
## Summary
- remove the border, background, and box shadow from the accessibility sort group styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf763cea0833183f0f7a3d57d44c5