### PR TITLE
Update SEO scan all button to refresh dashboard stats

### DIFF
--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -722,7 +722,7 @@ $dashboardStats = [
                     </button>
                     <span class="seo-hero-meta">
                         <i class="fas fa-clock" aria-hidden="true"></i>
-                        Last scan: <?php echo htmlspecialchars($lastScan); ?>
+                        Last scan: <span class="seo-last-scan-value"><?php echo htmlspecialchars($lastScan); ?></span>
                     </span>
                 </div>
             </div>
@@ -875,7 +875,7 @@ $dashboardStats = [
         </div>
 
         <footer class="seo-dashboard-footer">
-            <p>SEO data last analysed on <?php echo htmlspecialchars($lastScan); ?>. Refresh the scan whenever you publish new content or update templates.</p>
+            <p>SEO data last analysed on <span class="seo-last-scan-value"><?php echo htmlspecialchars($lastScan); ?></span>. Refresh the scan whenever you publish new content or update templates.</p>
         </footer>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- replace the Scan All Pages alert with a simulated rescan that recalculates dashboard stats and updates the last scan timestamp
- wrap the last scan timestamp in reusable spans so the refreshed value is reflected across the dashboard

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf72f92708331a1f8120b83d54be4