### PR TITLE
Add calendar search and sort filters

### DIFF
--- a/CMS/modules/calendar/view.php
+++ b/CMS/modules/calendar/view.php
@@ -134,12 +134,26 @@ $initialPayload = [
                     <h3>Event library</h3>
                     <p>Review upcoming and past events, update details, or remove outdated sessions.</p>
                 </div>
+                <div class="calendar-table-controls">
+                    <label class="calendar-search" for="calendarEventSearch">
+                        <span class="sr-only">Search events</span>
+                        <input type="search" id="calendarEventSearch" placeholder="Search events" data-calendar-filter="search">
+                    </label>
+                    <label class="calendar-sort" for="calendarEventSort">
+                        <span class="sr-only">Sort events</span>
+                        <select id="calendarEventSort" data-calendar-filter="sort">
+                            <option value="startAsc">Start date (ascending)</option>
+                            <option value="startDesc">Start date (descending)</option>
+                            <option value="titleAsc">Title (A–Z)</option>
+                            <option value="titleDesc">Title (Z–A)</option>
+                        </select>
+                    </label>
+                </div>
             </header>
             <div class="calendar-table-wrapper">
                 <table class="data-table calendar-table">
                     <thead>
                         <tr>
-                            <th class="is-id-column">ID</th>
                             <th>Title</th>
                             <th>Start</th>
                             <th>End</th>
@@ -150,7 +164,7 @@ $initialPayload = [
                     </thead>
                     <tbody data-calendar-events>
                         <tr>
-                            <td colspan="7" class="calendar-empty">Loading events…</td>
+                            <td colspan="6" class="calendar-empty">Loading events…</td>
                         </tr>
                     </tbody>
                 </table>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -8878,6 +8878,41 @@
     margin-bottom: 0;
 }
 
+.calendar-table-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+.calendar-table-controls label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.calendar-table-controls input[type="search"],
+.calendar-table-controls select {
+    border: 1px solid #d1d5db;
+    border-radius: 999px;
+    padding: 8px 14px;
+    font-size: 14px;
+    background: #fff;
+    color: #1f2937;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-table-controls input[type="search"]:focus,
+.calendar-table-controls select:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.calendar-table-controls select {
+    padding-right: 36px;
+}
+
 .calendar-card-header h3 {
     margin: 0;
     font-size: 20px;
@@ -8906,10 +8941,6 @@
 .calendar-table th,
 .calendar-table td {
     white-space: nowrap;
-}
-
-.calendar-table th.is-id-column {
-    width: 72px;
 }
 
 .calendar-table th.is-actions-column {


### PR DESCRIPTION
## Summary
- add search input and sort dropdown to the calendar event library and hide the ID column
- extend calendar JavaScript to filter and sort events client-side while preserving existing metrics updates
- style the new controls and adjust table empty states for the slimmer column layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafc475b08833197ca5d318198905c