### PR TITLE
Increase default blog post list size

### DIFF
--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -56,7 +56,7 @@
   function parseLimit(value) {
     var limit = parseInt(value, 10);
     if (!Number.isFinite(limit) || limit < 1) {
-      return 3;
+      return 6;
     }
     return limit;
   }

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -54,7 +54,7 @@
   function parseLimit(value) {
     var limit = parseInt(value, 10);
     if (!Number.isFinite(limit) || limit < 1) {
-      return 3;
+      return 6;
     }
     return limit;
   }

--- a/theme/templates/blocks/blog.post-list.php
+++ b/theme/templates/blocks/blog.post-list.php
@@ -18,9 +18,9 @@
         <dt>Number of Posts</dt>
         <dd>
             <select name="custom_limit" class="form-select">
-                <option value="3" selected>3 Posts</option>
+                <option value="3">3 Posts</option>
                 <option value="4">4 Posts</option>
-                <option value="6">6 Posts</option>
+                <option value="6" selected>6 Posts</option>
                 <option value="9">9 Posts</option>
                 <option value="12">12 Posts</option>
             </select>


### PR DESCRIPTION
## Summary
- update the blog list block to default to showing six posts
- adjust the blog list JavaScript fallback limit to match the new default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db02c9c6c48331b50ff8a7e8ec095e