### PR TITLE
Align SEO module sorting controls with performance dashboard

### DIFF
--- a/CMS/modules/seo/view.php
+++ b/CMS/modules/seo/view.php
@@ -758,21 +758,15 @@ $dashboardStats = [
                 <button type="button" class="a11y-filter-btn" data-seo-filter="optimized">Optimised <span class="a11y-filter-count" data-count="optimized"><?php echo $filterCounts['optimized']; ?></span></button>
             </div>
             <div class="a11y-sort-group" role="group" aria-label="Sort pages">
-                <button type="button" class="a11y-sort-btn active" data-seo-sort="score-desc">
-                    <i class="fas fa-sort-amount-down" aria-hidden="true"></i>
-                    <span>Score (High–Low)</span>
-                </button>
-                <button type="button" class="a11y-sort-btn" data-seo-sort="score-asc">
-                    <i class="fas fa-sort-amount-up" aria-hidden="true"></i>
-                    <span>Score (Low–High)</span>
-                </button>
-                <button type="button" class="a11y-sort-btn" data-seo-sort="issues-desc">
-                    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>
-                    <span>Most Issues</span>
-                </button>
-                <button type="button" class="a11y-sort-btn" data-seo-sort="title-asc">
-                    <i class="fas fa-sort-alpha-down" aria-hidden="true"></i>
-                    <span>Title (A–Z)</span>
+                <label for="seoSortSelect">Sort by</label>
+                <select id="seoSortSelect">
+                    <option value="score" selected>SEO score</option>
+                    <option value="title">Title</option>
+                    <option value="issues">Total issues</option>
+                </select>
+                <button type="button" class="a11y-sort-direction" id="seoSortDirection" data-direction="desc" aria-label="Toggle sort direction (High to low)" aria-pressed="true">
+                    <i class="fas fa-sort-amount-down-alt" aria-hidden="true"></i>
+                    <span class="a11y-sort-direction__text" id="seoSortDirectionLabel">High to low</span>
                 </button>
             </div>
             <div class="seo-view-toggle" role="group" aria-label="Toggle layout">


### PR DESCRIPTION
## Summary
- replace the SEO dashboard sort buttons with a dropdown and direction toggle that mirror the performance module
- add reusable helpers to sort SEO pages by score, title, or total issues with ascending/descending support
- update the dashboard filtering logic to react to the new controls and keep the UI state in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db02a596d08331a7025a482a1f0d1e