### PR TITLE
Adjust hero content spacing

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -10452,7 +10452,7 @@ body.calendar-modal-open {
             position: relative;
             display: flex;
             flex-direction: column;
-            gap: 20px;
+            gap: 6px;
         }
 
         @media (min-width: 960px) {
@@ -10471,7 +10471,7 @@ body.calendar-modal-open {
                 flex-direction: row;
                 align-items: flex-start;
                 justify-content: space-between;
-                gap: 32px;
+                gap: 6px;
             }
         }
 


### PR DESCRIPTION
## Summary
- reduce the flexbox gap to 6px for hero content sections across analytics, menu, media, and related pages
- ensure desktop layout uses the same tighter spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db061b45588331b314ea0779cc393e