### PR TITLE
Render blog posts from JSON

### DIFF
--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -132,6 +132,9 @@
     if (!(container instanceof HTMLElement)) {
       return;
     }
+    if (container.dataset.blogRendered === 'server') {
+      return;
+    }
     var itemsHost = container.querySelector('[data-blog-items]');
     if (!itemsHost) {
       itemsHost = container;

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -130,6 +130,9 @@
     if (!(container instanceof HTMLElement)) {
       return;
     }
+    if (container.dataset.blogRendered === 'server') {
+      return;
+    }
     var itemsHost = container.querySelector('[data-blog-items]');
     if (!itemsHost) {
       itemsHost = container;


### PR DESCRIPTION
## Summary
- server-render blog listing blocks by hydrating blog list markup from the stored blog_posts.json data
- skip client-side rehydration when the server has already rendered the blog list to avoid replacing real posts with placeholders

## Testing
- php -l CMS/index.php

------
https://chatgpt.com/codex/tasks/task_e_68db04e043648331b016fa7fe42ea5f0