### PR TITLE
Adjust SEO controls layout

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -10850,6 +10850,7 @@ body.calendar-modal-open {
     flex-wrap: wrap;
     gap: 16px;
     align-items: center;
+    justify-content: space-between;
 }
 
 .seo-search {


### PR DESCRIPTION
## Summary
- add space-between justification to the SEO controls container for better spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3a2d69908331ab7ad1ddbe8158bf