### PR TITLE
Align blog filters with category and author selects

### DIFF
--- a/CMS/modules/blogs/view.php
+++ b/CMS/modules/blogs/view.php
@@ -49,34 +49,38 @@
                     <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
                     <input type="search" id="blogSearchInput" placeholder="Search posts by title, slug, excerpt, or tag" aria-label="Search posts">
                 </label>
-                <div class="blog-filter-group" role="group" aria-label="Filter posts by status">
-                    <button type="button" class="blog-filter-btn active" data-blog-filter="all" aria-pressed="true">
-                        All Posts <span class="blog-filter-count" data-count="all">0</span>
-                    </button>
-                    <button type="button" class="blog-filter-btn" data-blog-filter="published" aria-pressed="false">
-                        Published <span class="blog-filter-count" data-count="published">0</span>
-                    </button>
-                    <button type="button" class="blog-filter-btn" data-blog-filter="drafts" aria-pressed="false">
-                        Drafts <span class="blog-filter-count" data-count="drafts">0</span>
-                    </button>
-                    <button type="button" class="blog-filter-btn" data-blog-filter="scheduled" aria-pressed="false">
-                        Scheduled <span class="blog-filter-count" data-count="scheduled">0</span>
-                    </button>
+                <div class="blog-filter-toolbar">
+                    <div class="blog-filter-group" role="group" aria-label="Filter posts by status">
+                        <button type="button" class="blog-filter-btn active" data-blog-filter="all" aria-pressed="true">
+                            All Posts <span class="blog-filter-count" data-count="all">0</span>
+                        </button>
+                        <button type="button" class="blog-filter-btn" data-blog-filter="published" aria-pressed="false">
+                            Published <span class="blog-filter-count" data-count="published">0</span>
+                        </button>
+                        <button type="button" class="blog-filter-btn" data-blog-filter="drafts" aria-pressed="false">
+                            Drafts <span class="blog-filter-count" data-count="drafts">0</span>
+                        </button>
+                        <button type="button" class="blog-filter-btn" data-blog-filter="scheduled" aria-pressed="false">
+                            Scheduled <span class="blog-filter-count" data-count="scheduled">0</span>
+                        </button>
+                    </div>
+                    <div class="blog-filter-selects">
+                        <div class="blog-select-filter">
+                            <label for="categoryFilter">Category</label>
+                            <select id="categoryFilter">
+                                <option value="">All Categories</option>
+                            </select>
+                        </div>
+                        <div class="blog-select-filter">
+                            <label for="authorFilter">Author</label>
+                            <select id="authorFilter">
+                                <option value="">All Authors</option>
+                            </select>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="blog-controls-secondary">
-                <div class="blog-select-filter">
-                    <label for="categoryFilter">Category</label>
-                    <select id="categoryFilter">
-                        <option value="">All Categories</option>
-                    </select>
-                </div>
-                <div class="blog-select-filter">
-                    <label for="authorFilter">Author</label>
-                    <select id="authorFilter">
-                        <option value="">All Authors</option>
-                    </select>
-                </div>
                 <div class="blog-select-filter blog-select-filter--actions">
                     <label>&nbsp;</label>
                     <button type="button" class="blog-btn blog-btn--subtle" id="clearFilters">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -6640,6 +6640,15 @@
     max-width: 420px;
 }
 
+.blog-filter-toolbar {
+    display: flex;
+    flex: 1 1 320px;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+    justify-content: flex-end;
+}
+
 .blog-search {
     display: flex;
     align-items: center;
@@ -6675,6 +6684,13 @@
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
+}
+
+.blog-filter-selects {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    align-items: stretch;
 }
 
 .blog-filter-btn {


### PR DESCRIPTION
## Summary
- group the status filter buttons with the category and author dropdowns in the blogs dashboard
- add layout styles so the dropdowns sit to the right of the filter chips while keeping responsive wrapping

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db3ae24ff88331bab1a7f9ae7948ad