### PR TITLE
Revamp Pages module list view

### DIFF
--- a/CMS/modules/pages/pages.js
+++ b/CMS/modules/pages/pages.js
@@ -2,14 +2,14 @@
 $(function(){
         $('#pageTabs').tabs();
 
-        const $pagesCollection = $('#pagesCollection');
         const $searchInput = $('#pagesSearchInput');
         const $filterButtons = $('[data-pages-filter]');
         const $listView = $('#pagesListView');
-        const $viewToggleButtons = $('[data-pages-view]');
+        const $sortButtons = $('[data-pages-sort]');
         const $emptyState = $('#pagesEmptyState');
         const $visibleCount = $('#pagesVisibleCount');
         let activeFilter = 'all';
+        const sortState = { key: null, direction: 'asc' };
         $('#cancelEdit').hide();
 
         function toastSuccess(message){
@@ -53,18 +53,11 @@ $(function(){
             $('#cancelEdit').hide();
         }
 
-        function getPageCards() {
-            if (!$pagesCollection.length) {
-                return $();
-            }
-            return $pagesCollection.find('[data-page-item][data-view="card"]');
-        }
-
         function getPageRows() {
             if (!$listView.length) {
                 return $();
             }
-            return $listView.find('[data-page-item][data-view="list"]');
+            return $listView.find('tbody [data-page-item]');
         }
 
         function updateVisibleCount(count) {
@@ -75,7 +68,7 @@ $(function(){
             $visibleCount.text(`Showing ${count} ${label}`);
         }
 
-        function refreshFilterCounts($cards) {
+        function refreshFilterCounts() {
             const counts = {
                 all: 0,
                 published: 0,
@@ -83,15 +76,15 @@ $(function(){
                 restricted: 0
             };
 
-            $cards.each(function(){
-                const $card = $(this);
+            getPageRows().each(function(){
+                const $row = $(this);
                 counts.all++;
-                if ($card.data('published') == 1) {
+                if ($row.data('published') == 1) {
                     counts.published++;
                 } else {
                     counts.drafts++;
                 }
-                const access = (($card.data('access') || 'public') + '').toLowerCase();
+                const access = (($row.data('access') || 'public') + '').toLowerCase();
                 if (access !== 'public') {
                     counts.restricted++;
                 }
@@ -102,14 +95,14 @@ $(function(){
             });
         }
 
-        function rowMatchesFilter($card) {
+        function rowMatchesFilter($row) {
             switch (activeFilter) {
                 case 'published':
-                    return $card.data('published') == 1;
+                    return $row.data('published') == 1;
                 case 'drafts':
-                    return $card.data('published') != 1;
+                    return $row.data('published') != 1;
                 case 'restricted':
-                    return (($card.data('access') || 'public') + '').toLowerCase() !== 'public';
+                    return (($row.data('access') || 'public') + '').toLowerCase() !== 'public';
                 case 'all':
                 default:
                     return true;
@@ -117,42 +110,27 @@ $(function(){
         }
 
         function applyPageFilters() {
-            if (!$pagesCollection.length) {
+            if (!$listView.length) {
                 return;
             }
 
             const query = ($searchInput.val() || '').toString().toLowerCase();
             let visible = 0;
-            const $cards = getPageCards();
             const $rows = getPageRows();
-            const rowIndex = {};
-
             $rows.each(function(){
                 const $row = $(this);
-                rowIndex[$row.data('id')] = $row;
-            });
-
-            $cards.each(function(){
-                const $card = $(this);
-                const title = ($card.find('.pages-card__title').text() || '').toLowerCase();
-                const slugAttr = ($card.attr('data-slug') || '').toLowerCase();
-                const slugData = (($card.data('slug') || '') + '').toLowerCase();
+                const title = ($row.find('.pages-list-title-text').text() || '').toLowerCase();
+                const slugAttr = ($row.attr('data-slug') || '').toLowerCase();
+                const slugData = (($row.data('slug') || '') + '').toLowerCase();
                 const slug = slugAttr || slugData;
                 const matchesQuery = !query || title.indexOf(query) !== -1 || slug.indexOf(query) !== -1;
-                const matchesFilter = rowMatchesFilter($card);
-                const $row = rowIndex[$card.data('id')];
+                const matchesFilter = rowMatchesFilter($row);
 
                 if (matchesQuery && matchesFilter) {
-                    $card.removeAttr('hidden');
-                    if ($row && $row.length) {
-                        $row.removeAttr('hidden');
-                    }
+                    $row.removeAttr('hidden');
                     visible++;
                 } else {
-                    $card.attr('hidden', 'hidden');
-                    if ($row && $row.length) {
-                        $row.attr('hidden', 'hidden');
-                    }
+                    $row.attr('hidden', 'hidden');
                 }
             });
 
@@ -165,18 +143,122 @@ $(function(){
             }
 
             if ($listView.length) {
-                const $header = $listView.children('.pages-list-header');
-                if ($header.length) {
-                    if (visible === 0) {
-                        $header.attr('hidden', 'hidden');
-                    } else {
-                        $header.removeAttr('hidden');
-                    }
+                if (visible === 0) {
+                    $listView.attr('hidden', 'hidden');
+                } else {
+                    $listView.removeAttr('hidden');
                 }
             }
 
             updateVisibleCount(visible);
-            refreshFilterCounts($cards);
+            refreshFilterCounts();
+            applySort();
+        }
+
+        function normalizeAccess(value) {
+            return ((value || 'public') + '').toLowerCase();
+        }
+
+        function compareStrings(a, b) {
+            return (a || '').toString().localeCompare((b || '').toString(), undefined, { sensitivity: 'base', numeric: true });
+        }
+
+        function compareTitles($a, $b) {
+            const titleA = ($a.data('title') || '').toString();
+            const titleB = ($b.data('title') || '').toString();
+            const primary = compareStrings(titleA, titleB);
+            if (primary !== 0) {
+                return primary;
+            }
+            return compareStrings(($a.data('slug') || '').toString(), ($b.data('slug') || '').toString());
+        }
+
+        function parseNumber(value) {
+            const num = Number(value);
+            return Number.isFinite(num) ? num : 0;
+        }
+
+        const comparators = {
+            title: compareTitles,
+            status: function($a, $b){
+                const statusA = parseNumber($a.data('published')) === 1 ? 1 : 0;
+                const statusB = parseNumber($b.data('published')) === 1 ? 1 : 0;
+                if (statusA !== statusB) {
+                    return statusA - statusB;
+                }
+                return compareTitles($a, $b);
+            },
+            template: function($a, $b){
+                return compareStrings(($a.data('template') || '').toString(), ($b.data('template') || '').toString());
+            },
+            views: function($a, $b){
+                return parseNumber($a.data('views')) - parseNumber($b.data('views'));
+            },
+            updated: function($a, $b){
+                return parseNumber($a.data('last_modified')) - parseNumber($b.data('last_modified'));
+            },
+            access: function($a, $b){
+                return compareStrings(normalizeAccess($a.data('access')), normalizeAccess($b.data('access')));
+            }
+        };
+
+        function applySort() {
+            if (!$listView.length || !sortState.key) {
+                return;
+            }
+            const comparator = comparators[sortState.key];
+            if (typeof comparator !== 'function') {
+                return;
+            }
+            const $tbody = $listView.find('tbody');
+            if (!$tbody.length) {
+                return;
+            }
+            const rows = getPageRows().get();
+            rows.sort(function(a, b){
+                const $a = $(a);
+                const $b = $(b);
+                const result = comparator($a, $b);
+                return sortState.direction === 'asc' ? result : -result;
+            });
+            rows.forEach(function(row){
+                $tbody.append(row);
+            });
+        }
+
+        function updateSortIndicators() {
+            if (!$sortButtons.length) {
+                return;
+            }
+            $sortButtons.each(function(){
+                const $btn = $(this);
+                const key = $btn.data('pagesSort');
+                const isActive = sortState.key === key;
+                let ariaValue = 'none';
+
+                $btn.removeClass('is-active sort-asc sort-desc');
+                if (isActive) {
+                    ariaValue = sortState.direction === 'asc' ? 'ascending' : 'descending';
+                    $btn.addClass('is-active');
+                    $btn.addClass(sortState.direction === 'asc' ? 'sort-asc' : 'sort-desc');
+                }
+
+                const $th = $btn.closest('th');
+                if ($th.length) {
+                    $th.attr('aria-sort', ariaValue);
+                }
+            });
+        }
+
+        function setSort(key, direction) {
+            if (!key) {
+                return;
+            }
+            const normalizedDirection = direction === 'desc' ? 'desc' : 'asc';
+            sortState.key = key;
+            sortState.direction = normalizedDirection;
+            updateSortIndicators();
+            applySort();
         }
 
         let slugEdited = false;
@@ -195,11 +277,16 @@ $(function(){
         });
 
         function formatTimestamp(date){
-            if (!(date instanceof Date)) {
+            if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
                 return '';
             }
-            const pad = (value) => value.toString().padStart(2, '0');
-            return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+            return date.toLocaleString(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit'
+            });
         }
 
         function updatePageRow(data){
@@ -207,10 +294,17 @@ $(function(){
                 return;
             }
 
-            const $card = $pagesCollection.find(`[data-page-item][data-id="${data.id}"][data-view="card"]`);
-            const $row = $listView.find(`[data-page-item][data-id="${data.id}"][data-view="list"]`);
-
+            const $row = getPageRows().filter(`[data-id="${data.id}"]`);
+            if (!$row.length) {
+                return;
+            }
             const publishedFlag = data.published ? 1 : 0;
+            const accessValue = ((data.access || 'public') + '').toLowerCase();
+            const isRestricted = accessValue !== 'public';
+            const lastModifiedSeconds = typeof data.last_modified === 'number' ? data.last_modified : Math.floor(Date.now() / 1000);
+            const lastModifiedDate = lastModifiedSeconds > 0 ? new Date(lastModifiedSeconds * 1000) : null;
+            const formattedTimestamp = lastModifiedDate ? formatTimestamp(lastModifiedDate) : '';
+            const viewsCount = typeof data.views === 'number' ? data.views : (parseFloat($row.data('views')) || 0);
             const sharedAttributes = {
                 'data-title': data.title,
                 'data-slug': data.slug,
@@ -223,94 +317,78 @@ $(function(){
                 'data-og_description': data.og_description,
                 'data-og_image': data.og_image,
                 'data-access': data.access,
-                'data-published': publishedFlag
+                'data-published': publishedFlag,
+                'data-views': viewsCount,
+                'data-last_modified': lastModifiedSeconds
             };
 
-            const timestamp = formatTimestamp(new Date());
-            const accessLabel = ((data.access || 'public') + '').toLowerCase() !== 'public' ? 'Private' : 'Public';
+            $row.attr(sharedAttributes);
 
-            if ($card.length) {
-                $card.attr(sharedAttributes);
+            $row.data('title', data.title);
+            $row.data('slug', data.slug);
+            $row.data('content', data.content);
+            $row.data('template', data.template);
+            $row.data('meta_title', data.meta_title);
+            $row.data('meta_description', data.meta_description);
+            $row.data('canonical_url', data.canonical_url);
+            $row.data('og_title', data.og_title);
+            $row.data('og_description', data.og_description);
+            $row.data('og_image', data.og_image);
+            $row.data('access', data.access);
+            $row.data('published', publishedFlag);
+            $row.data('views', viewsCount);
+            $row.data('last_modified', lastModifiedSeconds);
 
-                $card.data('title', data.title);
-                $card.data('slug', data.slug);
-                $card.data('content', data.content);
-                $card.data('template', data.template);
-                $card.data('meta_title', data.meta_title);
-                $card.data('meta_description', data.meta_description);
-                $card.data('canonical_url', data.canonical_url);
-                $card.data('og_title', data.og_title);
-                $card.data('og_description', data.og_description);
-                $card.data('og_image', data.og_image);
-                $card.data('access', data.access);
-                $card.data('published', publishedFlag);
+            $row.find('.pages-list-title-text').text(data.title);
+            $row.find('.pages-list-slug').text(`/${data.slug}`);
 
-                $card.find('.pages-card__title').text(data.title);
-                $card.find('.pages-card__slug').text(`/${data.slug}`);
+            const $rowStatusBadge = $row.find('.status-badge');
+            $rowStatusBadge.removeClass('status-published status-draft');
+            $rowStatusBadge.addClass(publishedFlag ? 'status-published' : 'status-draft');
+            $rowStatusBadge.text(publishedFlag ? 'Published' : 'Draft');
 
-                const $statusBadge = $card.find('.status-badge');
-                $statusBadge.removeClass('status-published status-draft');
-                $statusBadge.addClass(publishedFlag ? 'status-published' : 'status-draft');
-                $statusBadge.text(publishedFlag ? 'Published' : 'Draft');
+            const $rowViewLink = $row.find('[data-action="view"]').first();
+            if ($rowViewLink.length) {
+                $rowViewLink.attr('href', `../?page=${encodeURIComponent(data.slug)}`);
+            }
 
-                const $viewLink = $card.find('[data-action="view"]').first();
-                if ($viewLink.length) {
-                    $viewLink.attr('href', `../?page=${encodeURIComponent(data.slug)}`);
-                }
+            const $rowToggleBtn = $row.find('.togglePublishBtn');
+            if ($rowToggleBtn.length) {
+                $rowToggleBtn.text(publishedFlag ? 'Unpublish' : 'Publish');
+            }
 
-                const $toggleBtn = $card.find('.togglePublishBtn');
-                if ($toggleBtn.length) {
-                    $toggleBtn.text(publishedFlag ? 'Unpublish' : 'Publish');
-                }
-
-                const $updatedLabel = $card.find('.pages-card__updated');
-                if ($updatedLabel.length && timestamp) {
-                    $updatedLabel.html(`<i class="fa-regular fa-clock" aria-hidden="true"></i>Updated ${timestamp}`);
+            const $rowUpdated = $row.find('.pages-list-updated');
+            if ($rowUpdated.length) {
+                if (formattedTimestamp) {
+                    $rowUpdated.text(`Updated ${formattedTimestamp}`);
+                } else {
+                    $rowUpdated.text('No edits yet');
                 }
             }
 
-            if ($row.length) {
-                $row.attr(sharedAttributes);
+            const $rowAccess = $row.find('.pages-list-access');
+            if ($rowAccess.length) {
+                $rowAccess.text(isRestricted ? 'Private' : 'Public');
+            }
 
-                $row.data('title', data.title);
-                $row.data('slug', data.slug);
-                $row.data('content', data.content);
-                $row.data('template', data.template);
-                $row.data('meta_title', data.meta_title);
-                $row.data('meta_description', data.meta_description);
-                $row.data('canonical_url', data.canonical_url);
-                $row.data('og_title', data.og_title);
-                $row.data('og_description', data.og_description);
-                $row.data('og_image', data.og_image);
-                $row.data('access', data.access);
-                $row.data('published', publishedFlag);
+            const $rowTemplate = $row.find('.pages-list-template');
+            if ($rowTemplate.length) {
+                $rowTemplate.text(data.template || 'page.php');
+            }
 
-                $row.find('.pages-list-title-text').text(data.title);
-                $row.find('.pages-list-slug').text(`/${data.slug}`);
+            const $rowViews = $row.find('.pages-list-views');
+            if ($rowViews.length) {
+                $rowViews.text(Number(viewsCount).toLocaleString());
+            }
 
-                const $rowStatusBadge = $row.find('.status-badge');
-                $rowStatusBadge.removeClass('status-published status-draft');
-                $rowStatusBadge.addClass(publishedFlag ? 'status-published' : 'status-draft');
-                $rowStatusBadge.text(publishedFlag ? 'Published' : 'Draft');
-
-                const $rowViewLink = $row.find('[data-action="view"]').first();
-                if ($rowViewLink.length) {
-                    $rowViewLink.attr('href', `../?page=${encodeURIComponent(data.slug)}`);
-                }
-
-                const $rowToggleBtn = $row.find('.togglePublishBtn');
-                if ($rowToggleBtn.length) {
-                    $rowToggleBtn.text(publishedFlag ? 'Unpublish' : 'Publish');
-                }
-
-                const $rowUpdated = $row.find('.pages-list-updated');
-                if ($rowUpdated.length && timestamp) {
-                    $rowUpdated.text(`Updated ${timestamp}`);
-                }
-
-                const $rowAccess = $row.find('.pages-list-access');
-                if ($rowAccess.length) {
-                    $rowAccess.text(accessLabel);
+            const $badges = $row.find('.pages-list-badges');
+            if ($badges.length) {
+                if (isRestricted) {
+                    if (!$badges.find('.pages-card__badge--restricted').length) {
+                        $badges.append('<span class="pages-card__badge pages-card__badge--restricted"><i class="fa-solid fa-lock" aria-hidden="true"></i>Private</span>');
+                    }
+                } else {
+                    $badges.find('.pages-card__badge--restricted').remove();
                 }
             }
         }
@@ -321,29 +399,6 @@ $(function(){
 
         function getPageItemsById(id){
             return $(`[data-page-item][data-id="${id}"]`);
-        }
-
-        function setActiveView(view){
-            if (!$pagesCollection.length || !$viewToggleButtons.length) {
-                return;
-            }
-
-            const normalizedView = view === 'list' ? 'list' : 'grid';
-
-            if (normalizedView === 'list') {
-                $pagesCollection.attr('hidden', 'hidden');
-                if ($listView.length) {
-                    $listView.removeAttr('hidden');
-                }
-            } else {
-                $pagesCollection.removeAttr('hidden');
-                if ($listView.length) {
-                    $listView.attr('hidden', 'hidden');
-                }
-            }
-
-            $viewToggleButtons.removeClass('active').attr('aria-pressed', 'false');
-            $viewToggleButtons.filter(`[data-pages-view="${normalizedView}"]`).addClass('active').attr('aria-pressed', 'true');
         }
 
         $('#pageForm').on('submit', function(e){
@@ -374,6 +429,17 @@ $(function(){
                 access: $('#access').val(),
                 published: $('#published').is(':checked') ? 1 : 0
             };
+
+            const nowTimestamp = Math.floor(Date.now() / 1000);
+            if (isEditing) {
+                const $existingRow = getPageRows().filter(`[data-id="${pageData.id}"]`);
+                const existingViews = $existingRow.length ? parseNumber($existingRow.data('views')) : 0;
+                pageData.views = existingViews;
+                pageData.last_modified = nowTimestamp;
+            } else {
+                pageData.views = 0;
+                pageData.last_modified = nowTimestamp;
+            }
 
             const $submitButton = $form.find('button[type="submit"]');
             const originalButtonHtml = $submitButton.html();
@@ -478,7 +544,7 @@ $(function(){
             slugEdited = false;
         });
 
-        if ($pagesCollection.length) {
+        if ($listView.length) {
             applyPageFilters();
 
             $searchInput.on('input', applyPageFilters);
@@ -496,18 +562,23 @@ $(function(){
                 applyPageFilters();
             });
 
-            if ($viewToggleButtons.length) {
-                $viewToggleButtons.on('click', function(){
+            if ($sortButtons.length) {
+                $sortButtons.on('click', function(){
                     const $btn = $(this);
-                    const view = $btn.data('pagesView');
-                    if (!view) {
+                    const key = $btn.data('pagesSort');
+                    if (!key) {
                         return;
                     }
-                    setActiveView(view);
+                    const defaultDirection = ($btn.data('defaultDirection') || 'asc').toString().toLowerCase();
+                    let direction = defaultDirection === 'desc' ? 'desc' : 'asc';
+                    if (sortState.key === key) {
+                        direction = sortState.direction === 'asc' ? 'desc' : 'asc';
+                    }
+                    setSort(key, direction);
                 });
-
-                setActiveView('list');
             }
+
+            setSort('updated', 'desc');
         }
 
         $('.copyBtn').on('click', function(){

--- a/CMS/modules/pages/view.php
+++ b/CMS/modules/pages/view.php
@@ -107,14 +107,6 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                 <button type="button" class="pages-filter-btn" data-pages-filter="drafts" aria-pressed="false">Drafts <span class="pages-filter-count" data-count="drafts"><?php echo $filterCounts['drafts']; ?></span></button>
                 <button type="button" class="pages-filter-btn" data-pages-filter="restricted" aria-pressed="false">Private <span class="pages-filter-count" data-count="restricted"><?php echo $filterCounts['restricted']; ?></span></button>
             </div>
-            <div class="a11y-view-toggle pages-view-toggle" role="group" aria-label="Toggle page layout">
-                <button type="button" class="a11y-view-btn" data-pages-view="grid" aria-pressed="false" aria-label="Card view">
-                    <i class="fa-solid fa-grip" aria-hidden="true"></i>
-                </button>
-                <button type="button" class="a11y-view-btn active" data-pages-view="list" aria-pressed="true" aria-label="List view">
-                    <i class="fa-solid fa-list" aria-hidden="true"></i>
-                </button>
-            </div>
         </div>
 
         <section class="a11y-detail-card table-card pages-table-card" aria-labelledby="pagesInventoryTitle" aria-describedby="pagesInventoryDescription">
@@ -125,97 +117,49 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                 </div>
                 <span class="table-meta pages-table-meta" id="pagesVisibleCount" aria-live="polite">Showing <?php echo $totalPages . ' ' . $pagesWord; ?></span>
             </header>
-            <div class="pages-card-grid" id="pagesCollection" role="list" aria-describedby="pagesInventoryDescription" hidden>
-<?php foreach ($pages as $p): ?>
-<?php
-    $isPublished = !empty($p['published']);
-    $accessValue = strtolower((string) ($p['access'] ?? 'public'));
-    $isRestricted = $accessValue !== 'public';
-    $views = (int) ($p['views'] ?? 0);
-    $viewsDisplay = number_format($views);
-    $lastModified = isset($p['last_modified']) ? (int) $p['last_modified'] : 0;
-    $modifiedDisplay = $lastModified > 0 ? date('M j, Y g:i A', $lastModified) : 'No edits yet';
-    $viewUrl = '../?page=' . urlencode($p['slug']);
-?>
-                <article class="pages-card" role="listitem"
-                    data-id="<?php echo $p['id']; ?>"
-                    data-title="<?php echo htmlspecialchars($p['title'], ENT_QUOTES); ?>"
-                    data-slug="<?php echo htmlspecialchars($p['slug'], ENT_QUOTES); ?>"
-                    data-content="<?php echo htmlspecialchars($p['content'], ENT_QUOTES); ?>"
-                    data-published="<?php echo $isPublished ? 1 : 0; ?>"
-                    data-template="<?php echo htmlspecialchars($p['template'] ?? '', ENT_QUOTES); ?>"
-                    data-meta_title="<?php echo htmlspecialchars($p['meta_title'] ?? '', ENT_QUOTES); ?>"
-                    data-meta_description="<?php echo htmlspecialchars($p['meta_description'] ?? '', ENT_QUOTES); ?>"
-                    data-canonical_url="<?php echo htmlspecialchars($p['canonical_url'] ?? '', ENT_QUOTES); ?>"
-                    data-og_title="<?php echo htmlspecialchars($p['og_title'] ?? '', ENT_QUOTES); ?>"
-                    data-og_description="<?php echo htmlspecialchars($p['og_description'] ?? '', ENT_QUOTES); ?>"
-                    data-og_image="<?php echo htmlspecialchars($p['og_image'] ?? '', ENT_QUOTES); ?>"
-                    data-access="<?php echo htmlspecialchars($p['access'] ?? 'public', ENT_QUOTES); ?>"
-                    data-page-item="1"
-                    data-view="card">
-                    <div class="pages-card__header">
-                        <div class="pages-card__titles">
-                            <span class="pages-card__title"><?php echo htmlspecialchars($p['title']); ?></span>
-                            <span class="pages-card__slug"><?php echo '/' . htmlspecialchars($p['slug']); ?></span>
-                        </div>
-                        <span class="status-badge <?php echo $isPublished ? 'status-published' : 'status-draft'; ?>">
-                            <?php echo $isPublished ? 'Published' : 'Draft'; ?>
-                        </span>
-                    </div>
-                    <div class="pages-card__meta">
-                        <span class="pages-card__stat" data-pages-stat="views">
-                            <i class="fa-solid fa-chart-simple" aria-hidden="true"></i>
-                            <span class="pages-card__stat-value"><?php echo $viewsDisplay; ?></span> views
-                        </span>
-                        <span class="pages-card__updated">
-                            <i class="fa-regular fa-clock" aria-hidden="true"></i>
-                            <?php if ($lastModified > 0): ?>Updated <?php echo htmlspecialchars($modifiedDisplay); ?><?php else: ?>No edits yet<?php endif; ?>
-                        </span>
-                    </div>
-                    <div class="pages-card__footer">
-                        <div class="pages-card__badges">
-                            <?php if ($homepage === $p['slug']): ?>
-                                <span class="pages-card__badge pages-card__badge--home">
-                                    <i class="fa-solid fa-house" aria-hidden="true"></i>
-                                    Homepage
-                                </span>
-                            <?php else: ?>
-                                <button type="button" class="a11y-btn a11y-btn--icon pages-card__home set-home" title="Set as homepage" aria-label="Set as homepage">
-                                    <i class="fa-solid fa-house" aria-hidden="true"></i>
-                                </button>
-                            <?php endif; ?>
-                            <?php if ($isRestricted): ?>
-                                <span class="pages-card__badge pages-card__badge--restricted">
-                                    <i class="fa-solid fa-lock" aria-hidden="true"></i>
-                                    Private
-                                </span>
-                            <?php endif; ?>
-                        </div>
-                        <div class="pages-card__actions">
-                            <a class="a11y-btn a11y-btn--ghost pages-card__action" data-action="view" href="<?php echo $viewUrl; ?>" target="_blank" rel="noopener">
-                                View
-                            </a>
-                            <button type="button" class="a11y-btn a11y-btn--secondary pages-card__action editBtn">Settings</button>
-                            <button type="button" class="a11y-btn a11y-btn--ghost pages-card__action copyBtn">Copy</button>
-                            <button type="button" class="a11y-btn a11y-btn--secondary pages-card__action togglePublishBtn">
-                                <?php echo $isPublished ? 'Unpublish' : 'Publish'; ?>
+            <table class="pages-list-view" id="pagesListView" aria-describedby="pagesInventoryDescription">
+                <thead>
+                    <tr>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="pages-sort-btn" data-pages-sort="title" data-default-direction="asc">
+                                <span>Page</span>
+                                <span class="pages-sort-indicator" aria-hidden="true"></span>
                             </button>
-                            <button type="button" class="a11y-btn a11y-btn--danger pages-card__action deleteBtn">Delete</button>
-                        </div>
-                    </div>
-                </article>
-<?php endforeach; ?>
-            </div>
-            <div class="pages-list-view" id="pagesListView" role="table" aria-describedby="pagesInventoryDescription">
-                <div class="pages-list-header" role="row">
-                    <span role="columnheader">Page</span>
-                    <span role="columnheader">Status</span>
-                    <span role="columnheader">Views</span>
-                    <span role="columnheader">Last updated</span>
-                    <span role="columnheader">Access</span>
-                    <span role="columnheader" class="pages-list-actions-heading">Actions</span>
-                </div>
-                <div class="pages-list-body" role="rowgroup">
+                        </th>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="pages-sort-btn" data-pages-sort="status" data-default-direction="desc">
+                                <span>Status</span>
+                                <span class="pages-sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="pages-sort-btn" data-pages-sort="template" data-default-direction="asc">
+                                <span>Template</span>
+                                <span class="pages-sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="pages-sort-btn" data-pages-sort="views" data-default-direction="desc">
+                                <span>Views</span>
+                                <span class="pages-sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="pages-sort-btn" data-pages-sort="updated" data-default-direction="desc">
+                                <span>Last updated</span>
+                                <span class="pages-sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th scope="col" aria-sort="none">
+                            <button type="button" class="pages-sort-btn" data-pages-sort="access" data-default-direction="asc">
+                                <span>Access</span>
+                                <span class="pages-sort-indicator" aria-hidden="true"></span>
+                            </button>
+                        </th>
+                        <th scope="col" class="pages-list-actions-heading">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
 <?php foreach ($pages as $p): ?>
 <?php
     $isPublished = !empty($p['published']);
@@ -227,15 +171,15 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
     $modifiedDisplay = $lastModified > 0 ? date('M j, Y g:i A', $lastModified) : 'No edits yet';
     $viewUrl = '../?page=' . urlencode($p['slug']);
     $accessLabel = $isRestricted ? 'Private' : 'Public';
+    $templateName = $p['template'] ?? 'page.php';
 ?>
-                    <div class="pages-list-row"
-                        role="row"
+                    <tr class="pages-list-row"
                         data-id="<?php echo $p['id']; ?>"
                         data-title="<?php echo htmlspecialchars($p['title'], ENT_QUOTES); ?>"
                         data-slug="<?php echo htmlspecialchars($p['slug'], ENT_QUOTES); ?>"
                         data-content="<?php echo htmlspecialchars($p['content'], ENT_QUOTES); ?>"
                         data-published="<?php echo $isPublished ? 1 : 0; ?>"
-                        data-template="<?php echo htmlspecialchars($p['template'] ?? '', ENT_QUOTES); ?>"
+                        data-template="<?php echo htmlspecialchars($templateName, ENT_QUOTES); ?>"
                         data-meta_title="<?php echo htmlspecialchars($p['meta_title'] ?? '', ENT_QUOTES); ?>"
                         data-meta_description="<?php echo htmlspecialchars($p['meta_description'] ?? '', ENT_QUOTES); ?>"
                         data-canonical_url="<?php echo htmlspecialchars($p['canonical_url'] ?? '', ENT_QUOTES); ?>"
@@ -243,9 +187,11 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                         data-og_description="<?php echo htmlspecialchars($p['og_description'] ?? '', ENT_QUOTES); ?>"
                         data-og_image="<?php echo htmlspecialchars($p['og_image'] ?? '', ENT_QUOTES); ?>"
                         data-access="<?php echo htmlspecialchars($p['access'] ?? 'public', ENT_QUOTES); ?>"
+                        data-views="<?php echo $views; ?>"
+                        data-last_modified="<?php echo $lastModified; ?>"
                         data-page-item="1"
                         data-view="list">
-                        <div class="pages-list-cell pages-list-cell--title" role="cell">
+                        <td class="pages-list-cell pages-list-cell--title" data-label="Page">
                             <div class="pages-list-title">
                                 <span class="pages-list-title-text"><?php echo htmlspecialchars($p['title']); ?></span>
                                 <span class="pages-list-slug"><?php echo '/' . htmlspecialchars($p['slug']); ?></span>
@@ -268,16 +214,19 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                                     </span>
                                 <?php endif; ?>
                             </div>
-                        </div>
-                        <div class="pages-list-cell pages-list-cell--status" role="cell">
+                        </td>
+                        <td class="pages-list-cell pages-list-cell--status" data-label="Status">
                             <span class="status-badge <?php echo $isPublished ? 'status-published' : 'status-draft'; ?>">
                                 <?php echo $isPublished ? 'Published' : 'Draft'; ?>
                             </span>
-                        </div>
-                        <div class="pages-list-cell pages-list-cell--views" role="cell">
+                        </td>
+                        <td class="pages-list-cell pages-list-cell--template" data-label="Template">
+                            <span class="pages-list-template"><?php echo htmlspecialchars($templateName); ?></span>
+                        </td>
+                        <td class="pages-list-cell pages-list-cell--views" data-label="Views">
                             <span class="pages-list-views"><?php echo $viewsDisplay; ?></span>
-                        </div>
-                        <div class="pages-list-cell pages-list-cell--updated" role="cell">
+                        </td>
+                        <td class="pages-list-cell pages-list-cell--updated" data-label="Last updated">
                             <span class="pages-list-updated">
                                 <?php if ($lastModified > 0): ?>
                                     Updated <?php echo htmlspecialchars($modifiedDisplay); ?>
@@ -285,11 +234,11 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                                     No edits yet
                                 <?php endif; ?>
                             </span>
-                        </div>
-                        <div class="pages-list-cell pages-list-cell--access" role="cell">
+                        </td>
+                        <td class="pages-list-cell pages-list-cell--access" data-label="Access">
                             <span class="pages-list-access"><?php echo htmlspecialchars($accessLabel); ?></span>
-                        </div>
-                        <div class="pages-list-cell pages-list-cell--actions" role="cell">
+                        </td>
+                        <td class="pages-list-cell pages-list-cell--actions" data-label="Actions">
                             <div class="pages-list-actions">
                                 <a class="a11y-btn a11y-btn--ghost pages-card__action" data-action="view" href="<?php echo $viewUrl; ?>" target="_blank" rel="noopener">
                                     View
@@ -301,11 +250,11 @@ $pagesWord = $totalPages === 1 ? 'page' : 'pages';
                                 </button>
                                 <button type="button" class="a11y-btn a11y-btn--danger pages-card__action deleteBtn">Delete</button>
                             </div>
-                        </div>
-                    </div>
+                        </td>
+                    </tr>
 <?php endforeach; ?>
-                </div>
-            </div>
+                </tbody>
+            </table>
         </section>
 
         <div class="pages-empty-state" id="pagesEmptyState" hidden>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2573,6 +2573,7 @@
             border: 1px solid #e2e8f0;
             box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
             padding: 0;
+            overflow-x: auto;
         }
 
         .pages-table-header {
@@ -2625,48 +2626,57 @@
         }
 
         .pages-list-view {
-            padding: 0 0 24px;
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            min-width: 960px;
         }
 
-        .pages-list-header,
-        .pages-list-row {
-            display: grid;
-            grid-template-columns: minmax(220px, 1.8fr) 120px 120px 180px 120px minmax(240px, 1fr);
-            gap: 16px;
-            align-items: center;
+        .pages-list-view[hidden] {
+            display: none;
         }
 
-        .pages-list-header {
-            padding: 18px 24px;
+        .pages-list-view thead th {
             background: #f8fafc;
             font-size: 12px;
             font-weight: 600;
             letter-spacing: 0.5px;
             text-transform: uppercase;
             color: #475569;
+            padding: 16px 24px;
+            text-align: left;
+            border-bottom: 1px solid #e2e8f0;
         }
 
-        .pages-list-actions-heading {
+        .pages-list-view thead th:first-child {
+            border-top-left-radius: 14px;
+        }
+
+        .pages-list-view thead th:last-child {
+            border-top-right-radius: 14px;
+        }
+
+        .pages-list-actions-heading,
+        .pages-list-view thead th.pages-list-actions-heading {
             text-align: right;
         }
 
-        .pages-list-body {
-            display: flex;
-            flex-direction: column;
-        }
-
-        .pages-list-row {
-            padding: 18px 24px;
-            border-top: 1px solid #f1f5f9;
+        .pages-list-view tbody tr {
+            border-bottom: 1px solid #f1f5f9;
             transition: background 0.2s ease;
         }
 
-        .pages-list-row:hover {
+        .pages-list-view tbody tr:hover {
             background: #f8fafc;
         }
 
         .pages-list-row[hidden] {
             display: none;
+        }
+
+        .pages-list-view td {
+            padding: 18px 24px;
+            vertical-align: top;
         }
 
         .pages-list-cell {
@@ -2702,6 +2712,12 @@
             gap: 8px;
         }
 
+        .pages-list-template {
+            font-family: "Fira Code", "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 13px;
+            color: #475569;
+        }
+
         .pages-list-views,
         .pages-list-access {
             font-size: 14px;
@@ -2723,6 +2739,46 @@
 
         .pages-list-actions .a11y-btn {
             white-space: nowrap;
+        }
+
+        .pages-sort-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font: inherit;
+            color: inherit;
+            background: none;
+            border: none;
+            padding: 0;
+            cursor: pointer;
+            text-transform: inherit;
+            letter-spacing: inherit;
+        }
+
+        .pages-sort-btn .pages-sort-indicator::before {
+            content: '\21F5';
+            font-size: 11px;
+            color: #94a3b8;
+        }
+
+        .pages-sort-btn.is-active {
+            color: #1f2937;
+        }
+
+        .pages-sort-btn.sort-asc .pages-sort-indicator::before {
+            content: '\25B2';
+            color: #4338ca;
+        }
+
+        .pages-sort-btn.sort-desc .pages-sort-indicator::before {
+            content: '\25BC';
+            color: #4338ca;
+        }
+
+        .pages-sort-btn:focus-visible {
+            outline: 2px solid #4338ca;
+            outline-offset: 2px;
+            border-radius: 6px;
         }
 
         .pages-card {
@@ -2915,22 +2971,8 @@
                 align-self: flex-start;
             }
 
-            .pages-list-header,
-            .pages-list-row {
-                grid-template-columns: minmax(200px, 1.6fr) 120px 120px 1fr;
-            }
-
-            .pages-list-actions-heading {
-                display: none;
-            }
-
-            .pages-list-cell--actions {
-                grid-column: 1 / -1;
-                align-items: flex-start;
-            }
-
-            .pages-list-actions {
-                justify-content: flex-start;
+            .pages-list-view {
+                min-width: 100%;
             }
         }
 
@@ -2962,30 +3004,53 @@
                 width: 100%;
             }
 
-            .pages-list-view {
-                padding-bottom: 20px;
+            .pages-table-card {
+                overflow-x: visible;
             }
 
-            .pages-list-header {
+            .pages-list-view {
+                border-collapse: separate;
+                min-width: 100%;
+            }
+
+            .pages-list-view thead {
                 display: none;
             }
 
-            .pages-list-row {
-                grid-template-columns: 1fr;
-                gap: 14px;
+            .pages-list-view tbody {
+                display: flex;
+                flex-direction: column;
+                gap: 16px;
+                padding: 0 20px 24px;
+            }
+
+            .pages-list-view tbody .pages-list-row {
+                display: flex;
+                flex-direction: column;
+                gap: 16px;
                 padding: 18px 20px;
+                border: 1px solid #e2e8f0;
+                border-radius: 16px;
+                background: #fff;
+                box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
             }
 
-            .pages-list-cell {
-                align-items: flex-start;
+            .pages-list-view tbody .pages-list-row:hover {
+                background: #fff;
             }
 
-            .pages-list-cell--status,
-            .pages-list-cell--views,
-            .pages-list-cell--updated,
-            .pages-list-cell--access {
-                flex-direction: row;
-                gap: 10px;
+            .pages-list-view tbody .pages-list-cell {
+                padding: 0;
+                gap: 6px;
+            }
+
+            .pages-list-view tbody .pages-list-cell::before {
+                content: attr(data-label);
+                font-size: 12px;
+                font-weight: 600;
+                letter-spacing: 0.5px;
+                text-transform: uppercase;
+                color: #64748b;
             }
 
             .pages-list-cell--actions {
@@ -2998,7 +3063,7 @@
             }
 
             .pages-list-actions .a11y-btn {
-                flex: 1 1 45%;
+                width: 100%;
             }
         }
 


### PR DESCRIPTION
## Summary
- replace the Pages module card toggle with a richer table layout that adds sortable columns and template visibility
- streamline the list management script to filter, sort, and update table rows without relying on a card view
- refresh module styling to support the new responsive table, sort controls, and mobile layout

## Testing
- php -l CMS/modules/pages/view.php

------
https://chatgpt.com/codex/tasks/task_e_68db3d0e1a748331bb9ad2a2ecbcd15e