### PR TITLE
Add calendar block with frontend calendar rendering

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -1276,6 +1276,196 @@ section.container-fluid {
 }
 
 
+/* Calendar Block */
+.calendar-block {
+    background: var(--white, #ffffff);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 18px 35px rgba(15, 23, 42, 0.06);
+    backdrop-filter: blur(4px);
+}
+
+.calendar-block__items {
+    display: grid;
+    gap: 1rem;
+}
+
+.calendar-block__item {
+    display: flex;
+    gap: 1rem;
+    align-items: stretch;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 0.875rem;
+    padding: 1rem 1.25rem;
+    background: rgba(255, 255, 255, 0.9);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.calendar-block__item:hover,
+.calendar-block__item:focus-within {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.calendar-block__item--placeholder {
+    justify-content: center;
+    text-align: center;
+    border-style: dashed;
+    color: var(--gray-6, #6c757d);
+    background: rgba(248, 249, 250, 0.7);
+    box-shadow: none;
+}
+
+.calendar-block__date {
+    min-width: 4.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    padding: 0.75rem 0.5rem;
+    border-radius: 0.75rem;
+    background: linear-gradient(135deg, var(--primary-1, #e3f2fd), var(--primary-3, #64b5f6));
+    color: var(--primary-6, #0d47a1);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+}
+
+.calendar-block__date-month {
+    font-size: 0.85rem;
+}
+
+.calendar-block__date-day {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.calendar-block__body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.calendar-block__title {
+    font-size: 1.125rem;
+    margin: 0;
+    color: var(--gray-9, #212529);
+}
+
+.calendar-block__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    align-items: center;
+    font-size: 0.95rem;
+    color: var(--gray-7, #495057);
+}
+
+.calendar-block__meta-line {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.calendar-block__time {
+    font-weight: 500;
+}
+
+.calendar-block__category {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(102, 126, 234, 0.12);
+    color: var(--primary-6, #0d47a1);
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.calendar-block__description {
+    margin: 0;
+    color: var(--gray-7, #495057);
+}
+
+.calendar-block__empty {
+    margin-top: 1rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    background: rgba(248, 249, 252, 0.9);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    color: var(--gray-7, #495057);
+}
+
+.calendar-block--layout-cards .calendar-block__items {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.calendar-block--layout-cards .calendar-block__item {
+    flex-direction: column;
+}
+
+.calendar-block--layout-cards .calendar-block__date {
+    align-self: flex-start;
+}
+
+.calendar-block--layout-compact .calendar-block__item {
+    padding: 0.75rem 1rem;
+}
+
+.calendar-block--layout-compact .calendar-block__date {
+    min-width: 3.5rem;
+    padding: 0.5rem 0.35rem;
+    border-radius: 0.65rem;
+}
+
+.calendar-block--layout-compact .calendar-block__title {
+    font-size: 1rem;
+}
+
+.calendar-block--layout-compact .calendar-block__meta {
+    font-size: 0.9rem;
+}
+
+.calendar-block--layout-compact .calendar-block__description {
+    font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+    .calendar-block {
+        padding: 1.25rem;
+    }
+
+    .calendar-block__item {
+        flex-direction: column;
+    }
+
+    .calendar-block__date {
+        flex-direction: row;
+        justify-content: flex-start;
+        gap: 0.75rem;
+        background: transparent;
+        color: var(--gray-7, #495057);
+        padding: 0;
+    }
+
+    .calendar-block__date-month {
+        font-size: 1rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+    }
+
+    .calendar-block__date-day {
+        font-size: 1.5rem;
+        color: var(--primary-5, #1565c0);
+    }
+}
+
+
 .rich-text {
     width: 100%;
 }

--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -250,7 +250,433 @@
       });
   }
 
-  function initAll() {
+  var calendarEventsPromise = null;
+
+  function fetchCalendarEvents() {
+    if (calendarEventsPromise) {
+      return calendarEventsPromise;
+    }
+    var base = normalizeBasePath();
+    var url = base + '/CMS/data/calendar_events.json';
+    calendarEventsPromise = fetch(url, { credentials: 'same-origin', cache: 'no-store' })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Failed to load calendar events');
+        }
+        return response.json();
+      })
+      .then(function (events) {
+        if (!Array.isArray(events)) {
+          return [];
+        }
+        return events.filter(function (event) {
+          return event && typeof event === 'object';
+        });
+      })
+      .catch(function (error) {
+        console.error('[SparkCMS] Calendar load error:', error);
+        calendarEventsPromise = null;
+        throw error;
+      });
+    return calendarEventsPromise;
+  }
+
+  function parsePositiveInt(value, fallback) {
+    var parsed = parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return fallback;
+    }
+    return parsed;
+  }
+
+  function parseIsoDate(value) {
+    if (!value) {
+      return null;
+    }
+    var date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+    return date;
+  }
+
+  function addRecurringInterval(date, recurrence) {
+    if (!(date instanceof Date)) {
+      return null;
+    }
+    var next;
+    switch (recurrence) {
+      case 'daily':
+        next = new Date(date.getTime());
+        next.setDate(next.getDate() + 1);
+        return next;
+      case 'weekly':
+        next = new Date(date.getTime());
+        next.setDate(next.getDate() + 7);
+        return next;
+      case 'monthly':
+        next = new Date(date.getTime());
+        var day = next.getDate();
+        next.setDate(1);
+        next.setMonth(next.getMonth() + 1);
+        var daysInMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
+        next.setDate(Math.min(day, daysInMonth));
+        return next;
+      case 'yearly':
+        next = new Date(date.getTime());
+        var month = next.getMonth();
+        var dayOfMonth = next.getDate();
+        next.setDate(1);
+        next.setFullYear(next.getFullYear() + 1);
+        next.setMonth(month);
+        var maxDay = new Date(next.getFullYear(), month + 1, 0).getDate();
+        next.setDate(Math.min(dayOfMonth, maxDay));
+        return next;
+      default:
+        return null;
+    }
+  }
+
+  function expandEventOccurrences(event, options) {
+    var occurrences = [];
+    if (!event.start) {
+      return occurrences;
+    }
+    var duration = event.end ? Math.max(event.end.getTime() - event.start.getTime(), 0) : 0;
+    var start = new Date(event.start.getTime());
+    var recurrence = event.recurrence;
+    var recurrenceEnd = event.recurrenceEnd;
+    var perEventLimit = options.perEventLimit || 12;
+    var maxIterations = options.maxIterations || 120;
+    var windowStart = options.windowStart;
+    var windowEnd = options.windowEnd;
+    var sequence = 0;
+    var iterations = 0;
+    while (iterations < maxIterations) {
+      if (recurrenceEnd && start > recurrenceEnd) {
+        break;
+      }
+      var include = !windowStart || start >= windowStart;
+      if (include && (!windowEnd || start <= windowEnd)) {
+        var end = duration ? new Date(start.getTime() + duration) : null;
+        occurrences.push({
+          id: event.id,
+          title: event.title,
+          category: event.category,
+          description: event.description,
+          start: new Date(start.getTime()),
+          end: end,
+          recurrence: recurrence,
+          occurrenceIndex: sequence
+        });
+        if (occurrences.length >= perEventLimit) {
+          break;
+        }
+      }
+      if (recurrence === 'none') {
+        break;
+      }
+      var nextStart = addRecurringInterval(start, recurrence);
+      if (!nextStart || nextStart.getTime() === start.getTime()) {
+        break;
+      }
+      start = nextStart;
+      sequence += 1;
+      iterations += 1;
+    }
+    return occurrences;
+  }
+
+  function buildCalendarOccurrences(records, options) {
+    var now = options.now || new Date();
+    var windowStart = options.windowStart || now;
+    var windowEnd = options.windowEnd || null;
+    var perEventLimit = options.perEventLimit || 24;
+    var maxIterations = options.maxIterations || 120;
+    var normalizedCategory = options.category || '';
+    var limit = options.limit || 6;
+    var aggregated = [];
+    records.forEach(function (raw) {
+      if (!raw || typeof raw !== 'object') {
+        return;
+      }
+      var start = parseIsoDate(raw.start_date);
+      if (!start) {
+        return;
+      }
+      var event = {
+        id: raw.id,
+        title: raw.title || 'Untitled Event',
+        category: raw.category || '',
+        description: raw.description || '',
+        start: start,
+        end: parseIsoDate(raw.end_date),
+        recurrence: (raw.recurring_interval || 'none').toLowerCase(),
+        recurrenceEnd: parseIsoDate(raw.recurring_end_date)
+      };
+      if (['daily', 'weekly', 'monthly', 'yearly'].indexOf(event.recurrence) === -1) {
+        event.recurrence = 'none';
+      }
+      var occurrences = expandEventOccurrences(event, {
+        windowStart: windowStart,
+        windowEnd: windowEnd,
+        perEventLimit: perEventLimit,
+        maxIterations: maxIterations
+      });
+      occurrences.forEach(function (occurrence) {
+        if (normalizedCategory && normalizeCategory(occurrence.category) !== normalizedCategory) {
+          return;
+        }
+        aggregated.push(occurrence);
+      });
+    });
+    aggregated.sort(function (a, b) {
+      return a.start.getTime() - b.start.getTime();
+    });
+    if (limit && aggregated.length > limit) {
+      aggregated = aggregated.slice(0, limit);
+    }
+    return aggregated;
+  }
+
+  var MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  var WEEKDAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  function formatMonthLabel(date) {
+    if (!(date instanceof Date)) {
+      return '--';
+    }
+    try {
+      return date.toLocaleDateString(undefined, { month: 'short' });
+    } catch (err) {
+      return MONTH_NAMES[date.getMonth()] || '';
+    }
+  }
+
+  function formatDayLabel(date) {
+    if (!(date instanceof Date)) {
+      return '--';
+    }
+    var day = date.getDate();
+    if (!Number.isFinite(day)) {
+      return '--';
+    }
+    return day < 10 ? '0' + day : String(day);
+  }
+
+  function formatWeekdayLabel(date) {
+    if (!(date instanceof Date)) {
+      return '';
+    }
+    try {
+      return date.toLocaleDateString(undefined, { weekday: 'short' });
+    } catch (err) {
+      return WEEKDAY_NAMES[date.getDay()] || '';
+    }
+  }
+
+  function formatTimeRangeDisplay(start, end) {
+    if (!(start instanceof Date)) {
+      return '';
+    }
+    var timeFormatter;
+    try {
+      timeFormatter = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' });
+    } catch (err) {
+      timeFormatter = null;
+    }
+    var dateFormatter;
+    try {
+      dateFormatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+    } catch (err) {
+      dateFormatter = null;
+    }
+    var startTime = timeFormatter ? timeFormatter.format(start) : start.toISOString().slice(11, 16);
+    if (!(end instanceof Date) || end.getTime() <= start.getTime()) {
+      return startTime;
+    }
+    var sameDay = start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth() && start.getDate() === end.getDate();
+    var endTime = timeFormatter ? timeFormatter.format(end) : end.toISOString().slice(11, 16);
+    if (sameDay) {
+      return startTime + ' – ' + endTime;
+    }
+    var startLabel = dateFormatter ? dateFormatter.format(start) : start.toISOString().slice(0, 10);
+    var endLabel = dateFormatter ? dateFormatter.format(end) : end.toISOString().slice(0, 10);
+    return startLabel + ' ' + startTime + ' – ' + endLabel + ' ' + endTime;
+  }
+
+  function normalizeCalendarLayout(value) {
+    var layout = (value || '').toString().toLowerCase();
+    if (layout !== 'cards' && layout !== 'compact') {
+      layout = 'list';
+    }
+    return layout;
+  }
+
+  function showCalendarEmpty(container, message) {
+    var empty = container.querySelector('[data-calendar-empty]');
+    if (!empty) {
+      empty = document.createElement('div');
+      empty.className = 'calendar-block__empty';
+      empty.setAttribute('data-calendar-empty', '');
+      container.appendChild(empty);
+    }
+    empty.textContent = message || '';
+    empty.classList.remove('d-none');
+  }
+
+  function hideCalendarEmpty(container) {
+    var empty = container.querySelector('[data-calendar-empty]');
+    if (empty) {
+      empty.classList.add('d-none');
+    }
+  }
+
+  function createCalendarItem(occurrence, settings) {
+    var item = document.createElement('article');
+    item.className = 'calendar-block__item';
+    item.setAttribute('data-calendar-event-id', String(occurrence.id));
+    item.setAttribute('data-calendar-occurrence', String(occurrence.occurrenceIndex));
+
+    var dateWrap = document.createElement('div');
+    dateWrap.className = 'calendar-block__date';
+    var monthSpan = document.createElement('span');
+    monthSpan.className = 'calendar-block__date-month';
+    monthSpan.textContent = formatMonthLabel(occurrence.start);
+    dateWrap.appendChild(monthSpan);
+    var daySpan = document.createElement('span');
+    daySpan.className = 'calendar-block__date-day';
+    daySpan.textContent = formatDayLabel(occurrence.start);
+    dateWrap.appendChild(daySpan);
+    item.appendChild(dateWrap);
+
+    var body = document.createElement('div');
+    body.className = 'calendar-block__body';
+
+    var title = document.createElement('h3');
+    title.className = 'calendar-block__title';
+    title.textContent = occurrence.title || 'Untitled Event';
+    body.appendChild(title);
+
+    var meta = document.createElement('div');
+    meta.className = 'calendar-block__meta';
+
+    var metaLine = document.createElement('div');
+    metaLine.className = 'calendar-block__meta-line';
+    var parts = [];
+    var weekday = formatWeekdayLabel(occurrence.start);
+    if (weekday) {
+      parts.push(weekday);
+    }
+    var timeRange = formatTimeRangeDisplay(occurrence.start, occurrence.end);
+    if (timeRange) {
+      parts.push(timeRange);
+    }
+    if (parts.length) {
+      var timeEl = document.createElement('time');
+      timeEl.className = 'calendar-block__time';
+      timeEl.dateTime = occurrence.start.toISOString();
+      timeEl.textContent = parts.join(' • ');
+      metaLine.appendChild(timeEl);
+      meta.appendChild(metaLine);
+    }
+
+    if (settings.showCategory && occurrence.category) {
+      var badge = document.createElement('span');
+      badge.className = 'calendar-block__category';
+      badge.textContent = occurrence.category;
+      meta.appendChild(badge);
+    }
+
+    if (meta.childNodes.length) {
+      body.appendChild(meta);
+    }
+
+    if (settings.showDescription && occurrence.description) {
+      var description = document.createElement('p');
+      description.className = 'calendar-block__description';
+      description.textContent = occurrence.description;
+      body.appendChild(description);
+    }
+
+    item.appendChild(body);
+    return item;
+  }
+
+  function renderCalendarBlock(container) {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+    var itemsHost = container.querySelector('[data-calendar-items]');
+    if (!itemsHost) {
+      return;
+    }
+    itemsHost.innerHTML = '';
+    hideCalendarEmpty(container);
+    var loading = document.createElement('article');
+    loading.className = 'calendar-block__item calendar-block__item--placeholder';
+    var loadingBody = document.createElement('div');
+    loadingBody.className = 'calendar-block__body';
+    var loadingTitle = document.createElement('h3');
+    loadingTitle.className = 'calendar-block__title';
+    loadingTitle.textContent = 'Loading events…';
+    loadingBody.appendChild(loadingTitle);
+    loading.appendChild(loadingBody);
+    itemsHost.appendChild(loading);
+
+    var layout = normalizeCalendarLayout(container.dataset.calendarLayout);
+    container.dataset.calendarLayout = layout;
+    container.classList.remove('calendar-block--layout-list', 'calendar-block--layout-cards', 'calendar-block--layout-compact');
+    container.classList.add('calendar-block--layout-' + layout);
+
+    var limit = parsePositiveInt(container.dataset.calendarLimit, 6);
+    var category = normalizeCategory(container.dataset.calendarCategory);
+    var emptyMessage = container.dataset.calendarEmptyMessage || 'No upcoming events found.';
+    var showDescription = String(container.dataset.calendarDescription || '').toLowerCase();
+    var showCategory = String(container.dataset.calendarShowCategory || '').toLowerCase();
+    var showDescriptionFlag = showDescription !== 'no' && showDescription !== 'false' && showDescription !== 'hide';
+    var showCategoryFlag = showCategory !== 'no' && showCategory !== 'false' && showCategory !== 'hide';
+
+    fetchCalendarEvents()
+      .then(function (records) {
+        var now = new Date();
+        var occurrences = buildCalendarOccurrences(records, {
+          now: now,
+          windowStart: now,
+          windowEnd: null,
+          limit: limit,
+          category: category,
+          perEventLimit: Math.max(limit * 3, 18),
+          maxIterations: Math.max(limit * 6, 120)
+        });
+        itemsHost.innerHTML = '';
+        if (!occurrences.length) {
+          showCalendarEmpty(container, emptyMessage);
+          return;
+        }
+        hideCalendarEmpty(container);
+        occurrences.forEach(function (occurrence) {
+          var node = createCalendarItem(occurrence, {
+            showDescription: showDescriptionFlag,
+            showCategory: showCategoryFlag
+          });
+          itemsHost.appendChild(node);
+        });
+      })
+      .catch(function () {
+        itemsHost.innerHTML = '';
+        showCalendarEmpty(container, 'Unable to load events right now.');
+      });
+  }
+
+  function initCalendarBlocks() {
+    var blocks = document.querySelectorAll('[data-calendar-block]');
+    blocks.forEach(function (block) {
+      renderCalendarBlock(block);
+    });
+  }
+
+  function initBlogLists() {
     var lists = document.querySelectorAll('[data-blog-list]');
     lists.forEach(function (container) {
       hydrate(container);
@@ -262,7 +688,8 @@
       return;
     }
     var observer = new MutationObserver(function (mutations) {
-      var shouldRefresh = false;
+      var shouldRefreshBlogs = false;
+      var shouldRefreshCalendars = false;
       mutations.forEach(function (mutation) {
         if (mutation.type !== 'childList') {
           return;
@@ -272,12 +699,18 @@
             return;
           }
           if (node.matches('[data-blog-list]') || node.querySelector('[data-blog-list]')) {
-            shouldRefresh = true;
+            shouldRefreshBlogs = true;
+          }
+          if (node.matches('[data-calendar-block]') || node.querySelector('[data-calendar-block]')) {
+            shouldRefreshCalendars = true;
           }
         });
       });
-      if (shouldRefresh) {
-        initAll();
+      if (shouldRefreshBlogs) {
+        initBlogLists();
+      }
+      if (shouldRefreshCalendars) {
+        initCalendarBlocks();
       }
     });
     observer.observe(document.body || document.documentElement, {
@@ -287,12 +720,17 @@
   }
 
   ready(function () {
-    initAll();
+    initBlogLists();
+    initCalendarBlocks();
     observe();
   });
 
   window.SparkCMSBlogLists = {
-    refresh: initAll
+    refresh: initBlogLists
+  };
+
+  window.SparkCMSCalendars = {
+    refresh: initCalendarBlocks
   };
 })();
 

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -248,7 +248,433 @@
       });
   }
 
-  function initAll() {
+  var calendarEventsPromise = null;
+
+  function fetchCalendarEvents() {
+    if (calendarEventsPromise) {
+      return calendarEventsPromise;
+    }
+    var base = normalizeBasePath();
+    var url = base + '/CMS/data/calendar_events.json';
+    calendarEventsPromise = fetch(url, { credentials: 'same-origin', cache: 'no-store' })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Failed to load calendar events');
+        }
+        return response.json();
+      })
+      .then(function (events) {
+        if (!Array.isArray(events)) {
+          return [];
+        }
+        return events.filter(function (event) {
+          return event && typeof event === 'object';
+        });
+      })
+      .catch(function (error) {
+        console.error('[SparkCMS] Calendar load error:', error);
+        calendarEventsPromise = null;
+        throw error;
+      });
+    return calendarEventsPromise;
+  }
+
+  function parsePositiveInt(value, fallback) {
+    var parsed = parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      return fallback;
+    }
+    return parsed;
+  }
+
+  function parseIsoDate(value) {
+    if (!value) {
+      return null;
+    }
+    var date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+    return date;
+  }
+
+  function addRecurringInterval(date, recurrence) {
+    if (!(date instanceof Date)) {
+      return null;
+    }
+    var next;
+    switch (recurrence) {
+      case 'daily':
+        next = new Date(date.getTime());
+        next.setDate(next.getDate() + 1);
+        return next;
+      case 'weekly':
+        next = new Date(date.getTime());
+        next.setDate(next.getDate() + 7);
+        return next;
+      case 'monthly':
+        next = new Date(date.getTime());
+        var day = next.getDate();
+        next.setDate(1);
+        next.setMonth(next.getMonth() + 1);
+        var daysInMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate();
+        next.setDate(Math.min(day, daysInMonth));
+        return next;
+      case 'yearly':
+        next = new Date(date.getTime());
+        var month = next.getMonth();
+        var dayOfMonth = next.getDate();
+        next.setDate(1);
+        next.setFullYear(next.getFullYear() + 1);
+        next.setMonth(month);
+        var maxDay = new Date(next.getFullYear(), month + 1, 0).getDate();
+        next.setDate(Math.min(dayOfMonth, maxDay));
+        return next;
+      default:
+        return null;
+    }
+  }
+
+  function expandEventOccurrences(event, options) {
+    var occurrences = [];
+    if (!event.start) {
+      return occurrences;
+    }
+    var duration = event.end ? Math.max(event.end.getTime() - event.start.getTime(), 0) : 0;
+    var start = new Date(event.start.getTime());
+    var recurrence = event.recurrence;
+    var recurrenceEnd = event.recurrenceEnd;
+    var perEventLimit = options.perEventLimit || 12;
+    var maxIterations = options.maxIterations || 120;
+    var windowStart = options.windowStart;
+    var windowEnd = options.windowEnd;
+    var sequence = 0;
+    var iterations = 0;
+    while (iterations < maxIterations) {
+      if (recurrenceEnd && start > recurrenceEnd) {
+        break;
+      }
+      var include = !windowStart || start >= windowStart;
+      if (include && (!windowEnd || start <= windowEnd)) {
+        var end = duration ? new Date(start.getTime() + duration) : null;
+        occurrences.push({
+          id: event.id,
+          title: event.title,
+          category: event.category,
+          description: event.description,
+          start: new Date(start.getTime()),
+          end: end,
+          recurrence: recurrence,
+          occurrenceIndex: sequence
+        });
+        if (occurrences.length >= perEventLimit) {
+          break;
+        }
+      }
+      if (recurrence === 'none') {
+        break;
+      }
+      var nextStart = addRecurringInterval(start, recurrence);
+      if (!nextStart || nextStart.getTime() === start.getTime()) {
+        break;
+      }
+      start = nextStart;
+      sequence += 1;
+      iterations += 1;
+    }
+    return occurrences;
+  }
+
+  function buildCalendarOccurrences(records, options) {
+    var now = options.now || new Date();
+    var windowStart = options.windowStart || now;
+    var windowEnd = options.windowEnd || null;
+    var perEventLimit = options.perEventLimit || 24;
+    var maxIterations = options.maxIterations || 120;
+    var normalizedCategory = options.category || '';
+    var limit = options.limit || 6;
+    var aggregated = [];
+    records.forEach(function (raw) {
+      if (!raw || typeof raw !== 'object') {
+        return;
+      }
+      var start = parseIsoDate(raw.start_date);
+      if (!start) {
+        return;
+      }
+      var event = {
+        id: raw.id,
+        title: raw.title || 'Untitled Event',
+        category: raw.category || '',
+        description: raw.description || '',
+        start: start,
+        end: parseIsoDate(raw.end_date),
+        recurrence: (raw.recurring_interval || 'none').toLowerCase(),
+        recurrenceEnd: parseIsoDate(raw.recurring_end_date)
+      };
+      if (['daily', 'weekly', 'monthly', 'yearly'].indexOf(event.recurrence) === -1) {
+        event.recurrence = 'none';
+      }
+      var occurrences = expandEventOccurrences(event, {
+        windowStart: windowStart,
+        windowEnd: windowEnd,
+        perEventLimit: perEventLimit,
+        maxIterations: maxIterations
+      });
+      occurrences.forEach(function (occurrence) {
+        if (normalizedCategory && normalizeCategory(occurrence.category) !== normalizedCategory) {
+          return;
+        }
+        aggregated.push(occurrence);
+      });
+    });
+    aggregated.sort(function (a, b) {
+      return a.start.getTime() - b.start.getTime();
+    });
+    if (limit && aggregated.length > limit) {
+      aggregated = aggregated.slice(0, limit);
+    }
+    return aggregated;
+  }
+
+  var MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  var WEEKDAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+  function formatMonthLabel(date) {
+    if (!(date instanceof Date)) {
+      return '--';
+    }
+    try {
+      return date.toLocaleDateString(undefined, { month: 'short' });
+    } catch (err) {
+      return MONTH_NAMES[date.getMonth()] || '';
+    }
+  }
+
+  function formatDayLabel(date) {
+    if (!(date instanceof Date)) {
+      return '--';
+    }
+    var day = date.getDate();
+    if (!Number.isFinite(day)) {
+      return '--';
+    }
+    return day < 10 ? '0' + day : String(day);
+  }
+
+  function formatWeekdayLabel(date) {
+    if (!(date instanceof Date)) {
+      return '';
+    }
+    try {
+      return date.toLocaleDateString(undefined, { weekday: 'short' });
+    } catch (err) {
+      return WEEKDAY_NAMES[date.getDay()] || '';
+    }
+  }
+
+  function formatTimeRangeDisplay(start, end) {
+    if (!(start instanceof Date)) {
+      return '';
+    }
+    var timeFormatter;
+    try {
+      timeFormatter = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' });
+    } catch (err) {
+      timeFormatter = null;
+    }
+    var dateFormatter;
+    try {
+      dateFormatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+    } catch (err) {
+      dateFormatter = null;
+    }
+    var startTime = timeFormatter ? timeFormatter.format(start) : start.toISOString().slice(11, 16);
+    if (!(end instanceof Date) || end.getTime() <= start.getTime()) {
+      return startTime;
+    }
+    var sameDay = start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth() && start.getDate() === end.getDate();
+    var endTime = timeFormatter ? timeFormatter.format(end) : end.toISOString().slice(11, 16);
+    if (sameDay) {
+      return startTime + ' – ' + endTime;
+    }
+    var startLabel = dateFormatter ? dateFormatter.format(start) : start.toISOString().slice(0, 10);
+    var endLabel = dateFormatter ? dateFormatter.format(end) : end.toISOString().slice(0, 10);
+    return startLabel + ' ' + startTime + ' – ' + endLabel + ' ' + endTime;
+  }
+
+  function normalizeCalendarLayout(value) {
+    var layout = (value || '').toString().toLowerCase();
+    if (layout !== 'cards' && layout !== 'compact') {
+      layout = 'list';
+    }
+    return layout;
+  }
+
+  function showCalendarEmpty(container, message) {
+    var empty = container.querySelector('[data-calendar-empty]');
+    if (!empty) {
+      empty = document.createElement('div');
+      empty.className = 'calendar-block__empty';
+      empty.setAttribute('data-calendar-empty', '');
+      container.appendChild(empty);
+    }
+    empty.textContent = message || '';
+    empty.classList.remove('d-none');
+  }
+
+  function hideCalendarEmpty(container) {
+    var empty = container.querySelector('[data-calendar-empty]');
+    if (empty) {
+      empty.classList.add('d-none');
+    }
+  }
+
+  function createCalendarItem(occurrence, settings) {
+    var item = document.createElement('article');
+    item.className = 'calendar-block__item';
+    item.setAttribute('data-calendar-event-id', String(occurrence.id));
+    item.setAttribute('data-calendar-occurrence', String(occurrence.occurrenceIndex));
+
+    var dateWrap = document.createElement('div');
+    dateWrap.className = 'calendar-block__date';
+    var monthSpan = document.createElement('span');
+    monthSpan.className = 'calendar-block__date-month';
+    monthSpan.textContent = formatMonthLabel(occurrence.start);
+    dateWrap.appendChild(monthSpan);
+    var daySpan = document.createElement('span');
+    daySpan.className = 'calendar-block__date-day';
+    daySpan.textContent = formatDayLabel(occurrence.start);
+    dateWrap.appendChild(daySpan);
+    item.appendChild(dateWrap);
+
+    var body = document.createElement('div');
+    body.className = 'calendar-block__body';
+
+    var title = document.createElement('h3');
+    title.className = 'calendar-block__title';
+    title.textContent = occurrence.title || 'Untitled Event';
+    body.appendChild(title);
+
+    var meta = document.createElement('div');
+    meta.className = 'calendar-block__meta';
+
+    var metaLine = document.createElement('div');
+    metaLine.className = 'calendar-block__meta-line';
+    var parts = [];
+    var weekday = formatWeekdayLabel(occurrence.start);
+    if (weekday) {
+      parts.push(weekday);
+    }
+    var timeRange = formatTimeRangeDisplay(occurrence.start, occurrence.end);
+    if (timeRange) {
+      parts.push(timeRange);
+    }
+    if (parts.length) {
+      var timeEl = document.createElement('time');
+      timeEl.className = 'calendar-block__time';
+      timeEl.dateTime = occurrence.start.toISOString();
+      timeEl.textContent = parts.join(' • ');
+      metaLine.appendChild(timeEl);
+      meta.appendChild(metaLine);
+    }
+
+    if (settings.showCategory && occurrence.category) {
+      var badge = document.createElement('span');
+      badge.className = 'calendar-block__category';
+      badge.textContent = occurrence.category;
+      meta.appendChild(badge);
+    }
+
+    if (meta.childNodes.length) {
+      body.appendChild(meta);
+    }
+
+    if (settings.showDescription && occurrence.description) {
+      var description = document.createElement('p');
+      description.className = 'calendar-block__description';
+      description.textContent = occurrence.description;
+      body.appendChild(description);
+    }
+
+    item.appendChild(body);
+    return item;
+  }
+
+  function renderCalendarBlock(container) {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+    var itemsHost = container.querySelector('[data-calendar-items]');
+    if (!itemsHost) {
+      return;
+    }
+    itemsHost.innerHTML = '';
+    hideCalendarEmpty(container);
+    var loading = document.createElement('article');
+    loading.className = 'calendar-block__item calendar-block__item--placeholder';
+    var loadingBody = document.createElement('div');
+    loadingBody.className = 'calendar-block__body';
+    var loadingTitle = document.createElement('h3');
+    loadingTitle.className = 'calendar-block__title';
+    loadingTitle.textContent = 'Loading events…';
+    loadingBody.appendChild(loadingTitle);
+    loading.appendChild(loadingBody);
+    itemsHost.appendChild(loading);
+
+    var layout = normalizeCalendarLayout(container.dataset.calendarLayout);
+    container.dataset.calendarLayout = layout;
+    container.classList.remove('calendar-block--layout-list', 'calendar-block--layout-cards', 'calendar-block--layout-compact');
+    container.classList.add('calendar-block--layout-' + layout);
+
+    var limit = parsePositiveInt(container.dataset.calendarLimit, 6);
+    var category = normalizeCategory(container.dataset.calendarCategory);
+    var emptyMessage = container.dataset.calendarEmptyMessage || 'No upcoming events found.';
+    var showDescription = String(container.dataset.calendarDescription || '').toLowerCase();
+    var showCategory = String(container.dataset.calendarShowCategory || '').toLowerCase();
+    var showDescriptionFlag = showDescription !== 'no' && showDescription !== 'false' && showDescription !== 'hide';
+    var showCategoryFlag = showCategory !== 'no' && showCategory !== 'false' && showCategory !== 'hide';
+
+    fetchCalendarEvents()
+      .then(function (records) {
+        var now = new Date();
+        var occurrences = buildCalendarOccurrences(records, {
+          now: now,
+          windowStart: now,
+          windowEnd: null,
+          limit: limit,
+          category: category,
+          perEventLimit: Math.max(limit * 3, 18),
+          maxIterations: Math.max(limit * 6, 120)
+        });
+        itemsHost.innerHTML = '';
+        if (!occurrences.length) {
+          showCalendarEmpty(container, emptyMessage);
+          return;
+        }
+        hideCalendarEmpty(container);
+        occurrences.forEach(function (occurrence) {
+          var node = createCalendarItem(occurrence, {
+            showDescription: showDescriptionFlag,
+            showCategory: showCategoryFlag
+          });
+          itemsHost.appendChild(node);
+        });
+      })
+      .catch(function () {
+        itemsHost.innerHTML = '';
+        showCalendarEmpty(container, 'Unable to load events right now.');
+      });
+  }
+
+  function initCalendarBlocks() {
+    var blocks = document.querySelectorAll('[data-calendar-block]');
+    blocks.forEach(function (block) {
+      renderCalendarBlock(block);
+    });
+  }
+
+  function initBlogLists() {
     var lists = document.querySelectorAll('[data-blog-list]');
     lists.forEach(function (container) {
       hydrate(container);
@@ -260,7 +686,8 @@
       return;
     }
     var observer = new MutationObserver(function (mutations) {
-      var shouldRefresh = false;
+      var shouldRefreshBlogs = false;
+      var shouldRefreshCalendars = false;
       mutations.forEach(function (mutation) {
         if (mutation.type !== 'childList') {
           return;
@@ -270,12 +697,18 @@
             return;
           }
           if (node.matches('[data-blog-list]') || node.querySelector('[data-blog-list]')) {
-            shouldRefresh = true;
+            shouldRefreshBlogs = true;
+          }
+          if (node.matches('[data-calendar-block]') || node.querySelector('[data-calendar-block]')) {
+            shouldRefreshCalendars = true;
           }
         });
       });
-      if (shouldRefresh) {
-        initAll();
+      if (shouldRefreshBlogs) {
+        initBlogLists();
+      }
+      if (shouldRefreshCalendars) {
+        initCalendarBlocks();
       }
     });
     observer.observe(document.body || document.documentElement, {
@@ -285,11 +718,16 @@
   }
 
   ready(function () {
-    initAll();
+    initBlogLists();
+    initCalendarBlocks();
     observe();
   });
 
   window.SparkCMSBlogLists = {
-    refresh: initAll
+    refresh: initBlogLists
+  };
+
+  window.SparkCMSCalendars = {
+    refresh: initCalendarBlocks
   };
 })();

--- a/theme/templates/blocks/interactive.calendar.php
+++ b/theme/templates/blocks/interactive.calendar.php
@@ -1,0 +1,66 @@
+<!-- File: interactive.calendar.php -->
+<!-- Template: interactive.calendar -->
+<templateSetting caption="Calendar Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Display Style</dt>
+        <dd>
+            <select name="custom_layout">
+                <option value="list" selected>Event list</option>
+                <option value="cards">Event cards</option>
+                <option value="compact">Compact list</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Events to Display</dt>
+        <dd>
+            <input type="number" name="custom_limit" value="6" min="1" max="50" />
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Category Filter</dt>
+        <dd>
+            <input type="text" name="custom_category" value="" placeholder="Leave blank for all categories" />
+            <p class="mt-2 small text-muted">Match category names exactly to filter results.</p>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Show Descriptions</dt>
+        <dd>
+            <select name="custom_show_description">
+                <option value="yes" selected>Show</option>
+                <option value="no">Hide</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Show Categories</dt>
+        <dd>
+            <select name="custom_show_category">
+                <option value="yes" selected>Show</option>
+                <option value="no">Hide</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Empty State Message</dt>
+        <dd>
+            <input type="text" name="custom_empty" value="No upcoming events found." />
+        </dd>
+    </dl>
+</templateSetting>
+<div class="calendar-block calendar-block--layout-{custom_layout}" data-calendar-block data-calendar-layout="{custom_layout}" data-calendar-limit="{custom_limit}" data-calendar-category="{custom_category}" data-calendar-description="{custom_show_description}" data-calendar-show-category="{custom_show_category}" data-calendar-empty-message="{custom_empty}">
+    <div class="calendar-block__items" data-calendar-items>
+        <article class="calendar-block__item calendar-block__item--placeholder" aria-live="polite">
+            <div class="calendar-block__date">
+                <span class="calendar-block__date-month">--</span>
+                <span class="calendar-block__date-day">--</span>
+            </div>
+            <div class="calendar-block__body">
+                <h3 class="calendar-block__title">Loading events…</h3>
+                <p class="calendar-block__description">Calendar events will appear here once published.</p>
+            </div>
+        </article>
+    </div>
+    <div class="calendar-block__empty d-none" data-calendar-empty>{custom_empty}</div>
+</div>


### PR DESCRIPTION
## Summary
- add a new interactive calendar block template with configurable layout, limits, and messaging
- implement client-side calendar rendering with recurrence handling and block hydration support
- style the calendar block layouts and regenerate the combined frontend bundle

## Testing
- php bundle.php

------
https://chatgpt.com/codex/tasks/task_e_68db3f56b06c8331b6f33a4d84045e25