### PR TITLE
Adjust pages list cell layout

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2680,8 +2680,6 @@
         }
 
         .pages-list-cell {
-            display: flex;
-            flex-direction: column;
             gap: 6px;
         }
 


### PR DESCRIPTION
## Summary
- remove the flex layout declarations from the `.pages-list-cell` rule to revert to default table cell layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db487ea3488331ada01d0f01516cc4