### PR TITLE
Remove attendance components from events dashboard

### DIFF
--- a/CMS/modules/events/events.js
+++ b/CMS/modules/events/events.js
@@ -32,16 +32,6 @@
             filterStatus: root.querySelector('[data-events-orders-filter="status"]'),
             exportBtn: root.querySelector('[data-events-export]'),
         },
-        attendance: {
-            wrapper: root.querySelector('[data-events-attendance]'),
-            event: root.querySelector('[data-events-attendance="event"]'),
-            stats: root.querySelector('[data-events-attendance="stats"]'),
-            rate: root.querySelector('.events-attendance-rate'),
-            detail: root.querySelector('.events-attendance-detail'),
-            input: root.querySelector('[data-events-attendance="input"]'),
-            apply: root.querySelector('[data-events-attendance="apply"]'),
-            list: root.querySelector('[data-events-attendance="orders"]'),
-        },
         reports: {
             tableBody: root.querySelector('[data-events-reports-table]'),
         },
@@ -186,19 +176,6 @@
         if (selectors.stats.revenue) {
             const revenue = stats.total_revenue ?? 0;
             selectors.stats.revenue.textContent = formatCurrency(revenue);
-        }
-        const heroMeta = selectors.attendance.wrapper;
-        if (heroMeta) {
-            const count = stats.attendance_checked_in ?? stats.checked_in ?? 0;
-            const capacity = stats.attendance_capacity ?? stats.capacity ?? 0;
-            const countNode = heroMeta.querySelector('.events-hero-count');
-            const labelNode = heroMeta.querySelector('.events-hero-label');
-            if (countNode) {
-                countNode.textContent = count;
-            }
-            if (labelNode) {
-                labelNode.textContent = `Checked-in of ${Math.max(capacity, 1)} capacity`;
-            }
         }
     }
 
@@ -411,80 +388,6 @@
             }
             table.appendChild(row);
         });
-    }
-
-    function updateAttendancePanel() {
-        if (!selectors.attendance.event) {
-            return;
-        }
-        const eventId = selectors.attendance.event.value;
-        if (!eventId) {
-            selectors.attendance.rate.textContent = '0% attended';
-            selectors.attendance.detail.textContent = '0 of 0 tickets';
-            selectors.attendance.input.value = '0';
-            selectors.attendance.list.innerHTML = '<li class="events-empty">Select an event to begin tracking attendance.</li>';
-            return;
-        }
-        const event = state.events.get(eventId);
-        const metrics = state.eventRows.find((row) => row.id === eventId);
-        const sales = state.salesSummary.find((row) => row.event_id === eventId);
-        const capacity = metrics ? (metrics.capacity ?? 0) : 0;
-        const checkedIn = sales ? (sales.checked_in ?? 0) : 0;
-        const sold = metrics ? (metrics.tickets_sold ?? 0) : 0;
-        const rate = capacity > 0 ? Math.round((checkedIn / capacity) * 100) : 0;
-        selectors.attendance.rate.textContent = `${rate}% attended`;
-        selectors.attendance.detail.textContent = `${checkedIn} of ${sold || capacity} tickets`;
-        selectors.attendance.input.value = String(checkedIn);
-        if (event && event.track_attendance) {
-            selectors.attendance.input.removeAttribute('disabled');
-            selectors.attendance.apply.removeAttribute('disabled');
-        } else {
-            selectors.attendance.input.setAttribute('disabled', 'true');
-            selectors.attendance.apply.setAttribute('disabled', 'true');
-        }
-
-        const relatedOrders = state.orders.filter((order) => order.event === (event ? event.title : '') || order.event_id === eventId);
-        selectors.attendance.list.innerHTML = '';
-        if (relatedOrders.length === 0) {
-            const li = document.createElement('li');
-            li.className = 'events-empty';
-            li.textContent = 'No orders yet. Attendance will appear as sales come in.';
-            selectors.attendance.list.appendChild(li);
-        } else {
-            relatedOrders.slice(0, 5).forEach((order) => {
-                const li = document.createElement('li');
-                li.innerHTML = `<strong>${order.buyer_name || order.id}</strong> checked in ${order.checked_in ?? 0} of ${order.tickets ?? 0}`;
-                selectors.attendance.list.appendChild(li);
-            });
-        }
-    }
-
-    function updateAttendanceOptions() {
-        populateEventSelect(selectors.orders.filterEvent);
-        const attendanceSelect = selectors.attendance.event;
-        if (!attendanceSelect) {
-            return;
-        }
-        const current = attendanceSelect.value;
-        attendanceSelect.innerHTML = '';
-        const placeholder = document.createElement('option');
-        placeholder.value = '';
-        placeholder.textContent = 'Select event';
-        attendanceSelect.appendChild(placeholder);
-        Array.from(state.events.values()).forEach((event) => {
-            const option = document.createElement('option');
-            option.value = event.id;
-            option.textContent = event.title || 'Untitled event';
-            if (!event.track_attendance) {
-                option.dataset.disabled = 'true';
-                option.textContent += ' (tracking off)';
-            }
-            attendanceSelect.appendChild(option);
-        });
-        if (current && attendanceSelect.querySelector(`option[value="${current}"]`)) {
-            attendanceSelect.value = current;
-        }
-        updateAttendancePanel();
     }
 
     function openModal(modal) {
@@ -719,7 +622,6 @@
             .then((response) => {
                 state.orders = Array.isArray(response.orders) ? response.orders : [];
                 renderOrdersTable();
-                updateAttendancePanel();
             })
             .catch(() => {
                 showToast('Unable to load orders.', 'error');
@@ -737,7 +639,7 @@
                     }
                 });
                 renderEventsTable();
-                updateAttendanceOptions();
+                populateEventSelect(selectors.orders.filterEvent);
             })
             .catch(() => {
                 showToast('Unable to load events.', 'error');
@@ -751,8 +653,6 @@
                     total_events: response.stats?.total_events,
                     total_tickets_sold: response.stats?.total_tickets_sold,
                     total_revenue: response.stats?.total_revenue,
-                    attendance_checked_in: response.attendance?.checked_in,
-                    attendance_capacity: response.attendance?.capacity,
                 });
                 const upcoming = (response.upcoming || []).map((item) => ({
                     ...item,
@@ -769,7 +669,6 @@
         return fetchJSON('reports_summary')
             .then((response) => {
                 state.salesSummary = Array.isArray(response.reports) ? response.reports : [];
-                updateAttendancePanel();
                 renderReportsTable();
             })
             .catch(() => {
@@ -861,28 +760,6 @@
                 window.open(`${endpoint}?action=export_orders`, '_blank');
             });
         }
-        if (selectors.attendance.event) {
-            selectors.attendance.event.addEventListener('change', updateAttendancePanel);
-        }
-        if (selectors.attendance.apply) {
-            selectors.attendance.apply.addEventListener('click', () => {
-                const eventId = selectors.attendance.event.value;
-                const value = parseInt(selectors.attendance.input.value || '0', 10);
-                if (!eventId) {
-                    showToast('Select an event first.', 'error');
-                    return;
-                }
-                fetchJSON('update_attendance', { method: 'POST', body: { event_id: eventId, attended: value } })
-                    .then(() => {
-                        showToast('Attendance updated.');
-                        refreshReportsSummary();
-                        refreshOverview();
-                    })
-                    .catch(() => {
-                        showToast('Unable to update attendance.', 'error');
-                    });
-            });
-        }
         if (selectors.orders.body) {
             selectors.orders.body.addEventListener('click', (event) => {
                 const button = event.target.closest('[data-order-checkin]');
@@ -948,7 +825,6 @@
         handleEventForm();
         attachEventListeners();
         populateEventSelect(selectors.orders.filterEvent);
-        updateAttendanceOptions();
         renderEventsTable();
         renderOrdersTable();
         renderReportsTable();

--- a/CMS/modules/events/view.php
+++ b/CMS/modules/events/view.php
@@ -17,14 +17,6 @@ $totalTicketsSold = array_sum(array_column($salesByEvent, 'tickets_sold'));
 $totalRevenue = array_sum(array_column($salesByEvent, 'revenue'));
 $upcoming = array_slice(events_filter_upcoming($events), 0, 5);
 
-$attendanceCheckedIn = array_sum(array_map(static function ($metrics) {
-    return $metrics['checked_in'] ?? 0;
-}, $salesByEvent));
-
-$attendanceCapacity = array_sum(array_map(static function ($event) {
-    return events_ticket_capacity($event, true);
-}, $events));
-
 $initialPayload = [
     'events' => $events,
     'orders' => $orders,
@@ -45,10 +37,6 @@ $initialPayload = [
                         <i class="fa-solid fa-plus" aria-hidden="true"></i>
                         <span>Create New Event</span>
                     </button>
-                    <div class="events-hero-meta" data-events-attendance>
-                        <span class="events-hero-count"><?php echo (int) $attendanceCheckedIn; ?></span>
-                        <span class="events-hero-label">Checked-in of <?php echo max(1, (int) $attendanceCapacity); ?> capacity</span>
-                    </div>
                 </div>
             </div>
             <div class="events-overview-grid">
@@ -189,37 +177,6 @@ $initialPayload = [
                         </tr>
                     </tbody>
                 </table>
-            </div>
-        </section>
-
-        <section class="events-section events-attendance" aria-labelledby="eventsAttendanceTitle">
-            <header class="events-section-header">
-                <div>
-                    <h3 class="events-section-title" id="eventsAttendanceTitle">Attendance tracking</h3>
-                    <p class="events-section-description">Mark attendees as checked in with manual entry. Scanning tools can be added later.</p>
-                </div>
-            </header>
-            <div class="events-attendance-grid">
-                <div class="events-attendance-panel">
-                    <label for="eventsAttendanceEvent">Choose event</label>
-                    <select id="eventsAttendanceEvent" data-events-attendance="event"></select>
-                    <div class="events-attendance-stats" data-events-attendance="stats">
-                        <span class="events-attendance-rate">0% attended</span>
-                        <span class="events-attendance-detail">0 of 0 tickets</span>
-                    </div>
-                    <div class="events-attendance-controls">
-                        <label for="eventsAttendanceCheckin">Manual check-ins</label>
-                        <input type="number" id="eventsAttendanceCheckin" min="0" value="0" data-events-attendance="input">
-                        <button type="button" class="a11y-btn a11y-btn--secondary" data-events-attendance="apply">Update attendance</button>
-                    </div>
-                    <p class="events-attendance-note">Attendance tracking is optional. Enable it per event to unlock the check-in workflow.</p>
-                </div>
-                <div class="events-attendance-orders">
-                    <h4>Recent check-ins</h4>
-                    <ul class="events-attendance-list" data-events-attendance="orders">
-                        <li class="events-empty">Select an event to begin tracking attendance.</li>
-                    </ul>
-                </div>
             </div>
         </section>
 

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -11597,56 +11597,6 @@ body.calendar-modal-open {
     letter-spacing: 0.05em;
 }
 
-.events-attendance-grid {
-    display: grid;
-    gap: 2rem;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-}
-
-.events-attendance-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    padding: 1.5rem;
-    border-radius: 1rem;
-    border: 1px solid #e2e8f0;
-    background: #f8fafc;
-}
-
-.events-attendance-stats {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    font-weight: 600;
-    color: #0f172a;
-}
-
-.events-attendance-controls {
-    display: grid;
-    gap: 0.75rem;
-}
-
-.events-attendance-controls input[type='number'] {
-    padding: 0.65rem 0.85rem;
-    border-radius: 0.75rem;
-    border: 1px solid #cbd5f5;
-}
-
-.events-attendance-orders {
-    border-radius: 1rem;
-    border: 1px solid #e2e8f0;
-    padding: 1.5rem;
-    background: #fff;
-}
-
-.events-attendance-list {
-    list-style: none;
-    margin: 1rem 0 0;
-    padding: 0;
-    display: grid;
-    gap: 0.75rem;
-}
-
 .events-ticketing {
     margin-top: 2rem;
     border-top: 1px solid #e2e8f0;


### PR DESCRIPTION
## Summary
- remove the attendance hero metric and management panel from the events dashboard template
- simplify the events dashboard script by dropping attendance selectors, listeners, and refresh logic
- delete unused attendance styling so ticketing styles follow upcoming event rules directly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc0e9f21a48331b238e43fd858f9a4