### PR TITLE
Prevent calendar module from collapsing the admin sidebar

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -301,6 +301,7 @@
         /* Sidebar */
         .sidebar {
             width: 280px;
+            flex: 0 0 280px;
             background: linear-gradient(135deg, var(--color-primary) 0%, #764ba2 100%);
             color: var(--color-text-inverse);
             position: sticky;


### PR DESCRIPTION
## Summary
- prevent the calendar dashboard layout from shrinking the admin sidebar on wider viewports by locking its flex size

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68dc0c125a648331a76a26bc3b357e69