### PR TITLE
Add sortable columns to blogs table

### DIFF
--- a/CMS/modules/blogs/view.php
+++ b/CMS/modules/blogs/view.php
@@ -101,12 +101,37 @@
                 <table class="data-table blog-table">
                     <thead>
                         <tr>
-                            <th>Title</th>
-                            <th>Author</th>
-                            <th>Category</th>
-                            <th>Status</th>
-                            <th>Date</th>
-                            <th>Actions</th>
+                            <th scope="col" aria-sort="none">
+                                <button type="button" class="blog-sort-btn" data-blog-sort="title" data-default-direction="asc">
+                                    <span>Title</span>
+                                    <span class="blog-sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th scope="col" aria-sort="none">
+                                <button type="button" class="blog-sort-btn" data-blog-sort="author" data-default-direction="asc">
+                                    <span>Author</span>
+                                    <span class="blog-sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th scope="col" aria-sort="none">
+                                <button type="button" class="blog-sort-btn" data-blog-sort="category" data-default-direction="asc">
+                                    <span>Category</span>
+                                    <span class="blog-sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th scope="col" aria-sort="none">
+                                <button type="button" class="blog-sort-btn" data-blog-sort="status" data-default-direction="desc">
+                                    <span>Status</span>
+                                    <span class="blog-sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th scope="col" aria-sort="none">
+                                <button type="button" class="blog-sort-btn" data-blog-sort="date" data-default-direction="desc">
+                                    <span>Date</span>
+                                    <span class="blog-sort-indicator" aria-hidden="true"></span>
+                                </button>
+                            </th>
+                            <th scope="col" class="blog-table-actions-header">Actions</th>
                         </tr>
                     </thead>
                     <tbody id="postsTableBody"></tbody>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -2740,7 +2740,8 @@
             white-space: nowrap;
         }
 
-        .pages-sort-btn {
+        .pages-sort-btn,
+        .blog-sort-btn {
             display: inline-flex;
             align-items: center;
             gap: 8px;
@@ -2754,27 +2755,32 @@
             letter-spacing: inherit;
         }
 
-        .pages-sort-btn .pages-sort-indicator::before {
+        .pages-sort-btn .pages-sort-indicator::before,
+        .blog-sort-btn .blog-sort-indicator::before {
             content: '\21F5';
             font-size: 11px;
             color: #94a3b8;
         }
 
-        .pages-sort-btn.is-active {
+        .pages-sort-btn.is-active,
+        .blog-sort-btn.is-active {
             color: #1f2937;
         }
 
-        .pages-sort-btn.sort-asc .pages-sort-indicator::before {
+        .pages-sort-btn.sort-asc .pages-sort-indicator::before,
+        .blog-sort-btn.sort-asc .blog-sort-indicator::before {
             content: '\25B2';
             color: #4338ca;
         }
 
-        .pages-sort-btn.sort-desc .pages-sort-indicator::before {
+        .pages-sort-btn.sort-desc .pages-sort-indicator::before,
+        .blog-sort-btn.sort-desc .blog-sort-indicator::before {
             content: '\25BC';
             color: #4338ca;
         }
 
-        .pages-sort-btn:focus-visible {
+        .pages-sort-btn:focus-visible,
+        .blog-sort-btn:focus-visible {
             outline: 2px solid #4338ca;
             outline-offset: 2px;
             border-radius: 6px;


### PR DESCRIPTION
## Summary
- add sortable column headers to the blogs module table UI
- implement client-side sorting logic and row data attributes for blog posts
- share the sort button styling rules with the blogs module

## Testing
- php -l CMS/modules/blogs/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc4c81cbb08331b505d382707551ca