### PR TITLE
Add category management to events module

### DIFF
--- a/CMS/data/event_categories.json
+++ b/CMS/data/event_categories.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "evtcat_conference",
+    "name": "Conference",
+    "slug": "conference",
+    "created_at": "2024-06-01T12:00:00Z",
+    "updated_at": "2024-06-01T12:00:00Z"
+  },
+  {
+    "id": "evtcat_inperson",
+    "name": "In-person",
+    "slug": "in-person",
+    "created_at": "2024-06-01T12:00:00Z",
+    "updated_at": "2024-06-01T12:00:00Z"
+  },
+  {
+    "id": "evtcat_virtual",
+    "name": "Virtual",
+    "slug": "virtual",
+    "created_at": "2024-06-01T12:00:00Z",
+    "updated_at": "2024-06-01T12:00:00Z"
+  }
+]

--- a/CMS/data/events.json
+++ b/CMS/data/events.json
@@ -23,6 +23,10 @@
         "enabled": true
       }
     ],
+    "categories": [
+      "evtcat_conference",
+      "evtcat_inperson"
+    ],
     "created_at": "2024-06-01T12:00:00Z",
     "published_at": "2024-06-01T12:05:00Z",
     "updated_at": "2024-06-01T12:05:00Z"
@@ -51,6 +55,9 @@
         "enabled": true
       }
     ],
+    "categories": [
+      "evtcat_virtual"
+    ],
     "created_at": "2024-08-15T10:00:00Z",
     "updated_at": "2024-08-15T10:00:00Z"
   },
@@ -70,6 +77,9 @@
         "quantity": 150,
         "enabled": true
       }
+    ],
+    "categories": [
+      "evtcat_inperson"
     ],
     "created_at": "2024-05-10T09:15:00Z",
     "published_at": "2024-05-12T11:00:00Z",

--- a/CMS/modules/events/view.php
+++ b/CMS/modules/events/view.php
@@ -10,6 +10,7 @@ events_ensure_storage();
 
 $events = events_read_events();
 $orders = events_read_orders();
+$categories = events_read_categories();
 $salesByEvent = events_compute_sales($events, $orders);
 
 $totalEvents = count($events);
@@ -21,6 +22,7 @@ $initialPayload = [
     'events' => $events,
     'orders' => $orders,
     'sales' => $salesByEvent,
+    'categories' => $categories,
 ];
 ?>
 <div class="content-section" id="events">
@@ -36,6 +38,10 @@ $initialPayload = [
                     <button type="button" class="a11y-btn a11y-btn--primary" data-events-open="event">
                         <i class="fa-solid fa-plus" aria-hidden="true"></i>
                         <span>Create New Event</span>
+                    </button>
+                    <button type="button" class="a11y-btn a11y-btn--ghost" data-events-open="categories">
+                        <i class="fa-solid fa-tags" aria-hidden="true"></i>
+                        <span>Manage Categories</span>
                     </button>
                 </div>
             </div>
@@ -259,6 +265,17 @@ $initialPayload = [
                         <span>End date &amp; time</span>
                         <input type="datetime-local" name="end">
                     </label>
+                    <fieldset class="events-form-field span-2">
+                        <legend>Categories</legend>
+                        <p class="events-form-help">Tag this event to improve filtering and reporting.</p>
+                        <div class="events-category-options" data-events-category-options>
+                            <p class="events-category-empty">No categories yet. Manage categories to create one.</p>
+                        </div>
+                        <button type="button" class="a11y-btn a11y-btn--ghost events-category-manage-btn" data-events-open="categories">
+                            <i class="fa-solid fa-tags" aria-hidden="true"></i>
+                            <span>Manage categories</span>
+                        </button>
+                    </fieldset>
                     <fieldset class="events-form-field">
                         <legend>Status</legend>
                         <label class="events-radio">
@@ -293,6 +310,55 @@ $initialPayload = [
                     <button type="submit" class="a11y-btn a11y-btn--primary">Save event</button>
                 </footer>
             </form>
+        </div>
+    </div>
+</div>
+
+<div class="events-modal-backdrop" data-events-modal="categories">
+    <div class="events-modal" role="dialog" aria-modal="true" aria-labelledby="eventsCategoriesTitle">
+        <header class="events-modal-header">
+            <h2 class="events-modal-title" id="eventsCategoriesTitle">Manage categories</h2>
+            <button type="button" class="events-modal-close" data-events-close>&times;<span class="sr-only">Close</span></button>
+        </header>
+        <div class="events-modal-body">
+            <div class="events-category-manage">
+                <form class="events-category-form" data-events-form="category" aria-labelledby="eventsCategoriesFormTitle">
+                    <h3 class="events-category-form-title" id="eventsCategoriesFormTitle" data-events-category-form-title>Create category</h3>
+                    <input type="hidden" name="id" value="">
+                    <div class="events-form-grid">
+                        <label class="events-form-field">
+                            <span>Name</span>
+                            <input type="text" name="name" required>
+                        </label>
+                        <label class="events-form-field">
+                            <span>Slug</span>
+                            <input type="text" name="slug" placeholder="Auto-generated if left blank">
+                        </label>
+                    </div>
+                    <p class="events-category-hint">Slugs are used in URLs and filters. Leave blank to auto-generate.</p>
+                    <div class="events-form-actions events-category-actions">
+                        <button type="button" class="a11y-btn a11y-btn--ghost" data-events-category-reset>Clear</button>
+                        <button type="submit" class="a11y-btn a11y-btn--primary" data-events-category-submit>Save category</button>
+                    </div>
+                </form>
+                <div class="events-category-table">
+                    <table class="data-table events-table events-categories-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Name</th>
+                                <th scope="col">Slug</th>
+                                <th scope="col">Updated</th>
+                                <th scope="col" class="is-actions">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody data-events-categories-list>
+                            <tr>
+                                <td colspan="4" class="events-empty">No categories yet. Create one above.</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -11827,6 +11827,107 @@ body.calendar-modal-open {
     background: #f8fafc;
 }
 
+.events-form-help {
+    color: #64748b;
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+.events-category-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.85rem;
+    background: #f8fafc;
+    min-height: 3.5rem;
+}
+
+.events-category-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: #fff;
+    border: 1px solid #cbd5f5;
+    font-size: 0.9rem;
+    color: #1e293b;
+}
+
+.events-category-item input {
+    accent-color: #4f46e5;
+}
+
+.events-category-empty {
+    margin: 0;
+    color: #64748b;
+    font-style: italic;
+}
+
+.events-category-manage-btn {
+    align-self: flex-start;
+    margin-top: 0.75rem;
+}
+
+.events-category-manage {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.events-category-manage .events-category-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.events-category-form-title {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.events-category-hint {
+    margin: 0;
+    color: #64748b;
+    font-size: 0.9rem;
+}
+
+.events-category-actions {
+    justify-content: flex-start;
+}
+
+.events-category-table {
+    border: 1px solid #e2e8f0;
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.events-categories-table th:nth-child(2),
+.events-categories-table td:nth-child(2),
+.events-categories-table th:nth-child(3),
+.events-categories-table td:nth-child(3) {
+    white-space: nowrap;
+}
+
+.events-category-manage .events-category-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.events-category-manage .events-category-actions .a11y-btn {
+    min-width: 8rem;
+}
+
+.events-category-table .events-table-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
 .events-order-checkin {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add helpers and API endpoints to persist event categories alongside existing datasets
- extend the events dashboard UI and client script to create, edit, and delete categories while assigning them to events
- apply styling updates and seed default category data for the events module

## Testing
- php -l CMS/modules/events/helpers.php
- php -l CMS/modules/events/api.php
- php -l CMS/modules/events/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc5089a8c08331bdb854731715433b