### PR TITLE
Add media-backed featured images to events

### DIFF
--- a/CMS/modules/events/api.php
+++ b/CMS/modules/events/api.php
@@ -89,6 +89,7 @@ function handle_overview(array $events, array $orders, array $salesByEvent): voi
         $upcomingPreview[] = [
             'id' => $id,
             'title' => $event['title'] ?? 'Untitled',
+            'image' => $event['image'] ?? '',
             'start' => $event['start'] ?? '',
             'tickets_sold' => $metrics['tickets_sold'] ?? 0,
             'revenue' => $metrics['revenue'] ?? 0,
@@ -121,6 +122,7 @@ function handle_list_events(array $events, array $salesByEvent): void
             'location' => $event['location'] ?? '',
             'start' => $start,
             'end' => $end,
+            'image' => $event['image'] ?? '',
             'status' => $event['status'] ?? 'draft',
             'tickets_sold' => $metrics['tickets_sold'] ?? 0,
             'revenue' => $metrics['revenue'] ?? 0,
@@ -175,6 +177,7 @@ function handle_save_event(array $events, array $categories): void
         'title' => $payload['title'] ?? '',
         'description' => $payload['description'] ?? '',
         'location' => $payload['location'] ?? '',
+        'image' => $payload['image'] ?? '',
         'start' => $payload['start'] ?? '',
         'end' => $payload['end'] ?? '',
         'status' => $payload['status'] ?? 'draft',

--- a/CMS/modules/events/helpers.php
+++ b/CMS/modules/events/helpers.php
@@ -236,6 +236,7 @@ if (!function_exists('events_normalize_event')) {
         $event['title'] = trim((string) ($event['title'] ?? 'Untitled Event'));
         $event['description'] = (string) ($event['description'] ?? '');
         $event['location'] = trim((string) ($event['location'] ?? ''));
+        $event['image'] = trim((string) ($event['image'] ?? ''));
         $event['start'] = (string) ($event['start'] ?? '');
         $event['end'] = (string) ($event['end'] ?? '');
         $event['status'] = in_array($event['status'] ?? '', ['draft', 'published', 'ended'], true)

--- a/CMS/modules/events/view.php
+++ b/CMS/modules/events/view.php
@@ -247,6 +247,25 @@ $initialPayload = [
                         <span>Location / Venue</span>
                         <input type="text" name="location" placeholder="Venue or meeting link">
                     </label>
+                    <div class="events-form-field">
+                        <span>Featured image</span>
+                        <div class="events-image-picker" data-events-image-picker>
+                            <input type="hidden" name="image" value="">
+                            <div class="events-image-preview" data-events-image-preview aria-live="polite">
+                                <span class="events-image-placeholder">No image selected yet.</span>
+                            </div>
+                            <div class="events-image-actions">
+                                <button type="button" class="a11y-btn a11y-btn--secondary" data-events-image-open>
+                                    <i class="fa-solid fa-image" aria-hidden="true"></i>
+                                    <span>Choose image</span>
+                                </button>
+                                <button type="button" class="a11y-btn a11y-btn--ghost" data-events-image-clear hidden>
+                                    <i class="fa-solid fa-trash-can" aria-hidden="true"></i>
+                                    <span>Remove image</span>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
                     <div class="events-form-field span-2">
                         <span>Description</span>
                         <div class="events-editor-toolbar" role="toolbar" aria-label="Formatting">
@@ -376,6 +395,24 @@ $initialPayload = [
             <button type="button" class="a11y-btn a11y-btn--ghost" data-events-close>Cancel</button>
             <button type="button" class="a11y-btn a11y-btn--danger" data-events-confirm>Confirm</button>
         </footer>
+    </div>
+</div>
+
+<div class="events-modal-backdrop" data-events-modal="media">
+    <div class="events-modal events-media-modal" role="dialog" aria-modal="true" aria-labelledby="eventsMediaModalTitle">
+        <header class="events-modal-header">
+            <h2 class="events-modal-title" id="eventsMediaModalTitle">Select featured image</h2>
+            <button type="button" class="events-modal-close" data-events-close>&times;<span class="sr-only">Close</span></button>
+        </header>
+        <div class="events-modal-body">
+            <div class="events-media-picker">
+                <label class="events-media-search">
+                    <span class="sr-only">Search media library</span>
+                    <input type="search" placeholder="Search media" data-events-media-search>
+                </label>
+                <div class="events-media-grid" data-events-media-grid role="listbox" aria-live="polite"></div>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -11743,6 +11743,51 @@ body.calendar-modal-open {
     margin-top: 0.35rem;
 }
 
+.events-image-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+    border: 1px dashed #cbd5f5;
+    border-radius: 1rem;
+    background: #f8fafc;
+}
+
+.events-image-preview {
+    border-radius: 0.9rem;
+    border: 1px solid #cbd5f5;
+    background: #fff;
+    min-height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.events-image-preview.has-image {
+    border-color: #6366f1;
+    background: #0f172a;
+}
+
+.events-image-preview img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.events-image-placeholder {
+    color: #64748b;
+    font-style: italic;
+    text-align: center;
+}
+
+.events-image-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
 .events-radio {
     display: flex;
     align-items: center;
@@ -11791,6 +11836,105 @@ body.calendar-modal-open {
 
 .events-modal-small {
     width: min(420px, 100%);
+}
+
+.events-media-modal {
+    width: min(760px, 100%);
+}
+
+.events-media-picker {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.events-media-search {
+    display: flex;
+    align-items: center;
+    border: 1px solid #cbd5f5;
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.events-media-search:focus-within {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+}
+
+.events-media-search input {
+    border: none;
+    background: transparent;
+    width: 100%;
+    font-size: 0.95rem;
+    padding: 0.35rem 0.25rem;
+    outline: none;
+}
+
+.events-media-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+}
+
+.events-media-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    border: 1px solid #cbd5f5;
+    border-radius: 0.85rem;
+    padding: 0.75rem;
+    background: #fff;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.events-media-item:hover,
+.events-media-item:focus-visible {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+    outline: none;
+}
+
+.events-media-thumb {
+    position: relative;
+    width: 100%;
+    padding-top: 62%;
+    border-radius: 0.75rem;
+    background: #eef2ff;
+    overflow: hidden;
+}
+
+.events-media-thumb img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.events-media-name {
+    font-weight: 600;
+    color: #1f2937;
+    font-size: 0.95rem;
+}
+
+.events-media-status {
+    text-align: center;
+    padding: 1.5rem;
+    border-radius: 0.85rem;
+    border: 1px dashed #cbd5f5;
+    background: #f8fafc;
+    color: #475569;
+    font-size: 0.95rem;
+}
+
+.events-media-status--error {
+    border-color: #f87171;
+    background: #fef2f2;
+    color: #b91c1c;
 }
 
 .events-modal-header {


### PR DESCRIPTION
## Summary
- add a featured image picker and media library modal to the events form
- persist event image values through normalization and API responses
- implement front-end logic and styling for the image preview and media results

## Testing
- php -l CMS/modules/events/api.php
- php -l CMS/modules/events/helpers.php
- php -l CMS/modules/events/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc5abc91e48331b7bff52fc8e1c78f