### PR TITLE
Add modal workflows for commerce category and product management

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -12144,6 +12144,25 @@ body.calendar-modal-open {
     border: 1px solid var(--color-border);
 }
 
+.commerce-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.commerce-card-copy {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+}
+
+.commerce-card-footer {
+    margin-top: auto;
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
 .commerce-card--primary {
     grid-column: span 2;
 }
@@ -12418,6 +12437,11 @@ body.calendar-modal-open {
     color: var(--color-text-secondary);
 }
 
+.commerce-chip--empty {
+    border-style: dashed;
+    color: var(--color-text-muted);
+}
+
 .commerce-table-actions {
     text-align: right;
 }
@@ -12549,6 +12573,17 @@ body.calendar-modal-open {
     border: 1px solid var(--color-border);
 }
 
+.commerce-stat-label {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+}
+
+.commerce-stat-value {
+    font-size: var(--font-size-lg);
+    font-weight: 700;
+    color: var(--color-text-primary);
+}
+
 .commerce-priority-list,
 .commerce-benchmark-list {
     list-style: none;
@@ -12669,6 +12704,80 @@ body.calendar-modal-open {
     color: var(--color-text-secondary);
 }
 
+.commerce-modal {
+    padding: 24px;
+    align-items: flex-start;
+}
+
+.commerce-modal__surface {
+    background: var(--color-surface);
+    border-radius: 24px;
+    width: min(640px, 100%);
+    max-height: 90vh;
+    overflow: hidden;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.2);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+
+.commerce-modal__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 20px;
+    padding: 6px;
+    border-radius: 999px;
+    cursor: pointer;
+}
+
+.commerce-modal__close:hover,
+.commerce-modal__close:focus-visible {
+    color: var(--color-text-primary);
+    background: var(--color-surface-subtle);
+}
+
+.commerce-modal__header {
+    padding: 28px 32px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.commerce-modal__eyebrow {
+    font-size: var(--font-size-xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: var(--color-primary-strong);
+}
+
+.commerce-modal__title {
+    margin: 0;
+    font-size: var(--font-size-xl);
+}
+
+.commerce-modal__description {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+}
+
+.commerce-modal__body {
+    padding: 24px 32px 32px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+body.commerce-modal-open {
+    overflow: hidden;
+}
+
 @media (max-width: 1024px) {
     .commerce-hero {
         padding: 24px;
@@ -12696,5 +12805,21 @@ body.calendar-modal-open {
     .commerce-workspace-tab {
         flex: 1 1 100%;
         text-align: left;
+    }
+
+    .commerce-modal {
+        padding: 16px;
+    }
+
+    .commerce-modal__surface {
+        border-radius: 18px;
+    }
+
+    .commerce-modal__header {
+        padding: 24px 24px 0;
+    }
+
+    .commerce-modal__body {
+        padding: 20px 24px 24px;
     }
 }


### PR DESCRIPTION
## Summary
- surface catalogue stats and quick actions in the commerce dashboard
- move category and product maintenance into dedicated modals with updated interactions
- refresh commerce styles to support the new cards and modal layouts

## Testing
- php -l CMS/modules/commerce/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc5c1761e88331bbf2236fd87b2e3c