### PR TITLE
Revamp events module reports experience

### DIFF
--- a/CMS/modules/events/view.php
+++ b/CMS/modules/events/view.php
@@ -188,25 +188,86 @@ $initialPayload = [
         <section class="events-section" aria-labelledby="eventsReportsTitle">
             <header class="events-section-header">
                 <div>
-                    <h3 class="events-section-title" id="eventsReportsTitle">Reports</h3>
-                    <p class="events-section-description">Download ticket sales and revenue summaries whenever you need them.</p>
-                </div>
-                <div class="events-section-actions">
-                    <button type="button" class="a11y-btn a11y-btn--secondary" data-events-report="tickets">Ticket sales report</button>
-                    <button type="button" class="a11y-btn a11y-btn--secondary" data-events-report="revenue">Revenue report</button>
+                    <h3 class="events-section-title" id="eventsReportsTitle">Reports &amp; insights</h3>
+                    <p class="events-section-description">Monitor performance, spotlight momentum, and share polished exports in seconds.</p>
                 </div>
             </header>
-            <div class="events-reports" data-events-reports>
-                <article class="events-report-card">
-                    <h4>Ticket sales</h4>
-                    <p>Download totals per event and ticket type to share with finance.</p>
-                    <button type="button" class="a11y-btn a11y-btn--ghost" data-events-report-download="tickets">Export CSV</button>
-                </article>
-                <article class="events-report-card">
-                    <h4>Revenue</h4>
-                    <p>Share top-line revenue with leadership by event and ticket type.</p>
-                    <button type="button" class="a11y-btn a11y-btn--ghost" data-events-report-download="revenue">Export CSV</button>
-                </article>
+            <div class="events-reports-shell">
+                <div class="events-reports-summary">
+                    <div class="events-report-metric-grid">
+                        <article class="events-report-metric">
+                            <p class="events-report-metric-label">Lifetime revenue</p>
+                            <p class="events-report-metric-value" data-events-report-metric="revenue">$0.00</p>
+                            <p class="events-report-metric-caption">Combined across every published event.</p>
+                        </article>
+                        <article class="events-report-metric">
+                            <p class="events-report-metric-label">Tickets sold</p>
+                            <p class="events-report-metric-value" data-events-report-metric="tickets">0</p>
+                            <p class="events-report-metric-caption">Total tickets issued for tracked events.</p>
+                        </article>
+                        <article class="events-report-metric">
+                            <p class="events-report-metric-label">Avg. ticket value</p>
+                            <p class="events-report-metric-value" data-events-report-metric="average">$0.00</p>
+                            <p class="events-report-metric-caption">Revenue divided by tickets sold.</p>
+                        </article>
+                        <article class="events-report-metric">
+                            <p class="events-report-metric-label">Active events</p>
+                            <p class="events-report-metric-value" data-events-report-metric="active">0</p>
+                            <p class="events-report-metric-caption">Currently published or on sale.</p>
+                        </article>
+                    </div>
+                    <div class="events-report-insights">
+                        <article class="events-report-highlight" data-events-report-highlight>
+                            <h4 class="events-report-highlight-title">Top earning event</h4>
+                            <p class="events-report-highlight-name" data-events-report-highlight="name">No sales data yet</p>
+                            <dl class="events-report-highlight-metrics">
+                                <div>
+                                    <dt>Revenue</dt>
+                                    <dd data-events-report-highlight="revenue">$0.00</dd>
+                                </div>
+                                <div>
+                                    <dt>Tickets sold</dt>
+                                    <dd data-events-report-highlight="tickets">0</dd>
+                                </div>
+                                <div>
+                                    <dt>Status</dt>
+                                    <dd data-events-report-highlight="status">—</dd>
+                                </div>
+                            </dl>
+                        </article>
+                        <div class="events-report-trends">
+                            <h4 class="events-report-subtitle">Momentum watch</h4>
+                            <p class="events-report-subtitle-meta">Spot the experiences driving the majority of ticket sales.</p>
+                            <ol class="events-report-top-list" data-events-reports-top>
+                                <li class="events-report-top-empty">No performance data yet.</li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+                <aside class="events-reports-downloads">
+                    <div class="events-report-download-intro">
+                        <h4 class="events-report-subtitle">On-demand exports</h4>
+                        <p>Hand finance and leadership the exact breakdowns they ask for.</p>
+                    </div>
+                    <div class="events-report-download-grid">
+                        <article class="events-report-download-card">
+                            <h5>Ticket sales</h5>
+                            <p>Totals per event and ticket type ready for reconciliation.</p>
+                            <div class="events-report-download-actions">
+                                <button type="button" class="a11y-btn a11y-btn--ghost" data-events-report="tickets">View summary</button>
+                                <button type="button" class="a11y-btn a11y-btn--secondary" data-events-report-download="tickets">Export CSV</button>
+                            </div>
+                        </article>
+                        <article class="events-report-download-card">
+                            <h5>Revenue</h5>
+                            <p>Share top-line revenue by event and ticket configuration.</p>
+                            <div class="events-report-download-actions">
+                                <button type="button" class="a11y-btn a11y-btn--ghost" data-events-report="revenue">View summary</button>
+                                <button type="button" class="a11y-btn a11y-btn--secondary" data-events-report-download="revenue">Export CSV</button>
+                            </div>
+                        </article>
+                    </div>
+                </aside>
             </div>
             <div class="events-table-wrapper">
                 <table class="data-table events-table events-reports-table">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -11938,20 +11938,296 @@ body.calendar-modal-open {
     color: #312e81;
 }
 
-.events-reports {
+.events-reports-shell {
     display: grid;
-    gap: 1.25rem;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+    gap: 2rem;
+    align-items: stretch;
 }
 
-.events-report-card {
-    border-radius: 1.25rem;
+.events-reports-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.events-report-metric-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.25rem;
+}
+
+.events-report-metric {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1.5rem;
+    padding: 1.75rem;
+    background: linear-gradient(135deg, #1d4ed8 0%, #1e293b 100%);
+    color: #f8fafc;
+    box-shadow: 0 18px 42px rgba(29, 78, 216, 0.25);
+}
+
+.events-report-metric::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(148, 163, 184, 0.35), transparent 55%);
+    pointer-events: none;
+}
+
+.events-report-metric > * {
+    position: relative;
+    z-index: 1;
+}
+
+.events-report-metric-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-weight: 700;
+    color: rgba(248, 250, 252, 0.78);
+    margin-bottom: 0.5rem;
+}
+
+.events-report-metric-value {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.events-report-metric-caption {
+    margin-top: 0.75rem;
+    font-size: 0.9rem;
+    color: rgba(248, 250, 252, 0.7);
+}
+
+.events-report-insights {
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+    gap: 1.5rem;
+    align-items: stretch;
+}
+
+.events-report-highlight {
+    border-radius: 1.5rem;
     border: 1px solid #e2e8f0;
-    padding: 1.5rem;
+    padding: 1.75rem;
+    background: #fff;
+    box-shadow: 0 20px 32px rgba(148, 163, 184, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.events-report-highlight.is-empty {
+    opacity: 0.7;
+}
+
+.events-report-highlight.is-empty .events-report-highlight-name {
+    color: #475569;
+}
+
+.events-report-highlight-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.events-report-highlight-name {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #1e3a8a;
+}
+
+.events-report-highlight-metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 1rem;
+}
+
+.events-report-highlight-metrics div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.events-report-highlight-metrics dt {
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+    font-weight: 700;
+}
+
+.events-report-highlight-metrics dd {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.events-report-trends {
+    border-radius: 1.5rem;
+    border: 1px dashed #cbd5f5;
+    padding: 1.75rem;
     background: #f8fafc;
     display: flex;
     flex-direction: column;
+    gap: 1.25rem;
+}
+
+.events-report-subtitle {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #1e3a8a;
+    margin: 0;
+}
+
+.events-report-subtitle-meta {
+    margin: 0;
+    color: #475569;
+    font-size: 0.9rem;
+}
+
+.events-report-top-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
     gap: 1rem;
+}
+
+.events-report-top-empty {
+    border-radius: 1rem;
+    padding: 1.25rem;
+    background: #e2e8f0;
+    color: #475569;
+    text-align: center;
+    font-weight: 600;
+}
+
+.events-report-top-item {
+    border-radius: 1rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    padding: 1.25rem;
+    box-shadow: 0 10px 24px rgba(148, 163, 184, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.events-report-top-header {
+    display: grid;
+    grid-template-columns: 32px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.events-report-top-rank {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: #1d4ed8;
+    color: #fff;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.events-report-top-name {
+    font-size: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.events-report-top-value {
+    font-size: 0.95rem;
+    color: #1f2937;
+    text-align: right;
+    font-weight: 600;
+}
+
+.events-report-top-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    color: #64748b;
+    font-size: 0.85rem;
+    flex-wrap: wrap;
+}
+
+.events-report-top-progress {
+    position: relative;
+    width: 100%;
+    height: 0.5rem;
+    border-radius: 999px;
+    background: #e2e8f0;
+    overflow: hidden;
+}
+
+.events-report-top-progress span {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, #38bdf8, #1d4ed8);
+}
+
+.events-reports-downloads {
+    border-radius: 1.75rem;
+    border: 1px solid #e2e8f0;
+    background: #f8fafc;
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.events-report-download-intro p {
+    margin: 0.35rem 0 0;
+    color: #475569;
+    font-size: 0.9rem;
+}
+
+.events-report-download-grid {
+    display: grid;
+    gap: 1rem;
+}
+
+.events-report-download-card {
+    border-radius: 1.25rem;
+    padding: 1.25rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    box-shadow: 0 12px 22px rgba(148, 163, 184, 0.2);
+}
+
+.events-report-download-card h5 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #1e3a8a;
+}
+
+.events-report-download-card p {
+    margin: 0;
+    color: #475569;
+    font-size: 0.9rem;
+}
+
+.events-report-download-actions {
+    margin-top: auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
 }
 
 .events-reports-table th:nth-child(2),
@@ -11986,6 +12262,15 @@ body.calendar-modal-open {
 }
 
 @media (max-width: 768px) {
+    .events-reports-shell {
+        grid-template-columns: 1fr;
+    }
+    .events-report-insights {
+        grid-template-columns: 1fr;
+    }
+    .events-report-metric-grid {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    }
     .events-hero {
         padding: 2rem;
     }
@@ -11994,6 +12279,12 @@ body.calendar-modal-open {
     }
     .events-table {
         min-width: 620px;
+    }
+}
+
+@media (max-width: 1024px) {
+    .events-reports-shell {
+        grid-template-columns: 1fr;
     }
 }
 


### PR DESCRIPTION
## Summary
- redesign the events module reports section with metrics, highlight insights, and refreshed export cards
- extend events.js to compute aggregated revenue metrics, top performers, and populate the new reports layout
- add styling for the insights grid, download cards, and responsive behavior in spark-cms.css

## Testing
- php -l CMS/modules/events/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc5b32c2708331862c2a1b57d90076