### PR TITLE
Add CSV export for form submissions

### DIFF
--- a/CMS/modules/forms/export_submissions.php
+++ b/CMS/modules/forms/export_submissions.php
@@ -1,0 +1,182 @@
+<?php
+// File: modules/forms/export_submissions.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+require_login();
+
+$formId = isset($_GET['form_id']) ? (int) $_GET['form_id'] : 0;
+if ($formId <= 0) {
+    http_response_code(400);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'A valid form_id parameter is required.']);
+    return;
+}
+
+$formsFile = __DIR__ . '/../../data/forms.json';
+$forms = read_json_file($formsFile);
+if (!is_array($forms)) {
+    $forms = [];
+}
+
+$formName = '';
+foreach ($forms as $form) {
+    if (!is_array($form)) {
+        continue;
+    }
+    if ((int) ($form['id'] ?? 0) === $formId) {
+        $formName = isset($form['name']) ? (string) $form['name'] : '';
+        break;
+    }
+}
+
+$submissionsFile = __DIR__ . '/../../data/form_submissions.json';
+$submissions = read_json_file($submissionsFile);
+if (!is_array($submissions)) {
+    $submissions = [];
+}
+
+$filtered = array_values(array_filter($submissions, static function ($submission) use ($formId) {
+    if (!is_array($submission)) {
+        return false;
+    }
+    if (!isset($submission['form_id'])) {
+        return false;
+    }
+    return (int) $submission['form_id'] === $formId;
+}));
+
+$extractTimestamp = static function (array $entry): int {
+    $candidates = ['submitted_at', 'created_at', 'timestamp'];
+    foreach ($candidates as $key) {
+        if (empty($entry[$key])) {
+            continue;
+        }
+        $value = $entry[$key];
+        if (is_numeric($value)) {
+            $value = (float) $value;
+            if ($value > 0) {
+                return $value < 1_000_000_000_000 ? (int) round($value) : (int) round($value / 1000);
+            }
+            continue;
+        }
+        $time = strtotime((string) $value);
+        if ($time !== false) {
+            return $time;
+        }
+    }
+    return 0;
+};
+
+$fieldKeys = [];
+$metaKeys = [];
+foreach ($filtered as $submission) {
+    $data = isset($submission['data']) && is_array($submission['data']) ? $submission['data'] : [];
+    foreach ($data as $key => $_) {
+        $fieldKeys[$key] = true;
+    }
+    $meta = isset($submission['meta']) && is_array($submission['meta']) ? $submission['meta'] : [];
+    if (isset($submission['ip']) && !isset($meta['ip'])) {
+        $meta['ip'] = $submission['ip'];
+    }
+    foreach ($meta as $key => $_) {
+        $metaKeys[$key] = true;
+    }
+}
+
+$fieldColumns = array_keys($fieldKeys);
+sort($fieldColumns, SORT_NATURAL | SORT_FLAG_CASE);
+$metaColumns = array_keys($metaKeys);
+sort($metaColumns, SORT_NATURAL | SORT_FLAG_CASE);
+
+$slugify = static function (string $value): string {
+    $value = strtolower(trim($value));
+    $value = preg_replace('/[^a-z0-9]+/', '-', $value);
+    $value = trim($value, '-');
+    return $value !== '' ? $value : 'form';
+};
+
+$filenameParts = ['form', (string) $formId];
+if ($formName !== '') {
+    $filenameParts[] = $slugify($formName);
+}
+$filenameParts[] = 'submissions.csv';
+$filename = implode('-', $filenameParts);
+
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+header('Pragma: no-cache');
+
+$handle = fopen('php://output', 'w');
+if ($handle === false) {
+    http_response_code(500);
+    echo 'Unable to open output stream';
+    return;
+}
+
+$writeRow = static function ($resource, array $row): void {
+    $converted = array_map(static function ($value) {
+        if ($value === null) {
+            return '';
+        }
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+        if (is_array($value)) {
+            return implode(', ', array_map(static function ($item) {
+                return is_scalar($item) ? (string) $item : json_encode($item, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            }, $value));
+        }
+        return json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }, $row);
+    fputcsv($resource, $converted);
+};
+
+$headers = ['Form ID', 'Submission ID', 'Submitted At', 'Source'];
+foreach ($fieldColumns as $column) {
+    $headers[] = 'Field: ' . $column;
+}
+foreach ($metaColumns as $column) {
+    $headers[] = 'Metadata: ' . $column;
+}
+
+$writeRow($handle, $headers);
+
+foreach ($filtered as $submission) {
+    $data = isset($submission['data']) && is_array($submission['data']) ? $submission['data'] : [];
+    $meta = isset($submission['meta']) && is_array($submission['meta']) ? $submission['meta'] : [];
+    if (isset($submission['ip']) && !isset($meta['ip'])) {
+        $meta['ip'] = $submission['ip'];
+    }
+
+    $timestamp = $extractTimestamp($submission);
+    $submittedAt = '';
+    if ($timestamp > 0) {
+        $submittedAt = date(DATE_ATOM, $timestamp);
+    } else {
+        foreach (['submitted_at', 'created_at', 'timestamp'] as $key) {
+            if (!empty($submission[$key])) {
+                $submittedAt = (string) $submission[$key];
+                break;
+            }
+        }
+    }
+
+    $row = [
+        $submission['form_id'] ?? $formId,
+        $submission['id'] ?? '',
+        $submittedAt,
+        $submission['source'] ?? ($meta['source'] ?? ''),
+    ];
+
+    foreach ($fieldColumns as $column) {
+        $row[] = $data[$column] ?? '';
+    }
+    foreach ($metaColumns as $column) {
+        $row[] = $meta[$column] ?? '';
+    }
+
+    $writeRow($handle, $row);
+}
+
+fclose($handle);

--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -19,6 +19,9 @@ $(function(){
     const $closeFormBuilder = $('#closeFormBuilder');
     const $formsGrid = $('#formsLibrary');
     const $formsEmptyState = $('#formsLibraryEmptyState');
+    const $exportForm = $('#exportSubmissionsForm');
+    const $exportFormId = $('#exportFormId');
+    const $exportButton = $('#exportSubmissionsBtn');
 
     const FIELD_TYPE_LABELS = {
         text: 'Text input',
@@ -165,6 +168,19 @@ $(function(){
         });
     }
 
+    function setExportAvailability(formId){
+        if(!$exportForm.length || !$exportFormId.length || !$exportButton.length){
+            return;
+        }
+        if(formId){
+            $exportFormId.val(formId);
+            $exportButton.prop('disabled', false).removeAttr('aria-disabled');
+        } else {
+            $exportFormId.val('');
+            $exportButton.prop('disabled', true).attr('aria-disabled', 'true');
+        }
+    }
+
     function getFormCardName($card){
         if(!$card || !$card.length){
             return '';
@@ -234,6 +250,7 @@ $(function(){
         currentFormId = null;
         currentFormName = '';
         currentSubmissions = [];
+        setExportAvailability(null);
         closeSubmissionModal();
         const text = message || 'Select a form to view submissions';
         const placeholder = /[.!?]$/.test(text) ? text : text + '.';
@@ -337,6 +354,7 @@ $(function(){
         currentFormId = formId;
         currentFormName = formName;
         currentSubmissions = [];
+        setExportAvailability(formId);
         $formsGrid.find('.forms-library-item').removeClass('is-selected');
         $formsGrid.find('.forms-library-item').filter(function(){
             return $(this).data('id') == formId;

--- a/CMS/modules/forms/view.php
+++ b/CMS/modules/forms/view.php
@@ -144,6 +144,13 @@ $lastSubmissionLabel = $latestSubmission > 0
                     </div>
                     <div class="forms-submissions-meta">
                         <span class="forms-submissions-count" id="formSubmissionsCount">—</span>
+                        <form class="forms-submissions-export" id="exportSubmissionsForm" method="get" action="modules/forms/export_submissions.php">
+                            <input type="hidden" name="form_id" id="exportFormId" value="">
+                            <button type="submit" class="a11y-btn a11y-btn--ghost" id="exportSubmissionsBtn" disabled aria-disabled="true">
+                                <i class="fa-solid fa-file-arrow-down" aria-hidden="true"></i>
+                                <span>Export CSV</span>
+                            </button>
+                        </form>
                     </div>
                 </header>
                 <div class="forms-submissions-container">

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -10031,6 +10031,16 @@ body.calendar-modal-open {
     gap: 10px;
 }
 
+.forms-submissions-export {
+    display: inline-flex;
+}
+
+.forms-submissions-export .a11y-btn[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
 .forms-submissions-count {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add a CSV export endpoint for form submissions scoped to the selected form
- expose an Export CSV button in the submissions activity panel and enable it when a form is active
- style the new action and ensure the client script wires the selection state to the export form

## Testing
- php -l CMS/modules/forms/export_submissions.php
- php -l CMS/modules/forms/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc5b8599708331aecb4366e9d7b8ec