### PR TITLE
Enable order details navigation from customer segments

### DIFF
--- a/CMS/modules/commerce/commerce.js
+++ b/CMS/modules/commerce/commerce.js
@@ -358,6 +358,37 @@ $(function(){
     $customerSegment.on('change', applyCustomerFilters);
     $customerStatus.on('change', applyCustomerFilters);
 
+    const $customerOrderButtons = $('[data-commerce-customer-orders]');
+
+    function focusOrdersForCustomer(customerName) {
+        setActiveWorkspace('orders');
+
+        if ($orderStatus.length) {
+            $orderStatus.val('all');
+        }
+
+        if ($orderSearch.length) {
+            $orderSearch.val(customerName || '');
+        }
+
+        applyOrderFilters();
+
+        if ($orderSearch.length) {
+            $orderSearch.trigger('focus');
+        }
+    }
+
+    $customerOrderButtons.on('click keydown', function(event){
+        if (event.type === 'keydown' && !['Enter', ' ', 'Spacebar'].includes(event.key)) {
+            return;
+        }
+
+        event.preventDefault();
+
+        const customerName = ($(this).data('customerName') || '').toString();
+        focusOrdersForCustomer(customerName);
+    });
+
     function sortCategories(list) {
         return list.slice().sort(function(a, b){
             return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });

--- a/CMS/modules/commerce/view.php
+++ b/CMS/modules/commerce/view.php
@@ -573,7 +573,15 @@ foreach ($segments as $segment):
                                 <td><?php echo htmlspecialchars($name); ?></td>
                                 <td><a href="mailto:<?php echo htmlspecialchars($email); ?>" class="commerce-link"><?php echo htmlspecialchars($email); ?></a></td>
                                 <td><?php echo htmlspecialchars($segment); ?></td>
-                                <td><?php echo $ordersCount; ?></td>
+                                <td>
+                                    <button type="button"
+                                        class="commerce-link commerce-link-button"
+                                        data-commerce-customer-orders="<?php echo htmlspecialchars(strtolower($name)); ?>"
+                                        data-customer-name="<?php echo htmlspecialchars($name); ?>">
+                                        <?php echo $ordersCount; ?>
+                                        <span class="sr-only"> orders for <?php echo htmlspecialchars($name); ?></span>
+                                    </button>
+                                </td>
                                 <td><?php echo htmlspecialchars($ltv); ?></td>
                                 <td><?php echo htmlspecialchars($lastOrder); ?></td>
                                 <td><span class="<?php echo commerce_badge_class($status); ?>"><?php echo htmlspecialchars($status); ?></span></td>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -12529,6 +12529,21 @@ body.calendar-modal-open {
     text-decoration: none;
 }
 
+.commerce-link-button {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+}
+
+.commerce-link-button:focus {
+    outline: 2px solid rgba(99, 102, 241, 0.4);
+    outline-offset: 2px;
+}
+
 .commerce-link:hover,
 .commerce-link:focus {
     text-decoration: underline;


### PR DESCRIPTION
## Summary
- turn the customer order count into an accessible button that opens the Orders workspace filtered to that customer
- update commerce scripts to switch workspaces, reset filters, and focus the order search when a customer order button is activated
- add styling so the order buttons visually match existing commerce links while remaining keyboard accessible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc5be3c8c883319f6b166bf550a102