### PR TITLE
Expand Commerce configuration options

### DIFF
--- a/CMS/data/commerce.json
+++ b/CMS/data/commerce.json
@@ -250,11 +250,15 @@
   "settings": {
     "storefront_status": "Live",
     "currency": "USD",
+    "storefront_theme": "Aurora Dark",
+    "default_language": "English (US)",
     "low_inventory_threshold": 10,
     "default_tax_rate": 8.2,
     "fraud_protection": true,
     "express_checkout": true,
     "allow_guest_checkout": false,
+    "auto_apply_discounts": true,
+    "address_verification": true,
     "payment_methods": [
       { "label": "Credit Card", "enabled": true },
       { "label": "PayPal", "enabled": true },
@@ -265,6 +269,16 @@
       { "name": "Standard", "sla": "3-5 business days" },
       { "name": "Express", "sla": "1-2 business days" },
       { "name": "Pickup", "sla": "Ready in 2 hours" }
-    ]
+    ],
+    "shipping_partners": [
+      { "name": "SwiftShip Logistics", "status": "Primary" },
+      { "name": "Coastal Freight", "status": "Backup" },
+      { "name": "GlobalPost", "status": "International" }
+    ],
+    "return_policy": {
+      "window_days": 30,
+      "restocking_fee": "5%",
+      "return_shipping": "Prepaid label for domestic orders"
+    }
   }
 }

--- a/CMS/modules/commerce/view.php
+++ b/CMS/modules/commerce/view.php
@@ -652,6 +652,14 @@ foreach ($segments as $segment):
                                 <span class="commerce-settings-value"><?php echo htmlspecialchars($currency); ?></span>
                             </li>
                             <li>
+                                <span class="commerce-settings-label">Theme</span>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($commerceSettings['storefront_theme'] ?? 'Default'); ?></span>
+                            </li>
+                            <li>
+                                <span class="commerce-settings-label">Primary language</span>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($commerceSettings['default_language'] ?? 'Not set'); ?></span>
+                            </li>
+                            <li>
                                 <span class="commerce-settings-label">Low inventory threshold</span>
                                 <span class="commerce-settings-value"><?php echo htmlspecialchars((string) ($commerceSettings['low_inventory_threshold'] ?? 0)); ?> units</span>
                             </li>
@@ -668,7 +676,9 @@ foreach ($segments as $segment):
 $toggleMap = [
     'express_checkout' => 'Express checkout',
     'allow_guest_checkout' => 'Allow guest checkout',
-    'fraud_protection' => 'Fraud protection'
+    'fraud_protection' => 'Fraud protection',
+    'auto_apply_discounts' => 'Auto-apply discounts',
+    'address_verification' => 'Address verification'
 ];
 foreach ($toggleMap as $key => $label):
     $enabled = !empty($commerceSettings[$key]);
@@ -713,6 +723,64 @@ foreach ($windows as $window):
                                 <span class="commerce-settings-value"><?php echo htmlspecialchars($sla); ?></span>
                             </li>
 <?php endforeach; ?>
+                        </ul>
+                    </section>
+                    <section class="commerce-settings-group">
+                        <h4 class="commerce-settings-heading">Shipping partners</h4>
+                        <ul class="commerce-settings-list">
+<?php
+$partners = isset($commerceSettings['shipping_partners']) && is_array($commerceSettings['shipping_partners']) ? $commerceSettings['shipping_partners'] : [];
+if (empty($partners)):
+?>
+                            <li>
+                                <span class="commerce-settings-label">Partners</span>
+                                <span class="commerce-settings-value">No shipping partners configured</span>
+                            </li>
+<?php
+endif;
+foreach ($partners as $partner):
+    $partnerName = isset($partner['name']) ? (string) $partner['name'] : '';
+    $status = isset($partner['status']) ? (string) $partner['status'] : '';
+    $normalizedStatus = strtolower($status);
+    $statusClass = 'status-badge';
+    if ($normalizedStatus === 'primary' || $normalizedStatus === 'active') {
+        $statusClass = 'status-badge status-good';
+    } elseif ($normalizedStatus === 'backup' || $normalizedStatus === 'limited') {
+        $statusClass = 'status-badge status-warning';
+    } elseif ($normalizedStatus === 'paused' || $normalizedStatus === 'suspended') {
+        $statusClass = 'status-badge status-critical';
+    } elseif ($normalizedStatus === 'international') {
+        $statusClass = 'status-badge status-info';
+    }
+?>
+                            <li>
+                                <span class="commerce-settings-label"><?php echo htmlspecialchars($partnerName); ?></span>
+                                <span class="commerce-settings-value <?php echo $statusClass; ?>"><?php echo htmlspecialchars($status !== '' ? $status : 'Unavailable'); ?></span>
+                            </li>
+<?php endforeach; ?>
+                        </ul>
+                    </section>
+                    <section class="commerce-settings-group">
+                        <h4 class="commerce-settings-heading">Return policy</h4>
+                        <ul class="commerce-settings-list">
+<?php
+$returnPolicy = isset($commerceSettings['return_policy']) && is_array($commerceSettings['return_policy']) ? $commerceSettings['return_policy'] : [];
+$returnWindow = isset($returnPolicy['window_days']) && is_numeric($returnPolicy['window_days']) ? (int) $returnPolicy['window_days'] : null;
+$restockingFee = isset($returnPolicy['restocking_fee']) ? (string) $returnPolicy['restocking_fee'] : '';
+$returnShipping = isset($returnPolicy['return_shipping']) ? (string) $returnPolicy['return_shipping'] : '';
+?>
+                            <li>
+                                <span class="commerce-settings-label">Return window</span>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($returnWindow !== null ? $returnWindow . ' days' : 'Not specified'); ?></span>
+                            </li>
+                            <li>
+                                <span class="commerce-settings-label">Restocking fee</span>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($restockingFee !== '' ? $restockingFee : 'None'); ?></span>
+                            </li>
+                            <li>
+                                <span class="commerce-settings-label">Return shipping</span>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($returnShipping !== '' ? $returnShipping : 'Not specified'); ?></span>
+                            </li>
                         </ul>
                     </section>
                 </div>


### PR DESCRIPTION
## Summary
- add storefront theme and language metadata to the commerce configuration view
- extend checkout controls with additional toggles plus new shipping and return configuration panels
- enrich the commerce dataset with matching configuration options for the new UI elements

## Testing
- php -l CMS/modules/commerce/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dc8d4b8e108331926fb7520199a9ac