### PR TITLE
Add commerce product grid block template

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -1473,3 +1473,278 @@ section.container-fluid {
 .rich-text > :last-child {
     margin-bottom: 0;
 }
+
+/* Commerce showcase block */
+.commerce-showcase {
+    position: relative;
+    padding: clamp(3rem, 6vw, 5rem) 0;
+    background: linear-gradient(145deg, #eef2ff, #f9fafb);
+    color: #111827;
+}
+
+.commerce-showcase--light {
+    background: #ffffff;
+}
+
+.commerce-showcase--brand {
+    background: radial-gradient(circle at top left, #4f46e5, #7c3aed 55%, #312e81);
+    color: #f8fafc;
+}
+
+.commerce-showcase--dark {
+    background: #0f172a;
+    color: #f8fafc;
+}
+
+.commerce-showcase-inner {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.commerce-showcase-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    max-width: 720px;
+}
+
+.commerce-showcase--align-left .commerce-showcase-header {
+    text-align: left;
+    align-items: flex-start;
+}
+
+.commerce-showcase--align-center .commerce-showcase-header {
+    text-align: center;
+    align-items: center;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.commerce-showcase--align-right .commerce-showcase-header {
+    text-align: right;
+    align-items: flex-end;
+    margin-left: auto;
+}
+
+.commerce-showcase-eyebrow {
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: rgba(79, 70, 229, 0.85);
+}
+
+.commerce-showcase--dark .commerce-showcase-eyebrow,
+.commerce-showcase--brand .commerce-showcase-eyebrow {
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.commerce-showcase-title {
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    line-height: 1.1;
+    font-weight: 700;
+}
+
+.commerce-showcase-subtitle {
+    font-size: 1rem;
+    color: #4b5563;
+    max-width: 52ch;
+}
+
+.commerce-showcase--align-center .commerce-showcase-subtitle,
+.commerce-showcase--align-right .commerce-showcase-subtitle {
+    margin-left: 0;
+}
+
+.commerce-showcase--dark .commerce-showcase-subtitle,
+.commerce-showcase--brand .commerce-showcase-subtitle {
+    color: rgba(248, 250, 252, 0.78);
+}
+
+.commerce-showcase-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
+}
+
+.commerce-showcase--align-center .commerce-showcase-actions {
+    justify-content: center;
+}
+
+.commerce-showcase--align-right .commerce-showcase-actions {
+    justify-content: flex-end;
+}
+
+.commerce-showcase-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.85rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 1rem;
+    background: #4f46e5;
+    color: #f9fafb;
+    box-shadow: 0 18px 30px rgba(79, 70, 229, 0.25);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.commerce-showcase-button:hover,
+.commerce-showcase-button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 35px rgba(79, 70, 229, 0.3);
+    background: #4338ca;
+    color: #fff;
+}
+
+.commerce-showcase--brand .commerce-showcase-button,
+.commerce-showcase--dark .commerce-showcase-button {
+    background: #f9fafb;
+    color: #1e1b4b;
+    box-shadow: 0 18px 30px rgba(15, 23, 42, 0.2);
+}
+
+.commerce-showcase--brand .commerce-showcase-button:hover,
+.commerce-showcase--brand .commerce-showcase-button:focus-visible,
+.commerce-showcase--dark .commerce-showcase-button:hover,
+.commerce-showcase--dark .commerce-showcase-button:focus-visible {
+    background: #e0e7ff;
+    color: #1e1b4b;
+}
+
+.commerce-showcase-grid {
+    display: grid;
+    gap: clamp(1.5rem, 4vw, 2.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.commerce-product-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 24px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    box-shadow: 0 25px 50px -20px rgba(15, 23, 42, 0.2);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.commerce-product-card:hover,
+.commerce-product-card:focus-within {
+    transform: translateY(-6px);
+    box-shadow: 0 30px 55px -18px rgba(79, 70, 229, 0.35);
+}
+
+.commerce-showcase--dark .commerce-product-card,
+.commerce-showcase--brand .commerce-product-card {
+    background: rgba(15, 23, 42, 0.6);
+    box-shadow: 0 24px 45px -18px rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(6px);
+}
+
+.commerce-product-media {
+    position: relative;
+    overflow: hidden;
+    padding-top: 65%;
+}
+
+.commerce-product-media img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
+}
+
+.commerce-product-card:hover .commerce-product-media img,
+.commerce-product-card:focus-within .commerce-product-media img {
+    transform: scale(1.05);
+}
+
+.commerce-product-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1.75rem;
+}
+
+.commerce-product-title {
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1.3;
+    color: #111827;
+}
+
+.commerce-product-price {
+    font-weight: 700;
+    color: #2563eb;
+    font-size: 1rem;
+}
+
+.commerce-product-description {
+    color: #4b5563;
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.commerce-product-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+    color: #1d4ed8;
+    text-decoration: none;
+    margin-top: auto;
+}
+
+.commerce-product-link::after {
+    content: '\2192';
+    transition: transform 0.2s ease;
+}
+
+.commerce-product-link:hover::after,
+.commerce-product-link:focus-visible::after {
+    transform: translateX(4px);
+}
+
+.commerce-showcase--dark .commerce-product-title,
+.commerce-showcase--brand .commerce-product-title {
+    color: #f8fafc;
+}
+
+.commerce-showcase--dark .commerce-product-price,
+.commerce-showcase--brand .commerce-product-price {
+    color: #fbbf24;
+}
+
+.commerce-showcase--dark .commerce-product-description,
+.commerce-showcase--brand .commerce-product-description {
+    color: rgba(248, 250, 252, 0.7);
+}
+
+.commerce-showcase--dark .commerce-product-link,
+.commerce-showcase--brand .commerce-product-link {
+    color: #c7d2fe;
+}
+
+@media (max-width: 640px) {
+    .commerce-showcase-header {
+        max-width: 100%;
+    }
+
+    .commerce-showcase-actions {
+        justify-content: flex-start;
+    }
+
+    .commerce-showcase--align-center .commerce-showcase-actions {
+        justify-content: center;
+    }
+
+    .commerce-showcase--align-right .commerce-showcase-actions {
+        justify-content: flex-end;
+    }
+}

--- a/theme/templates/blocks/commerce.product-grid.php
+++ b/theme/templates/blocks/commerce.product-grid.php
@@ -1,0 +1,191 @@
+<!-- File: commerce.product-grid.php -->
+<!-- Template: commerce.product-grid -->
+<templateSetting caption="Section Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Tagline</dt>
+        <dd><input type="text" name="custom_tagline" value="New this week"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Title</dt>
+        <dd><input type="text" name="custom_title" value="Featured products"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Description</dt>
+        <dd><textarea class="form-control" name="custom_description">Discover merchandise your customers will love.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Background style</dt>
+        <dd>
+            <select name="custom_theme">
+                <option value="">Soft surface</option>
+                <option value=" commerce-showcase--light">Bright</option>
+                <option value=" commerce-showcase--brand">Brand gradient</option>
+                <option value=" commerce-showcase--dark">Midnight</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Alignment</dt>
+        <dd class="align-options">
+            <label><input type="radio" name="custom_alignment" value=" commerce-showcase--align-left" checked> Left</label>
+            <label><input type="radio" name="custom_alignment" value=" commerce-showcase--align-center"> Center</label>
+            <label><input type="radio" name="custom_alignment" value=" commerce-showcase--align-right"> Right</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Primary button label</dt>
+        <dd><input type="text" name="custom_button_text" value="Shop all products"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Primary button link</dt>
+        <dd><input type="text" name="custom_button_url" value="#"></dd>
+    </dl>
+</templateSetting>
+<templateSetting caption="Product 1" order="2">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Product name</dt>
+        <dd><input type="text" name="custom_product1_title" value="Luminous desk lamp"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Price</dt>
+        <dd><input type="text" name="custom_product1_price" value="$129.00"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Description</dt>
+        <dd><textarea class="form-control" name="custom_product1_description">A sculptural lamp that delivers warm, diffused light for creative workspaces.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image URL</dt>
+        <dd>
+            <input type="text" name="custom_product1_image" id="custom_product1_image" value="">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_product1_image')"><i class="fa-solid fa-image btn-icon" aria-hidden="true"></i><span class="btn-label">Browse</span></button>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image alt text</dt>
+        <dd><input type="text" name="custom_product1_alt" value="Sleek desk lamp"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Link label</dt>
+        <dd><input type="text" name="custom_product1_link_text" value="View product"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Link URL</dt>
+        <dd><input type="text" name="custom_product1_link_url" value="#"></dd>
+    </dl>
+</templateSetting>
+<templateSetting caption="Product 2" order="3">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Product name</dt>
+        <dd><input type="text" name="custom_product2_title" value="Modular shelving system"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Price</dt>
+        <dd><input type="text" name="custom_product2_price" value="$349.00"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Description</dt>
+        <dd><textarea class="form-control" name="custom_product2_description">Configurable storage with magnetic accents and soft-close drawers.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image URL</dt>
+        <dd>
+            <input type="text" name="custom_product2_image" id="custom_product2_image" value="">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_product2_image')"><i class="fa-solid fa-image btn-icon" aria-hidden="true"></i><span class="btn-label">Browse</span></button>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image alt text</dt>
+        <dd><input type="text" name="custom_product2_alt" value="Modern shelving unit"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Link label</dt>
+        <dd><input type="text" name="custom_product2_link_text" value="View product"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Link URL</dt>
+        <dd><input type="text" name="custom_product2_link_url" value="#"></dd>
+    </dl>
+</templateSetting>
+<templateSetting caption="Product 3" order="4">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Product name</dt>
+        <dd><input type="text" name="custom_product3_title" value="Handwoven throw blanket"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Price</dt>
+        <dd><input type="text" name="custom_product3_price" value="$89.00"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Description</dt>
+        <dd><textarea class="form-control" name="custom_product3_description">Ethically sourced fibres woven for year-round comfort and style.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image URL</dt>
+        <dd>
+            <input type="text" name="custom_product3_image" id="custom_product3_image" value="">
+            <button type="button" class="btn btn-secondary" onclick="openMediaPicker('custom_product3_image')"><i class="fa-solid fa-image btn-icon" aria-hidden="true"></i><span class="btn-label">Browse</span></button>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Image alt text</dt>
+        <dd><input type="text" name="custom_product3_alt" value="Textured throw blanket"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Link label</dt>
+        <dd><input type="text" name="custom_product3_link_text" value="View product"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Link URL</dt>
+        <dd><input type="text" name="custom_product3_link_url" value="#"></dd>
+    </dl>
+</templateSetting>
+<section class="commerce-showcase{custom_theme}{custom_alignment}" data-tpl-tooltip="Commerce products">
+    <div class="container">
+        <div class="commerce-showcase-inner">
+            <header class="commerce-showcase-header">
+                <p class="commerce-showcase-eyebrow" data-editable>{custom_tagline}</p>
+                <h2 class="commerce-showcase-title" data-editable>{custom_title}</h2>
+                <p class="commerce-showcase-subtitle" data-editable>{custom_description}</p>
+                <div class="commerce-showcase-actions">
+                    <a href="{custom_button_url}" class="commerce-showcase-button" data-editable>{custom_button_text}</a>
+                </div>
+            </header>
+            <div class="commerce-showcase-grid">
+                <article class="commerce-product-card" data-tpl-tooltip="Product listing">
+                    <figure class="commerce-product-media">
+                        <img src="{custom_product1_image}" alt="{custom_product1_alt}">
+                    </figure>
+                    <div class="commerce-product-body">
+                        <h3 class="commerce-product-title" data-editable>{custom_product1_title}</h3>
+                        <p class="commerce-product-price" data-editable>{custom_product1_price}</p>
+                        <p class="commerce-product-description" data-editable>{custom_product1_description}</p>
+                        <a href="{custom_product1_link_url}" class="commerce-product-link" data-editable>{custom_product1_link_text}</a>
+                    </div>
+                </article>
+                <article class="commerce-product-card" data-tpl-tooltip="Product listing">
+                    <figure class="commerce-product-media">
+                        <img src="{custom_product2_image}" alt="{custom_product2_alt}">
+                    </figure>
+                    <div class="commerce-product-body">
+                        <h3 class="commerce-product-title" data-editable>{custom_product2_title}</h3>
+                        <p class="commerce-product-price" data-editable>{custom_product2_price}</p>
+                        <p class="commerce-product-description" data-editable>{custom_product2_description}</p>
+                        <a href="{custom_product2_link_url}" class="commerce-product-link" data-editable>{custom_product2_link_text}</a>
+                    </div>
+                </article>
+                <article class="commerce-product-card" data-tpl-tooltip="Product listing">
+                    <figure class="commerce-product-media">
+                        <img src="{custom_product3_image}" alt="{custom_product3_alt}">
+                    </figure>
+                    <div class="commerce-product-body">
+                        <h3 class="commerce-product-title" data-editable>{custom_product3_title}</h3>
+                        <p class="commerce-product-price" data-editable>{custom_product3_price}</p>
+                        <p class="commerce-product-description" data-editable>{custom_product3_description}</p>
+                        <a href="{custom_product3_link_url}" class="commerce-product-link" data-editable>{custom_product3_link_text}</a>
+                    </div>
+                </article>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add a configurable commerce product grid block template for the front-end
- add styling for the new commerce showcase and product card presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc91f361608331859d83bbe7be73c0