### PR TITLE
Enhance CMS search with fuzzy matching and suggestions

### DIFF
--- a/CMS/includes/search_helpers.php
+++ b/CMS/includes/search_helpers.php
@@ -1,0 +1,727 @@
+<?php
+// File: search_helpers.php
+require_once __DIR__ . '/data.php';
+
+/**
+ * Load and cache the unified search index for pages, blog posts, and media.
+ *
+ * @return array
+ */
+function get_search_index()
+{
+    static $cache = null;
+    if ($cache !== null) {
+        return $cache;
+    }
+
+    $pagesFile = __DIR__ . '/../data/pages.json';
+    $postsFile = __DIR__ . '/../data/blog_posts.json';
+    $mediaFile = __DIR__ . '/../data/media.json';
+
+    $pages = get_cached_json($pagesFile);
+    $posts = get_cached_json($postsFile);
+    $media = get_cached_json($mediaFile);
+
+    $cache = build_search_index($pages, $posts, $media);
+    return $cache;
+}
+
+/**
+ * Build the search index from the supplied datasets.
+ *
+ * @param array $pages
+ * @param array $posts
+ * @param array $media
+ * @return array
+ */
+function build_search_index(array $pages, array $posts, array $media)
+{
+    $index = [];
+
+    foreach ($pages as $page) {
+        $index[] = build_page_entry($page);
+    }
+
+    foreach ($posts as $post) {
+        $index[] = build_post_entry($post);
+    }
+
+    foreach ($media as $item) {
+        $index[] = build_media_entry($item, $pages, $posts);
+    }
+
+    return $index;
+}
+
+/**
+ * Return a list of suggestion candidates derived from the index.
+ *
+ * @param int $limit
+ * @return array
+ */
+function get_search_suggestions($limit = 60)
+{
+    $index = get_search_index();
+    $seen = [];
+    $suggestions = [];
+
+    foreach ($index as $entry) {
+        $candidates = $entry['suggestions'];
+        foreach ($candidates as $candidate) {
+            $value = strtolower($candidate['value']);
+            if ($value === '') {
+                continue;
+            }
+            $key = $value . '|' . strtolower($candidate['type']);
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $suggestions[] = [
+                'value' => $candidate['value'],
+                'type' => $candidate['type'],
+                'label' => $candidate['label'],
+            ];
+            if (count($suggestions) >= $limit) {
+                break 2;
+            }
+        }
+    }
+
+    return $suggestions;
+}
+
+/**
+ * Execute a search query against the index.
+ *
+ * @param string $query
+ * @param array $filters
+ * @return array
+ */
+function perform_search($query, array $filters = [])
+{
+    $query = trim((string) $query);
+    $index = get_search_index();
+    if ($query === '') {
+        return [
+            'results' => [],
+            'counts' => ['Page' => 0, 'Post' => 0, 'Media' => 0],
+        ];
+    }
+
+    $terms = extract_search_terms($query);
+    if (!$terms) {
+        return [
+            'results' => [],
+            'counts' => ['Page' => 0, 'Post' => 0, 'Media' => 0],
+        ];
+    }
+
+    $selectedTypes = [];
+    if (!empty($filters['types']) && is_array($filters['types'])) {
+        foreach ($filters['types'] as $type) {
+            $type = strtolower(trim($type));
+            if ($type !== '') {
+                $selectedTypes[] = $type;
+            }
+        }
+    }
+
+    $results = [];
+    $typeCounts = ['Page' => 0, 'Post' => 0, 'Media' => 0];
+
+    foreach ($index as $entry) {
+        $typeKey = strtolower($entry['type']);
+        if ($selectedTypes && !in_array($typeKey, $selectedTypes, true)) {
+            continue;
+        }
+
+        $score = score_entry_against_terms($entry, $terms);
+        if ($score === null) {
+            continue;
+        }
+
+        $snippet = build_result_snippet($entry['plain_text'], $terms, $entry['type']);
+        $result = [
+            'id' => $entry['id'],
+            'type' => $entry['type'],
+            'title' => $entry['title'],
+            'slug' => $entry['slug'],
+            'score' => $score,
+            'snippet' => $snippet,
+            'record' => $entry['record'],
+        ];
+
+        $results[] = $result;
+        if (isset($typeCounts[$entry['type']])) {
+            $typeCounts[$entry['type']]++;
+        }
+    }
+
+    usort($results, function ($a, $b) {
+        if ($a['score'] === $b['score']) {
+            return strcasecmp($a['title'], $b['title']);
+        }
+        return $a['score'] <=> $b['score'];
+    });
+
+    return [
+        'results' => $results,
+        'counts' => $typeCounts,
+    ];
+}
+
+/**
+ * Extract search terms supporting quoted phrases.
+ *
+ * @param string $query
+ * @return array
+ */
+function extract_search_terms($query)
+{
+    $query = strtolower($query);
+    preg_match_all('/"([^"]+)"|\'([^\']+)\'|(\S+)/', $query, $matches);
+    $terms = [];
+    foreach ($matches[0] as $i => $match) {
+        $term = $matches[1][$i] ?? $matches[2][$i] ?? $matches[3][$i] ?? '';
+        $term = trim($term);
+        if ($term !== '' && $term !== 'and') {
+            $terms[] = $term;
+        }
+    }
+    return array_values(array_unique($terms));
+}
+
+/**
+ * Score an index entry against the supplied search terms.
+ *
+ * @param array $entry
+ * @param array $terms
+ * @return float|null
+ */
+function score_entry_against_terms(array $entry, array $terms)
+{
+    $score = 0.0;
+    foreach ($terms as $term) {
+        $termScore = match_term_against_entry($entry, $term);
+        if ($termScore === null) {
+            return null;
+        }
+        $score += $termScore;
+    }
+    return $score;
+}
+
+/**
+ * Match an individual term against the entry fields.
+ *
+ * @param array $entry
+ * @param string $term
+ * @return float|null
+ */
+function match_term_against_entry(array $entry, $term)
+{
+    $bestScore = null;
+    $term = strtolower($term);
+    $threshold = max(1, (int) ceil(strlen($term) * 0.4));
+
+    $wordDistance = minimum_levenshtein_distance($term, $entry['words']);
+
+    foreach ($entry['fields'] as $field) {
+        $text = $field['value'];
+        if ($text === '') {
+            continue;
+        }
+
+        if (strpos($text, $term) !== false) {
+            $score = $field['weight'];
+            if ($bestScore === null || $score < $bestScore) {
+                $bestScore = $score;
+            }
+            continue;
+        }
+
+        $distance = $wordDistance;
+        if ($distance === null || $distance > $threshold) {
+            continue;
+        }
+
+        $score = $field['weight'] + ($distance * 0.1);
+        if ($bestScore === null || $score < $bestScore) {
+            $bestScore = $score;
+        }
+    }
+
+    return $bestScore;
+}
+
+/**
+ * Calculate the minimum Levenshtein distance between a term and a list of words.
+ *
+ * @param string $term
+ * @param array $words
+ * @return int|null
+ */
+function minimum_levenshtein_distance($term, array $words)
+{
+    $termLength = strlen($term);
+    if ($termLength === 0) {
+        return null;
+    }
+
+    $closest = null;
+    foreach ($words as $word) {
+        if ($word === '') {
+            continue;
+        }
+        if (abs(strlen($word) - $termLength) > max(3, (int) ceil($termLength * 0.6))) {
+            continue;
+        }
+        $distance = levenshtein($term, $word);
+        if ($closest === null || $distance < $closest) {
+            $closest = $distance;
+            if ($distance === 0) {
+                break;
+            }
+        }
+    }
+
+    return $closest;
+}
+
+/**
+ * Build a snippet of text around the matched terms.
+ *
+ * @param string $plainText
+ * @param array $terms
+ * @param string $type
+ * @param int $length
+ * @return string
+ */
+function build_result_snippet($plainText, array $terms, $type, $length = 180)
+{
+    $plainText = trim(preg_replace('/\s+/', ' ', $plainText));
+    if ($plainText === '') {
+        return '';
+    }
+
+    $lower = strtolower($plainText);
+    $position = null;
+    foreach ($terms as $term) {
+        $pos = strpos($lower, $term);
+        if ($pos !== false) {
+            $position = $pos;
+            break;
+        }
+    }
+
+    if ($position === null) {
+        $position = 0;
+    }
+
+    $start = max(0, $position - (int) ($length / 2));
+    $snippet = substr($plainText, $start, $length);
+
+    if ($start > 0) {
+        $snippet = '…' . ltrim($snippet);
+    }
+    if ($start + $length < strlen($plainText)) {
+        $snippet = rtrim($snippet) . '…';
+    }
+
+    foreach ($terms as $term) {
+        $escaped = preg_quote($term, '/');
+        $snippet = preg_replace('/(' . $escaped . ')/i', '<mark>$1</mark>', $snippet);
+    }
+
+    return $snippet;
+}
+
+/**
+ * Build an index entry for a page record.
+ *
+ * @param array $page
+ * @return array
+ */
+function build_page_entry(array $page)
+{
+    $content = is_string($page['content'] ?? '') ? $page['content'] : '';
+    $plain = strip_tags($content);
+    $metadata = implode(' ', array_filter([
+        $page['meta_title'] ?? '',
+        $page['meta_description'] ?? '',
+        $page['og_title'] ?? '',
+        $page['og_description'] ?? '',
+        $page['canonical_url'] ?? '',
+    ]));
+
+    $fields = [
+        ['name' => 'title', 'value' => strtolower((string) ($page['title'] ?? '')), 'weight' => 1],
+        ['name' => 'slug', 'value' => strtolower((string) ($page['slug'] ?? '')), 'weight' => 1.5],
+        ['name' => 'metadata', 'value' => strtolower($metadata), 'weight' => 2],
+        ['name' => 'content', 'value' => strtolower($plain), 'weight' => 3],
+    ];
+
+    return [
+        'id' => $page['id'] ?? null,
+        'type' => 'Page',
+        'title' => (string) ($page['title'] ?? ''),
+        'slug' => (string) ($page['slug'] ?? ''),
+        'fields' => $fields,
+        'words' => extract_words_from_fields($fields),
+        'plain_text' => $plain,
+        'record' => $page,
+        'suggestions' => build_entry_suggestions($page, 'Page'),
+    ];
+}
+
+/**
+ * Build an index entry for a blog post record.
+ *
+ * @param array $post
+ * @return array
+ */
+function build_post_entry(array $post)
+{
+    $content = is_string($post['content'] ?? '') ? $post['content'] : '';
+    $excerpt = is_string($post['excerpt'] ?? '') ? $post['excerpt'] : '';
+    $plain = strip_tags($content . ' ' . $excerpt);
+    $metadata = implode(' ', array_filter([
+        $post['category'] ?? '',
+        $post['author'] ?? '',
+        $post['tags'] ?? '',
+    ]));
+
+    $fields = [
+        ['name' => 'title', 'value' => strtolower((string) ($post['title'] ?? '')), 'weight' => 1],
+        ['name' => 'slug', 'value' => strtolower((string) ($post['slug'] ?? '')), 'weight' => 1.5],
+        ['name' => 'metadata', 'value' => strtolower($metadata), 'weight' => 2],
+        ['name' => 'content', 'value' => strtolower($plain), 'weight' => 3],
+    ];
+
+    return [
+        'id' => $post['id'] ?? null,
+        'type' => 'Post',
+        'title' => (string) ($post['title'] ?? ''),
+        'slug' => (string) ($post['slug'] ?? ''),
+        'fields' => $fields,
+        'words' => extract_words_from_fields($fields),
+        'plain_text' => $plain,
+        'record' => $post,
+        'suggestions' => build_entry_suggestions($post, 'Post'),
+    ];
+}
+
+/**
+ * Build an index entry for a media record.
+ *
+ * @param array $media
+ * @param array $pages
+ * @param array $posts
+ * @param array $pageContents
+ * @param array $postContents
+ * @return array
+ */
+function build_media_entry(array $media, array $pages, array $posts)
+{
+    $name = (string) ($media['name'] ?? ($media['file'] ?? ''));
+    $filename = (string) ($media['file'] ?? '');
+    $tags = '';
+    if (!empty($media['tags']) && is_array($media['tags'])) {
+        $tags = implode(', ', $media['tags']);
+    } elseif (is_string($media['tags'] ?? null)) {
+        $tags = $media['tags'];
+    }
+    $altText = (string) ($media['alt'] ?? '');
+    $description = (string) ($media['description'] ?? '');
+
+    $context = gather_media_context($filename, $pages, $posts);
+    if ($altText !== '') {
+        $context[] = $altText;
+    }
+    if ($description !== '') {
+        $context[] = $description;
+    }
+
+    $plain = trim(implode(' ', $context));
+
+    $fields = [
+        ['name' => 'name', 'value' => strtolower($name), 'weight' => 1],
+        ['name' => 'file', 'value' => strtolower($filename), 'weight' => 1.5],
+        ['name' => 'tags', 'value' => strtolower($tags), 'weight' => 2],
+        ['name' => 'context', 'value' => strtolower($plain), 'weight' => 2.5],
+    ];
+
+    return [
+        'id' => $media['id'] ?? ($media['file'] ?? ''),
+        'type' => 'Media',
+        'title' => $name,
+        'slug' => $filename,
+        'fields' => $fields,
+        'words' => extract_words_from_fields($fields),
+        'plain_text' => $plain,
+        'record' => $media,
+        'suggestions' => build_entry_suggestions($media, 'Media'),
+    ];
+}
+
+/**
+ * Gather contextual strings for a media file by scanning pages and posts.
+ *
+ * @param string $filename
+ * @param array $pages
+ * @param array $posts
+ * @return array
+ */
+function gather_media_context($filename, array $pages, array $posts)
+{
+    $context = [];
+    if ($filename === '') {
+        return $context;
+    }
+
+    foreach ($pages as $page) {
+        $content = (string) ($page['content'] ?? '');
+        $matches = extract_image_context($content, $filename);
+        foreach ($matches as $match) {
+            $context[] = $match;
+        }
+    }
+
+    foreach ($posts as $post) {
+        $content = (string) ($post['content'] ?? '');
+        $matches = extract_image_context($content, $filename);
+        foreach ($matches as $match) {
+            $context[] = $match;
+        }
+        if (stripos($post['excerpt'] ?? '', $filename) !== false) {
+            $context[] = $post['excerpt'];
+        }
+    }
+
+    return $context;
+}
+
+/**
+ * Extract image context strings (alt text and surrounding text) from HTML content.
+ *
+ * @param string $html
+ * @param string $filename
+ * @return array
+ */
+function extract_image_context($html, $filename)
+{
+    $results = [];
+    if ($html === '' || stripos($html, $filename) === false) {
+        return $results;
+    }
+
+    if (!class_exists('DOMDocument')) {
+        return $results;
+    }
+
+    $wrapped = '<div>' . $html . '</div>';
+    $previous = libxml_use_internal_errors(true);
+    $dom = new DOMDocument();
+    if (!$dom->loadHTML($wrapped)) {
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        return $results;
+    }
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+
+    $images = $dom->getElementsByTagName('img');
+    foreach ($images as $img) {
+        $src = $img->getAttribute('src');
+        if ($src === '') {
+            continue;
+        }
+        if (stripos($src, $filename) === false) {
+            continue;
+        }
+        $alt = trim($img->getAttribute('alt'));
+        if ($alt !== '') {
+            $results[] = $alt;
+        }
+        $title = trim($img->getAttribute('title'));
+        if ($title !== '') {
+            $results[] = $title;
+        }
+        $parentText = trim(preg_replace('/\s+/', ' ', $img->parentNode->textContent ?? ''));
+        if ($parentText !== '') {
+            $results[] = $parentText;
+        }
+    }
+
+    return $results;
+}
+
+/**
+ * Extract words from the fields for fuzzy matching.
+ *
+ * @param array $fields
+ * @return array
+ */
+function extract_words_from_fields(array $fields)
+{
+    $words = [];
+    foreach ($fields as $field) {
+        $value = strtolower((string) $field['value']);
+        if ($value === '') {
+            continue;
+        }
+        $parts = preg_split('/[^a-z0-9]+/', $value);
+        foreach ($parts as $part) {
+            if ($part === '') {
+                continue;
+            }
+            $words[] = $part;
+        }
+    }
+    return array_values(array_unique(array_slice($words, 0, 2000)));
+}
+
+/**
+ * Build suggestion entries for a record.
+ *
+ * @param array $record
+ * @param string $type
+ * @return array
+ */
+function build_entry_suggestions(array $record, $type)
+{
+    $suggestions = [];
+    $title = trim((string) ($record['title'] ?? ''));
+    if ($title !== '') {
+        $suggestions[] = [
+            'value' => $title,
+            'type' => $type,
+            'label' => $title . ' · ' . $type,
+        ];
+    }
+
+    $slug = trim((string) ($record['slug'] ?? ($record['file'] ?? '')));
+    if ($slug !== '') {
+        $suggestions[] = [
+            'value' => $slug,
+            'type' => $type,
+            'label' => $slug . ' · ' . $type,
+        ];
+    }
+
+    $keywords = [];
+    if (!empty($record['tags'])) {
+        if (is_string($record['tags'])) {
+            $keywords = array_map('trim', explode(',', $record['tags']));
+        } elseif (is_array($record['tags'])) {
+            $keywords = $record['tags'];
+        }
+    }
+
+    foreach ($keywords as $keyword) {
+        $keyword = trim((string) $keyword);
+        if ($keyword === '') {
+            continue;
+        }
+        $suggestions[] = [
+            'value' => $keyword,
+            'type' => $type,
+            'label' => $keyword . ' · ' . $type,
+        ];
+    }
+
+    return $suggestions;
+}
+
+/**
+ * Record the supplied term in the user's search history.
+ *
+ * @param string $term
+ * @return array
+ */
+function push_search_history($term)
+{
+    $term = trim((string) $term);
+    if ($term === '') {
+        return get_search_history();
+    }
+
+    if (!isset($_SESSION['search_history'])) {
+        $_SESSION['search_history'] = [];
+    }
+
+    $key = strtolower($term);
+    $records = $_SESSION['search_history'];
+    if (!isset($records[$key])) {
+        $records[$key] = [
+            'term' => $term,
+            'count' => 0,
+            'last' => 0,
+        ];
+    }
+
+    $records[$key]['count']++;
+    $records[$key]['last'] = time();
+    $records[$key]['term'] = $term;
+
+    uasort($records, function ($a, $b) {
+        if ($a['count'] === $b['count']) {
+            return $b['last'] <=> $a['last'];
+        }
+        return $b['count'] <=> $a['count'];
+    });
+
+    if (count($records) > 15) {
+        $records = array_slice($records, 0, 15, true);
+    }
+
+    $_SESSION['search_history'] = $records;
+    return get_search_history();
+}
+
+/**
+ * Retrieve the user's prioritized search history.
+ *
+ * @param int $limit
+ * @return array
+ */
+function get_search_history($limit = 10)
+{
+    if (empty($_SESSION['search_history']) || !is_array($_SESSION['search_history'])) {
+        return [];
+    }
+
+    $records = $_SESSION['search_history'];
+    uasort($records, function ($a, $b) {
+        if ($a['count'] === $b['count']) {
+            return $b['last'] <=> $a['last'];
+        }
+        return $b['count'] <=> $a['count'];
+    });
+
+    $records = array_slice($records, 0, $limit, true);
+    $history = [];
+    foreach ($records as $item) {
+        $history[] = [
+            'term' => $item['term'],
+            'count' => $item['count'],
+            'last' => $item['last'],
+        ];
+    }
+    return $history;
+}
+
+/**
+ * Return the raw search history terms only.
+ *
+ * @param int $limit
+ * @return array
+ */
+function get_search_history_terms($limit = 10)
+{
+    return array_map(function ($item) {
+        return $item['term'];
+    }, get_search_history($limit));
+}
+?>

--- a/CMS/modules/search/search.js
+++ b/CMS/modules/search/search.js
@@ -1,9 +1,481 @@
 // File: search.js
-$(function(){
-    const query = $('#search').data('query');
-    if(query){
-        $('#pageTitle').text('Search: ' + query);
-    } else {
-        $('#pageTitle').text('Search');
+(function (window, $) {
+    const STORAGE_KEY = 'sparkcms.search.history';
+    const MAX_HISTORY = 15;
+    const MAX_SUGGESTIONS = 8;
+
+    function parseJSON(value) {
+        if (!value) {
+            return [];
+        }
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            return [];
+        }
     }
-});
+
+    function levenshtein(a, b) {
+        const matrix = [];
+        const lenA = a.length;
+        const lenB = b.length;
+        for (let i = 0; i <= lenB; i += 1) {
+            matrix[i] = [i];
+        }
+        for (let j = 0; j <= lenA; j += 1) {
+            matrix[0][j] = j;
+        }
+        for (let i = 1; i <= lenB; i += 1) {
+            for (let j = 1; j <= lenA; j += 1) {
+                if (b.charAt(i - 1) === a.charAt(j - 1)) {
+                    matrix[i][j] = matrix[i - 1][j - 1];
+                } else {
+                    matrix[i][j] = Math.min(
+                        matrix[i - 1][j - 1] + 1,
+                        matrix[i][j - 1] + 1,
+                        matrix[i - 1][j] + 1
+                    );
+                }
+            }
+        }
+        return matrix[lenB][lenA];
+    }
+
+    function normaliseTerm(term) {
+        return (term || '').toString().trim();
+    }
+
+    function lower(term) {
+        return normaliseTerm(term).toLowerCase();
+    }
+
+    const SparkSearch = {
+        $input: null,
+        $container: null,
+        $panel: null,
+        submitCallback: null,
+        activeIndex: -1,
+        currentSuggestions: [],
+        history: [],
+        suggestionPool: [],
+
+        mount({ input, container, history = [], suggestions = [], onSubmit } = {}) {
+            if (!input || !input.length) {
+                return;
+            }
+
+            this.$input = input;
+            this.$container = container && container.length ? container : input.closest('.search-box');
+            this.submitCallback = typeof onSubmit === 'function' ? onSubmit : null;
+
+            this.ensurePanel();
+            this.mergeHistory(history);
+            this.mergeHistory(this.loadLocalHistory());
+            this.mergeSuggestions(suggestions);
+            this.registerEvents();
+        },
+
+        ensurePanel() {
+            if (this.$panel && this.$panel.length) {
+                return;
+            }
+            this.$panel = $('<div class="search-suggestions" role="listbox" aria-label="Search suggestions"></div>');
+            if (this.$container && this.$container.length) {
+                this.$container.append(this.$panel);
+            }
+        },
+
+        registerEvents() {
+            if (!this.$input) {
+                return;
+            }
+
+            this.$input.off('.sparkSearch');
+            this.$input.on('input.sparkSearch', (event) => {
+                const value = normaliseTerm(event.target.value);
+                this.showSuggestions(value);
+            });
+            this.$input.on('keydown.sparkSearch', (event) => this.handleKeydown(event));
+            this.$input.on('focus.sparkSearch', () => {
+                const value = normaliseTerm(this.$input.val());
+                this.showSuggestions(value);
+            });
+            this.$input.on('blur.sparkSearch', () => {
+                window.setTimeout(() => this.hideSuggestions(), 120);
+            });
+        },
+
+        mergeHistory(history) {
+            if (!Array.isArray(history)) {
+                return;
+            }
+            const existing = new Map(this.history.map((item) => [lower(item.term), item]));
+            history.forEach((item) => {
+                if (!item) {
+                    return;
+                }
+                const term = normaliseTerm(item.term || item.value || item);
+                if (!term) {
+                    return;
+                }
+                const key = lower(term);
+                const count = typeof item.count === 'number' ? item.count : 1;
+                const last = typeof item.last === 'number' ? item.last : Date.now();
+                if (existing.has(key)) {
+                    const record = existing.get(key);
+                    record.count = Math.max(record.count, count);
+                    record.last = Math.max(record.last, last);
+                    record.term = term;
+                } else {
+                    existing.set(key, {
+                        term,
+                        count,
+                        last,
+                    });
+                }
+            });
+            const merged = Array.from(existing.values());
+            merged.sort((a, b) => {
+                if (b.count === a.count) {
+                    return b.last - a.last;
+                }
+                return b.count - a.count;
+            });
+            this.history = merged.slice(0, MAX_HISTORY);
+        },
+
+        mergeSuggestions(suggestions) {
+            if (!Array.isArray(suggestions)) {
+                return;
+            }
+            const seen = new Set(this.suggestionPool.map((item) => `${lower(item.value)}|${lower(item.type || '')}`));
+            suggestions.forEach((item) => {
+                if (!item || !item.value) {
+                    return;
+                }
+                const key = `${lower(item.value)}|${lower(item.type || '')}`;
+                if (seen.has(key)) {
+                    return;
+                }
+                seen.add(key);
+                this.suggestionPool.push({
+                    value: item.value,
+                    label: item.label || item.value,
+                    type: item.type || '',
+                });
+            });
+        },
+
+        loadLocalHistory() {
+            if (!window.localStorage) {
+                return [];
+            }
+            const raw = window.localStorage.getItem(STORAGE_KEY);
+            if (!raw) {
+                return [];
+            }
+            const parsed = parseJSON(raw);
+            return parsed.map((term) => ({
+                term,
+                count: 1,
+                last: Date.now(),
+            }));
+        },
+
+        persistLocalHistory() {
+            if (!window.localStorage) {
+                return;
+            }
+            const terms = this.history.map((item) => item.term).slice(0, MAX_HISTORY);
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(terms));
+        },
+
+        showSuggestions(term) {
+            const query = lower(term);
+            const suggestions = [];
+            const used = new Set();
+
+            this.history.forEach((item) => {
+                if (!item.term) {
+                    return;
+                }
+                const valueLower = lower(item.term);
+                if (query && valueLower.indexOf(query) === -1) {
+                    const distance = levenshtein(query, valueLower.slice(0, Math.max(query.length, 3)));
+                    if (distance > Math.max(2, Math.round(query.length * 0.4))) {
+                        return;
+                    }
+                }
+                const key = valueLower;
+                if (used.has(key)) {
+                    return;
+                }
+                used.add(key);
+                suggestions.push({
+                    value: item.term,
+                    label: `${item.term} · Recent`,
+                    type: 'history',
+                    count: item.count,
+                });
+            });
+
+            this.suggestionPool.forEach((item) => {
+                if (suggestions.length >= MAX_SUGGESTIONS) {
+                    return;
+                }
+                const candidate = lower(item.value);
+                if (query) {
+                    if (candidate.indexOf(query) === -1) {
+                        const distance = levenshtein(query, candidate.slice(0, Math.max(query.length, 3)));
+                        if (distance > Math.max(2, Math.round(query.length * 0.4))) {
+                            return;
+                        }
+                    }
+                }
+                const key = `${candidate}|${lower(item.type || '')}`;
+                if (used.has(key)) {
+                    return;
+                }
+                used.add(key);
+                suggestions.push({
+                    value: item.value,
+                    label: item.label || item.value,
+                    type: item.type || '',
+                });
+            });
+
+            this.currentSuggestions = suggestions.slice(0, MAX_SUGGESTIONS);
+            this.renderSuggestions();
+        },
+
+        renderSuggestions() {
+            if (!this.$panel) {
+                return;
+            }
+            this.$panel.empty();
+            if (!this.currentSuggestions.length) {
+                this.$panel.removeClass('is-active');
+                this.activeIndex = -1;
+                return;
+            }
+
+            const fragment = document.createDocumentFragment();
+            this.currentSuggestions.forEach((item, index) => {
+                const option = document.createElement('button');
+                option.type = 'button';
+                option.className = 'search-suggestion';
+                option.setAttribute('role', 'option');
+                option.setAttribute('data-index', index.toString());
+                option.innerHTML = `<span class="search-suggestion__value">${$('<div>').text(item.value).html()}</span>`;
+                if (item.type) {
+                    const meta = document.createElement('span');
+                    meta.className = 'search-suggestion__meta';
+                    meta.textContent = item.type;
+                    option.appendChild(meta);
+                }
+                option.addEventListener('mousedown', (event) => {
+                    event.preventDefault();
+                    this.selectSuggestion(index);
+                });
+                fragment.appendChild(option);
+            });
+            this.$panel.append(fragment);
+            this.$panel.addClass('is-active');
+        },
+
+        hideSuggestions() {
+            if (this.$panel) {
+                this.$panel.removeClass('is-active');
+            }
+            this.activeIndex = -1;
+        },
+
+        handleKeydown(event) {
+            if (!this.currentSuggestions.length) {
+                if (event.key === 'Enter' && this.$input && this.$input.val()) {
+                    event.preventDefault();
+                    this.submit(this.$input.val());
+                }
+                return;
+            }
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                this.activeIndex = (this.activeIndex + 1) % this.currentSuggestions.length;
+                this.highlightActive();
+            } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                this.activeIndex = this.activeIndex <= 0 ? this.currentSuggestions.length - 1 : this.activeIndex - 1;
+                this.highlightActive();
+            } else if (event.key === 'Enter') {
+                event.preventDefault();
+                if (this.activeIndex >= 0) {
+                    this.selectSuggestion(this.activeIndex);
+                } else if (this.$input && this.$input.val()) {
+                    this.submit(this.$input.val());
+                }
+            } else if (event.key === 'Escape') {
+                this.hideSuggestions();
+            }
+        },
+
+        highlightActive() {
+            if (!this.$panel) {
+                return;
+            }
+            this.$panel.find('.search-suggestion').removeClass('is-active');
+            if (this.activeIndex < 0) {
+                return;
+            }
+            const $target = this.$panel.find(`.search-suggestion[data-index="${this.activeIndex}"]`);
+            $target.addClass('is-active');
+        },
+
+        selectSuggestion(index) {
+            const item = this.currentSuggestions[index];
+            if (!item) {
+                return;
+            }
+            if (this.$input) {
+                this.$input.val(item.value);
+            }
+            this.hideSuggestions();
+            this.submit(item.value);
+        },
+
+        submit(query, extra = {}) {
+            const term = normaliseTerm(query);
+            if (!term) {
+                return;
+            }
+            this.addToHistory(term);
+            this.hideSuggestions();
+            if (this.submitCallback) {
+                this.submitCallback(term, extra);
+            }
+        },
+
+        addToHistory(term) {
+            const key = lower(term);
+            const existing = this.history.find((item) => lower(item.term) === key);
+            if (existing) {
+                existing.count += 1;
+                existing.last = Date.now();
+                existing.term = term;
+            } else {
+                this.history.unshift({ term, count: 1, last: Date.now() });
+            }
+            this.history.sort((a, b) => {
+                if (b.count === a.count) {
+                    return b.last - a.last;
+                }
+                return b.count - a.count;
+            });
+            this.history = this.history.slice(0, MAX_HISTORY);
+            this.persistLocalHistory();
+        },
+
+        bootstrapFromModule($module) {
+            if (!$module || !$module.length) {
+                return;
+            }
+            const historyAttr = $module.attr('data-history');
+            const suggestionAttr = $module.attr('data-suggestions');
+            const selectedAttr = $module.attr('data-selected-types');
+            const query = $module.attr('data-query') || '';
+
+            this.mergeHistory(parseJSON(historyAttr));
+            this.mergeSuggestions(parseJSON(suggestionAttr));
+            this.persistLocalHistory();
+
+            if (this.$input) {
+                this.$input.val(query);
+            }
+
+            const selectedTypes = parseJSON(selectedAttr);
+            this.applyTypeFilters(Array.isArray(selectedTypes) ? selectedTypes : []);
+            this.updateSummary(query);
+            if (query) {
+                $('#pageTitle').text('Search: ' + query);
+            } else {
+                $('#pageTitle').text('Search');
+            }
+        },
+
+        applyTypeFilters(types, allowEmpty = false) {
+            const normalized = Array.isArray(types) ? types.map((type) => lower(type)) : [];
+            const showAll = !allowEmpty && normalized.length === 0;
+            const $rows = $('.search-table tbody tr[data-type]');
+            const counts = { Page: 0, Post: 0, Media: 0 };
+            let visible = 0;
+
+            $rows.each(function () {
+                const $row = $(this);
+                const type = $row.data('type') || '';
+                const typeKey = lower(type);
+                const shouldShow = showAll || normalized.indexOf(typeKey) !== -1;
+                $row.toggle(shouldShow);
+                if (shouldShow) {
+                    visible += 1;
+                    if (counts[type] !== undefined) {
+                        counts[type] += 1;
+                    }
+                }
+            });
+
+            $('.search-empty-row[data-filter-empty="true"]').toggle(visible === 0 && $rows.length > 0);
+
+            $('#searchCountPages').text((counts.Page || 0).toLocaleString());
+            $('#searchCountPosts').text((counts.Post || 0).toLocaleString());
+            $('#searchCountMedia').text((counts.Media || 0).toLocaleString());
+
+            const query = $('#search').attr('data-query') || '';
+            this.updateSummary(query, visible);
+        },
+
+        updateSummary(query, visibleCount) {
+            const $meta = $('.search-results-card__meta');
+            if (!$meta.length) {
+                return;
+            }
+            let visible = typeof visibleCount === 'number' ? visibleCount : $('.search-table tbody tr[data-type]:visible').length;
+            const summary = visible === 1 ? 'Showing 1 result' : `Showing ${visible.toLocaleString()} results`;
+            const suffix = query ? ` for “${query}”` : '';
+            $meta.text(summary + suffix);
+        },
+    };
+
+    $(document).on('click', '[data-search-term]', function (event) {
+        event.preventDefault();
+        const term = normaliseTerm($(this).data('search-term'));
+        if (!term || !window.SparkSearch) {
+            return;
+        }
+        window.SparkSearch.submit(term);
+    });
+
+    $(document).on('change', '.search-filters input[type="checkbox"]', function () {
+        const types = $('.search-filters input[type="checkbox"]:checked')
+            .map(function () {
+                return $(this).val();
+            })
+            .get();
+        if (window.SparkSearch) {
+            window.SparkSearch.applyTypeFilters(types, true);
+        }
+    });
+
+    window.SparkSearch = Object.assign(window.SparkSearch || {}, SparkSearch);
+
+    $(function () {
+        const $module = $('#search');
+        if ($module.length && window.SparkSearch) {
+            window.SparkSearch.bootstrapFromModule($module);
+            const query = $module.data('query');
+            if (query) {
+                $('#pageTitle').text('Search: ' + query);
+            } else {
+                $('#pageTitle').text('Search');
+            }
+        }
+    });
+})(window, jQuery);

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -482,6 +482,60 @@
             color: #a0aec0;
         }
 
+        .search-suggestions {
+            position: absolute;
+            top: calc(100% + 8px);
+            left: 0;
+            right: 0;
+            background: #ffffff;
+            border-radius: 12px;
+            border: 1px solid #e2e8f0;
+            box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+            padding: 6px 0;
+            display: none;
+            z-index: 25;
+        }
+
+        .search-suggestions.is-active {
+            display: block;
+        }
+
+        .search-suggestion {
+            width: 100%;
+            background: none;
+            border: none;
+            padding: 10px 16px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 14px;
+            color: #1f2937;
+            cursor: pointer;
+            transition: background 0.2s ease, color 0.2s ease;
+        }
+
+        .search-suggestion.is-active,
+        .search-suggestion:hover,
+        .search-suggestion:focus-visible {
+            background: #eef2ff;
+            color: #312e81;
+        }
+
+        .search-suggestion:focus-visible {
+            outline: none;
+        }
+
+        .search-suggestion__value {
+            font-weight: 500;
+        }
+
+        .search-suggestion__meta {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: #64748b;
+        }
+
 .notification-btn {
     position: relative;
     background: none;
@@ -782,6 +836,118 @@
         .search-results-card .data-table th,
         .search-results-card .data-table td {
             padding: 14px 20px;
+        }
+
+        .search-history-card {
+            background: #ffffff;
+            border-radius: 16px;
+            padding: 20px 24px;
+            box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+            border: 1px solid #e2e8f0;
+        }
+
+        .search-history-card__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            margin-bottom: 16px;
+            gap: 12px;
+        }
+
+        .search-history-card__title {
+            margin: 0;
+            font-size: 16px;
+            font-weight: 600;
+            color: #0f172a;
+        }
+
+        .search-history-card__description {
+            margin: 2px 0 0;
+            font-size: 13px;
+            color: #475569;
+        }
+
+        .search-history-chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .search-history-chip {
+            border: none;
+            background: #eef2ff;
+            color: #3730a3;
+            border-radius: 999px;
+            padding: 6px 14px;
+            font-size: 13px;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .search-history-chip:hover,
+        .search-history-chip:focus-visible {
+            transform: translateY(-1px);
+            box-shadow: 0 8px 18px rgba(59, 130, 246, 0.22);
+            outline: none;
+        }
+
+        .search-history-chip__term {
+            font-weight: 500;
+        }
+
+        .search-history-chip__meta {
+            font-size: 12px;
+            color: #6366f1;
+        }
+
+        .search-filters {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            margin-bottom: 16px;
+        }
+
+        .search-filters__option {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            background: #f8fafc;
+            border-radius: 12px;
+            padding: 6px 12px;
+            font-size: 13px;
+            color: #1e293b;
+            border: 1px solid #e2e8f0;
+        }
+
+        .search-filters__option input {
+            accent-color: #4f46e5;
+        }
+
+        .search-filters__option small {
+            color: #64748b;
+            font-size: 12px;
+        }
+
+        .search-result-title {
+            font-weight: 600;
+            color: #0f172a;
+            margin-bottom: 4px;
+        }
+
+        .search-result-snippet {
+            font-size: 13px;
+            color: #475569;
+            line-height: 1.5;
+        }
+
+        .search-result-snippet mark {
+            background: #fef3c7;
+            color: inherit;
+            padding: 0 3px;
+            border-radius: 4px;
         }
 
         /* Import/Export module */


### PR DESCRIPTION
## Summary
- add a reusable search helper that indexes pages, posts, and media with fuzzy scoring, snippets, and history tracking
- refresh the search module UI with recent search chips, type filters, and contextual result snippets
- wire the global search box into the new autocomplete suggestions and update styles to support the richer experience

## Testing
- php -l CMS/includes/search_helpers.php
- php -l CMS/modules/search/view.php
- php -l CMS/admin.php

------
https://chatgpt.com/codex/tasks/task_e_68dc904d77d48331b53eedc871955975