### PR TITLE
Add front-end events block

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -1435,6 +1435,250 @@ section.container-fluid {
     font-size: 0.9rem;
 }
 
+/* Events block */
+.events-block {
+    padding: 4rem 0;
+}
+
+.events-block__heading {
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+.events-block__intro {
+    max-width: 640px;
+    margin: 0 auto 0.5rem;
+}
+
+.events-block__items {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.events-block__item {
+    display: flex;
+    gap: 1.5rem;
+    align-items: stretch;
+    background: #fff;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 15px 45px rgba(15, 23, 42, 0.12);
+    padding: 1.75rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    height: 100%;
+}
+
+.events-block__item:hover,
+.events-block__item:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 24px 55px rgba(30, 64, 175, 0.18);
+}
+
+.events-block__item--placeholder {
+    justify-content: center;
+    text-align: center;
+    color: #64748b;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(147, 51, 234, 0.08));
+    border-style: dashed;
+}
+
+.events-block__date {
+    flex: 0 0 auto;
+    width: 88px;
+    border-radius: 1rem;
+    background: linear-gradient(135deg, #4338ca, #7c3aed);
+    color: #fff;
+    text-align: center;
+    padding: 1.1rem 0.75rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+}
+
+.events-block__date-month {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.events-block__date-day {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.events-block__body {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.events-block__title {
+    font-size: 1.4rem;
+    margin-bottom: 0.25rem;
+}
+
+.events-block__title a,
+.events-block__title-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+.events-block__title a:hover,
+.events-block__title a:focus,
+.events-block__title-link:hover,
+.events-block__title-link:focus {
+    color: #4338ca;
+}
+
+.events-block__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+    color: #475569;
+}
+
+.events-block__meta-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.events-block__time {
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.events-block__location {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.events-block__badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.15);
+    color: #1d4ed8;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.events-block__price {
+    font-weight: 600;
+    color: #16a34a;
+}
+
+.events-block__description {
+    color: #475569;
+    margin-bottom: 0;
+}
+
+.events-block__cta {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.65rem 1.3rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #4f46e5, #6366f1);
+    color: #fff;
+    font-weight: 600;
+    text-decoration: none;
+    box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.events-block__cta:hover,
+.events-block__cta:focus-visible {
+    background: linear-gradient(135deg, #4338ca, #4c1d95);
+    transform: translateY(-1px);
+    color: #fff;
+}
+
+.events-block__empty {
+    margin-top: 2rem;
+}
+
+.events-block--layout-cards .events-block__items {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.events-block--layout-list .events-block__items {
+    display: flex;
+    flex-direction: column;
+}
+
+.events-block--layout-list .events-block__item {
+    width: 100%;
+}
+
+.events-block--layout-compact .events-block__items {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.events-block--layout-compact .events-block__item {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 1.25rem;
+}
+
+.events-block--layout-compact .events-block__date {
+    width: auto;
+    padding: 0.75rem 1.1rem;
+}
+
+.events-block--layout-compact .events-block__body {
+    align-items: center;
+}
+
+.events-block--layout-compact .events-block__meta {
+    align-items: center;
+}
+
+.events-block--layout-compact .events-block__cta {
+    align-self: center;
+}
+
+@media (max-width: 991px) {
+    .events-block {
+        padding: 3rem 0;
+    }
+    .events-block__items {
+        gap: 1.25rem;
+    }
+    .events-block__item {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .events-block__date {
+        width: 72px;
+        align-self: flex-start;
+    }
+}
+
+@media (max-width: 640px) {
+    .events-block__heading {
+        font-size: 1.75rem;
+    }
+    .events-block__items {
+        grid-template-columns: 1fr;
+    }
+    .events-block__item {
+        padding: 1.5rem;
+    }
+}
+
 @media (max-width: 768px) {
     .calendar-block {
         padding: 1.25rem;

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -248,6 +248,530 @@
       });
   }
 
+  var eventsPromise = null;
+  var eventCategoriesPromise = null;
+  var htmlParser = null;
+
+  function fetchEvents() {
+    if (eventsPromise) {
+      return eventsPromise;
+    }
+    var base = normalizeBasePath();
+    var url = base + '/CMS/data/events.json';
+    eventsPromise = fetch(url, { credentials: 'same-origin', cache: 'no-store' })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Failed to load events');
+        }
+        return response.json();
+      })
+      .then(function (events) {
+        if (!Array.isArray(events)) {
+          return [];
+        }
+        return events.filter(function (event) {
+          if (!event || typeof event !== 'object') {
+            return false;
+          }
+          var status = String(event.status || '').toLowerCase();
+          return !status || status === 'published';
+        });
+      })
+      .catch(function (error) {
+        console.error('[SparkCMS] Events load error:', error);
+        eventsPromise = null;
+        throw error;
+      });
+    return eventsPromise;
+  }
+
+  function fetchEventCategories() {
+    if (eventCategoriesPromise) {
+      return eventCategoriesPromise;
+    }
+    var base = normalizeBasePath();
+    var url = base + '/CMS/data/event_categories.json';
+    eventCategoriesPromise = fetch(url, { credentials: 'same-origin', cache: 'no-store' })
+      .then(function (response) {
+        if (!response.ok) {
+          throw new Error('Failed to load event categories');
+        }
+        return response.json();
+      })
+      .then(function (records) {
+        if (!Array.isArray(records)) {
+          return {};
+        }
+        return records.reduce(function (map, record) {
+          if (!record || typeof record !== 'object') {
+            return map;
+          }
+          var id = record.id || record.slug || record.name;
+          if (!id) {
+            return map;
+          }
+          map[id] = {
+            id: id,
+            name: record.name || '',
+            slug: record.slug || '',
+            normalizedName: normalizeCategory(record.name),
+            normalizedSlug: normalizeCategory(record.slug),
+            normalizedId: normalizeCategory(id)
+          };
+          return map;
+        }, {});
+      })
+      .catch(function (error) {
+        console.error('[SparkCMS] Event categories load error:', error);
+        eventCategoriesPromise = null;
+        return {};
+      });
+    return eventCategoriesPromise;
+  }
+
+  function parseBooleanOption(value, defaultValue) {
+    if (value == null) {
+      return defaultValue;
+    }
+    var normalized = String(value).toLowerCase().trim();
+    if (['no', 'false', '0', 'off', 'hide'].indexOf(normalized) !== -1) {
+      return false;
+    }
+    if (['yes', 'true', '1', 'show', 'on'].indexOf(normalized) !== -1) {
+      return true;
+    }
+    return defaultValue;
+  }
+
+  function normalizeEventsLayout(value) {
+    var layout = String(value || '').toLowerCase();
+    if (['list', 'compact', 'cards'].indexOf(layout) === -1) {
+      return 'cards';
+    }
+    return layout;
+  }
+
+  function eventMatchesCategoryFilter(event, filter, categoriesIndex) {
+    if (!filter) {
+      return true;
+    }
+    var ids = Array.isArray(event.categories) ? event.categories : [];
+    if (!ids.length) {
+      return false;
+    }
+    return ids.some(function (id) {
+      var info = categoriesIndex[id];
+      if (!info) {
+        return normalizeCategory(id) === filter;
+      }
+      return info.normalizedId === filter || info.normalizedSlug === filter || info.normalizedName === filter;
+    });
+  }
+
+  function stripHtml(html) {
+    if (!html) {
+      return '';
+    }
+    if (!htmlParser) {
+      htmlParser = document.createElement('div');
+    }
+    htmlParser.innerHTML = html;
+    return htmlParser.textContent || htmlParser.innerText || '';
+  }
+
+  function truncateText(value, maxLength) {
+    if (!value) {
+      return '';
+    }
+    var text = String(value).trim();
+    if (!maxLength || text.length <= maxLength) {
+      return text;
+    }
+    return text.slice(0, maxLength - 1).trimEnd() + '…';
+  }
+
+  function formatEventMonth(date) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+      return '';
+    }
+    try {
+      return date.toLocaleString(undefined, { month: 'short' });
+    } catch (error) {
+      return ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][date.getMonth()] || '';
+    }
+  }
+
+  function formatEventDay(date) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+      return '';
+    }
+    return String(date.getDate()).padStart(2, '0');
+  }
+
+  function formatEventRange(start, end) {
+    if (!(start instanceof Date) || Number.isNaN(start.getTime())) {
+      return '';
+    }
+    var formatterOptions = { month: 'short', day: 'numeric', year: 'numeric' };
+    var timeFormatterOptions = { hour: 'numeric', minute: '2-digit' };
+    var dateLabel;
+    try {
+      dateLabel = start.toLocaleDateString(undefined, formatterOptions);
+    } catch (error) {
+      dateLabel = start.getFullYear() + '-' + String(start.getMonth() + 1).padStart(2, '0') + '-' + String(start.getDate()).padStart(2, '0');
+    }
+    if (!(end instanceof Date) || Number.isNaN(end.getTime())) {
+      try {
+        var timeLabel = start.toLocaleTimeString(undefined, timeFormatterOptions);
+        return timeLabel ? dateLabel + ' • ' + timeLabel : dateLabel;
+      } catch (error) {
+        return dateLabel;
+      }
+    }
+    var sameDay = start.toDateString() === end.toDateString();
+    try {
+      if (sameDay) {
+        var startTime = start.toLocaleTimeString(undefined, timeFormatterOptions);
+        var endTime = end.toLocaleTimeString(undefined, timeFormatterOptions);
+        if (startTime && endTime) {
+          return dateLabel + ' • ' + startTime + ' – ' + endTime;
+        }
+        if (startTime) {
+          return dateLabel + ' • ' + startTime;
+        }
+        return dateLabel;
+      }
+      var endLabel = end.toLocaleDateString(undefined, formatterOptions);
+      return dateLabel + ' – ' + endLabel;
+    } catch (error) {
+      var endStamp = end.getFullYear() + '-' + String(end.getMonth() + 1).padStart(2, '0') + '-' + String(end.getDate()).padStart(2, '0');
+      return sameDay ? dateLabel : dateLabel + ' – ' + endStamp;
+    }
+  }
+
+  function findLowestPrice(tickets) {
+    if (!Array.isArray(tickets) || !tickets.length) {
+      return null;
+    }
+    var values = tickets
+      .filter(function (ticket) {
+        return ticket && ticket.enabled !== false && Number.isFinite(Number(ticket.price));
+      })
+      .map(function (ticket) {
+        return Number(ticket.price);
+      });
+    if (!values.length) {
+      return null;
+    }
+    return Math.min.apply(Math, values);
+  }
+
+  function formatCurrency(amount) {
+    if (!Number.isFinite(amount)) {
+      return '';
+    }
+    try {
+      return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(amount);
+    } catch (error) {
+      return '$' + amount.toFixed(2);
+    }
+  }
+
+  function createEventSlug(event) {
+    if (!event || typeof event !== 'object') {
+      return '';
+    }
+    if (event.slug) {
+      return String(event.slug).trim();
+    }
+    if (event.title) {
+      var generated = String(event.title)
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      if (generated) {
+        return generated;
+      }
+    }
+    if (event.id) {
+      return String(event.id).trim();
+    }
+    return '';
+  }
+
+  function resolveEventDetailUrl(prefix, event) {
+    var base = (prefix || '').toString().trim();
+    if (!base) {
+      return '';
+    }
+    var slug = createEventSlug(event);
+    if (/^https?:\/\//i.test(base)) {
+      return base.replace(/\/+$/, '') + (slug ? '/' + slug : '');
+    }
+    var normalized = base.replace(/\/+$/, '').replace(/^\/+/, '');
+    var path = normalized;
+    if (slug) {
+      path = normalized ? normalized + '/' + slug : slug;
+    }
+    var start = normalizeBasePath();
+    if (start && start.charAt(0) !== '/') {
+      start = '/' + start;
+    }
+    if (!start) {
+      return '/' + path;
+    }
+    return start.replace(/\/+$/, '') + '/' + path;
+  }
+
+  function showEventsEmpty(container, message) {
+    var empty = container.querySelector('[data-events-empty]');
+    if (empty) {
+      empty.textContent = message || empty.textContent || '';
+      empty.classList.remove('d-none');
+    }
+  }
+
+  function hideEventsEmpty(container) {
+    var empty = container.querySelector('[data-events-empty]');
+    if (empty) {
+      empty.classList.add('d-none');
+    }
+  }
+
+  function createEventsItem(event, options) {
+    var item = document.createElement('article');
+    item.className = 'events-block__item';
+    if (event.id) {
+      item.setAttribute('data-events-id', String(event.id));
+    }
+
+    if (event.startDate instanceof Date && !Number.isNaN(event.startDate.getTime())) {
+      var dateWrap = document.createElement('div');
+      dateWrap.className = 'events-block__date';
+      var monthSpan = document.createElement('span');
+      monthSpan.className = 'events-block__date-month';
+      monthSpan.textContent = formatEventMonth(event.startDate);
+      dateWrap.appendChild(monthSpan);
+      var daySpan = document.createElement('span');
+      daySpan.className = 'events-block__date-day';
+      daySpan.textContent = formatEventDay(event.startDate);
+      dateWrap.appendChild(daySpan);
+      item.appendChild(dateWrap);
+    }
+
+    var body = document.createElement('div');
+    body.className = 'events-block__body';
+    var title = document.createElement('h3');
+    title.className = 'events-block__title';
+    var linkUrl = resolveEventDetailUrl(options.detailBase, event.raw);
+    if (linkUrl) {
+      var link = document.createElement('a');
+      link.className = 'events-block__title-link';
+      link.href = linkUrl;
+      link.textContent = event.raw.title || 'Untitled Event';
+      title.appendChild(link);
+    } else {
+      title.textContent = event.raw.title || 'Untitled Event';
+    }
+    body.appendChild(title);
+
+    var meta = document.createElement('div');
+    meta.className = 'events-block__meta';
+
+    if (event.startDate) {
+      var metaLine = document.createElement('div');
+      metaLine.className = 'events-block__meta-line';
+      var timeEl = document.createElement('time');
+      timeEl.className = 'events-block__time';
+      timeEl.dateTime = event.startDate.toISOString();
+      timeEl.textContent = formatEventRange(event.startDate, event.endDate);
+      metaLine.appendChild(timeEl);
+      meta.appendChild(metaLine);
+    }
+
+    if (options.showLocation && event.raw.location) {
+      var locationLine = document.createElement('div');
+      locationLine.className = 'events-block__meta-line';
+      var locationSpan = document.createElement('span');
+      locationSpan.className = 'events-block__location';
+      locationSpan.textContent = event.raw.location;
+      locationLine.appendChild(locationSpan);
+      meta.appendChild(locationLine);
+    }
+
+    if (options.showCategories && event.categoryNames.length) {
+      var categoriesLine = document.createElement('div');
+      categoriesLine.className = 'events-block__meta-line events-block__meta-line--badges';
+      event.categoryNames.forEach(function (name) {
+        var badge = document.createElement('span');
+        badge.className = 'events-block__badge';
+        badge.textContent = name;
+        categoriesLine.appendChild(badge);
+      });
+      meta.appendChild(categoriesLine);
+    }
+
+    if (options.showPrice && Number.isFinite(event.lowestPrice)) {
+      var priceLine = document.createElement('div');
+      priceLine.className = 'events-block__meta-line';
+      var priceSpan = document.createElement('span');
+      priceSpan.className = 'events-block__price';
+      priceSpan.textContent = 'From ' + formatCurrency(event.lowestPrice);
+      priceLine.appendChild(priceSpan);
+      meta.appendChild(priceLine);
+    }
+
+    if (meta.childNodes.length) {
+      body.appendChild(meta);
+    }
+
+    if (options.showDescription && event.description) {
+      var description = document.createElement('p');
+      description.className = 'events-block__description';
+      description.textContent = event.description;
+      body.appendChild(description);
+    }
+
+    if (options.showButton && linkUrl) {
+      var cta = document.createElement('a');
+      cta.className = 'events-block__cta';
+      cta.href = linkUrl;
+      cta.textContent = options.buttonLabel || 'View event';
+      body.appendChild(cta);
+    }
+
+    item.appendChild(body);
+    return item;
+  }
+
+  function renderEventsBlock(container) {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+    var itemsHost = container.querySelector('[data-events-items]');
+    if (!itemsHost) {
+      return;
+    }
+
+    itemsHost.innerHTML = '';
+    hideEventsEmpty(container);
+
+    var loading = document.createElement('article');
+    loading.className = 'events-block__item events-block__item--placeholder';
+    var loadingBody = document.createElement('div');
+    loadingBody.className = 'events-block__body';
+    var loadingTitle = document.createElement('h3');
+    loadingTitle.className = 'events-block__title';
+    loadingTitle.textContent = 'Loading events…';
+    loadingBody.appendChild(loadingTitle);
+    loading.appendChild(loadingBody);
+    itemsHost.appendChild(loading);
+
+    var layout = normalizeEventsLayout(container.dataset.eventsLayout);
+    container.dataset.eventsLayout = layout;
+    container.classList.remove('events-block--layout-cards', 'events-block--layout-list', 'events-block--layout-compact');
+    container.classList.add('events-block--layout-' + layout);
+
+    var limit = parsePositiveInt(container.dataset.eventsLimit, 3);
+    var categoryFilter = normalizeCategory(container.dataset.eventsCategory);
+    var emptyMessage = container.dataset.eventsEmpty || 'No upcoming events found.';
+    var descriptionLength = parsePositiveInt(container.dataset.eventsDescriptionLength, 160);
+    var options = {
+      detailBase: container.dataset.eventsDetailBase || '',
+      buttonLabel: container.dataset.eventsButtonLabel || 'View event',
+      showButton: parseBooleanOption(container.dataset.eventsShowButton, !!container.dataset.eventsDetailBase),
+      showDescription: parseBooleanOption(container.dataset.eventsShowDescription, true),
+      showLocation: parseBooleanOption(container.dataset.eventsShowLocation, true),
+      showCategories: parseBooleanOption(container.dataset.eventsShowCategories, true),
+      showPrice: parseBooleanOption(container.dataset.eventsShowPrice, true)
+    };
+
+    Promise.all([fetchEvents(), fetchEventCategories()])
+      .then(function (results) {
+        var records = Array.isArray(results[0]) ? results[0] : [];
+        var categoriesIndex = results[1] && typeof results[1] === 'object' ? results[1] : {};
+        var now = new Date();
+        var enriched = records
+          .map(function (record) {
+            var startDate = parseIsoDate(record.start);
+            var endDate = parseIsoDate(record.end);
+            var inFuture = false;
+            if (startDate && !Number.isNaN(startDate.getTime())) {
+              inFuture = startDate.getTime() >= now.getTime();
+            }
+            if (!inFuture && endDate && !Number.isNaN(endDate.getTime())) {
+              inFuture = endDate.getTime() >= now.getTime();
+            }
+            var categoryNames = [];
+            var ids = Array.isArray(record.categories) ? record.categories : [];
+            ids.forEach(function (id) {
+              var info = categoriesIndex[id];
+              if (info && info.name) {
+                categoryNames.push(info.name);
+              } else if (id) {
+                categoryNames.push(String(id));
+              }
+            });
+            return {
+              raw: record,
+              id: record.id,
+              startDate: startDate,
+              endDate: endDate,
+              upcoming: inFuture,
+              description: truncateText(stripHtml(record.description), descriptionLength),
+              categoryNames: categoryNames,
+              lowestPrice: findLowestPrice(record.tickets)
+            };
+          })
+          .filter(function (event) {
+            if (!event.startDate) {
+              return false;
+            }
+            if (!event.upcoming) {
+              return false;
+            }
+            if (!categoryFilter) {
+              return true;
+            }
+            return eventMatchesCategoryFilter(event.raw, categoryFilter, categoriesIndex);
+          });
+
+        enriched.sort(function (a, b) {
+          var aTime = a.startDate instanceof Date ? a.startDate.getTime() : 0;
+          var bTime = b.startDate instanceof Date ? b.startDate.getTime() : 0;
+          return aTime - bTime;
+        });
+
+        if (limit && enriched.length > limit) {
+          enriched = enriched.slice(0, limit);
+        }
+
+        itemsHost.innerHTML = '';
+
+        if (!enriched.length) {
+          showEventsEmpty(container, emptyMessage);
+          return;
+        }
+
+        hideEventsEmpty(container);
+        enriched.forEach(function (event) {
+          var node = createEventsItem(event, options);
+          itemsHost.appendChild(node);
+        });
+      })
+      .catch(function () {
+        itemsHost.innerHTML = '';
+        showEventsEmpty(container, 'Unable to load events right now.');
+      });
+  }
+
+  function initEventsBlocks() {
+    var blocks = document.querySelectorAll('[data-events-block]');
+    blocks.forEach(function (block) {
+      renderEventsBlock(block);
+    });
+  }
+
   var calendarEventsPromise = null;
 
   function fetchCalendarEvents() {
@@ -688,6 +1212,7 @@
     var observer = new MutationObserver(function (mutations) {
       var shouldRefreshBlogs = false;
       var shouldRefreshCalendars = false;
+      var shouldRefreshEvents = false;
       mutations.forEach(function (mutation) {
         if (mutation.type !== 'childList') {
           return;
@@ -702,6 +1227,9 @@
           if (node.matches('[data-calendar-block]') || node.querySelector('[data-calendar-block]')) {
             shouldRefreshCalendars = true;
           }
+          if (node.matches('[data-events-block]') || node.querySelector('[data-events-block]')) {
+            shouldRefreshEvents = true;
+          }
         });
       });
       if (shouldRefreshBlogs) {
@@ -709,6 +1237,9 @@
       }
       if (shouldRefreshCalendars) {
         initCalendarBlocks();
+      }
+      if (shouldRefreshEvents) {
+        initEventsBlocks();
       }
     });
     observer.observe(document.body || document.documentElement, {
@@ -719,12 +1250,17 @@
 
   ready(function () {
     initBlogLists();
+    initEventsBlocks();
     initCalendarBlocks();
     observe();
   });
 
   window.SparkCMSBlogLists = {
     refresh: initBlogLists
+  };
+
+  window.SparkCMSEvents = {
+    refresh: initEventsBlocks
   };
 
   window.SparkCMSCalendars = {

--- a/theme/templates/blocks/interactive.events.php
+++ b/theme/templates/blocks/interactive.events.php
@@ -1,0 +1,125 @@
+<!-- File: interactive.events.php -->
+<!-- Template: interactive.events -->
+<?php $blockId = uniqid('events-block-'); ?>
+<templateSetting caption="Events Settings" order="1">
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Section Title</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_title" value="Upcoming Events">
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Intro Text</dt>
+        <dd>
+            <textarea class="form-control" name="custom_intro" rows="3">Join us for workshops, meetups, and community gatherings hosted by SparkCMS.</textarea>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Layout Style</dt>
+        <dd>
+            <select name="custom_layout" class="form-select">
+                <option value="cards" selected>Cards</option>
+                <option value="list">List</option>
+                <option value="compact">Compact</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Number of Events</dt>
+        <dd>
+            <select name="custom_limit" class="form-select">
+                <option value="3" selected>Show 3 events</option>
+                <option value="4">Show 4 events</option>
+                <option value="6">Show 6 events</option>
+                <option value="9">Show 9 events</option>
+            </select>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Filter by Category</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_category" placeholder="All categories">
+            <small class="form-text text-muted">Match an event category name, slug, or ID to limit the results.</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Detail Page URL Prefix</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_detail_base" value="/events">
+            <small class="form-text text-muted">The event slug (derived from the title or ID) is appended automatically.</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Button Label</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_button_label" value="View event">
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Button?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_button" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_button" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Description?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_description" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_description" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Description Length</dt>
+        <dd>
+            <input type="number" class="form-control" name="custom_description_length" value="160" min="40" max="320">
+            <small class="form-text text-muted">Maximum number of characters shown in the preview text.</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Location?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_location" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_location" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Categories?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_categories" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_categories" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Starting Price?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_price" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_price" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Empty State Message</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_empty" value="There are no upcoming events right now.">
+        </dd>
+    </dl>
+</templateSetting>
+<section id="<?= $blockId ?>" class="events-block events-block--layout-{custom_layout}" data-tpl-tooltip="Events" data-events-block data-events-layout="{custom_layout}" data-events-limit="{custom_limit}" data-events-category="{custom_category}" data-events-detail-base="{custom_detail_base}" data-events-button-label="{custom_button_label}" data-events-show-button="{custom_show_button}" data-events-show-description="{custom_show_description}" data-events-description-length="{custom_description_length}" data-events-show-location="{custom_show_location}" data-events-show-categories="{custom_show_categories}" data-events-show-price="{custom_show_price}" data-events-empty="{custom_empty}">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-8 text-center mb-4">
+                <h2 class="events-block__heading" data-editable>{custom_title}</h2>
+                <p class="events-block__intro text-muted" data-editable>{custom_intro}</p>
+            </div>
+        </div>
+        <div class="events-block__items" data-events-items>
+            <article class="events-block__item events-block__item--placeholder">
+                <div class="events-block__body">
+                    <h3 class="events-block__title">Loading events…</h3>
+                    <p class="events-block__description">Upcoming events will appear here once published.</p>
+                </div>
+            </article>
+        </div>
+        <div class="events-block__empty text-center text-muted d-none" data-events-empty>{custom_empty}</div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add a configurable events block template for front-end pages
- extend the public JavaScript bundle to fetch events data and render the new block
- style the events block layouts and states with responsive CSS additions

## Testing
- php -l theme/templates/blocks/interactive.events.php

------
https://chatgpt.com/codex/tasks/task_e_68dc920b64548331b9f68c4676766ad9