### PR TITLE
Add commerce pricing table block with responsive styling

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -1748,3 +1748,225 @@ section.container-fluid {
         justify-content: flex-end;
     }
 }
+
+/* Pricing table block */
+.pricing-table {
+    padding: clamp(3rem, 8vw, 5rem) 0;
+    background: linear-gradient(135deg, rgba(102, 126, 234, 0.08), rgba(118, 75, 162, 0.08));
+}
+
+.pricing-table__inner {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(2rem, 5vw, 3.5rem);
+}
+
+.pricing-table__header {
+    text-align: center;
+    max-width: 52rem;
+    margin: 0 auto;
+}
+
+.pricing-table__title {
+    font-size: clamp(2rem, 4vw, 2.75rem);
+    font-weight: 700;
+    color: #1f2937;
+}
+
+.pricing-table__subtitle {
+    margin-top: 0.75rem;
+    font-size: 1.05rem;
+    color: #4b5563;
+}
+
+.pricing-table__grid {
+    display: grid;
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    grid-template-columns: repeat(auto-fit, minmax(16.5rem, 1fr));
+    align-items: stretch;
+}
+
+.pricing-table__tier {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    border-radius: 1.25rem;
+    background: #ffffff;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(99, 102, 241, 0.12);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.pricing-table__tier:hover,
+.pricing-table__tier:focus-within {
+    transform: translateY(-6px);
+    box-shadow: 0 24px 48px rgba(79, 70, 229, 0.18);
+    border-color: rgba(79, 70, 229, 0.45);
+}
+
+.pricing-table__tier-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.pricing-table__tier-name {
+    font-size: 1.35rem;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.pricing-table__tier-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: #6366f1;
+    font-weight: 600;
+}
+
+.pricing-table__price {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: inherit;
+}
+
+.pricing-table__price-cycle {
+    font-size: 1rem;
+    font-weight: 500;
+    color: #6b7280;
+}
+
+.pricing-table__features {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+    padding: 0;
+    margin: 0;
+    font-size: 0.95rem;
+    color: #374151;
+}
+
+.pricing-table__features li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.pricing-table__features li::before {
+    content: '\2713';
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 999px;
+    background: rgba(99, 102, 241, 0.12);
+    color: #4f46e5;
+    line-height: 1.5rem;
+    text-align: center;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.pricing-table__cta {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 3rem;
+    padding: 0.75rem 1.75rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 1rem;
+    color: #ffffff;
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    text-decoration: none;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background-position 0.3s ease;
+    background-size: 200% 200%;
+    background-position: 0% 50%;
+}
+
+.pricing-table__cta:hover,
+.pricing-table__cta:focus-visible {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 32px rgba(99, 102, 241, 0.35);
+    background-position: 100% 50%;
+}
+
+.pricing-table__tier--featured {
+    border: 2px solid #f97316;
+    box-shadow: 0 28px 56px rgba(249, 115, 22, 0.25);
+}
+
+.pricing-table__tier--featured .pricing-table__tier-name {
+    color: #f97316;
+}
+
+.pricing-table__tier--featured .pricing-table__cta {
+    background: linear-gradient(135deg, #f97316, #fb923c);
+    box-shadow: 0 18px 40px rgba(249, 115, 22, 0.35);
+}
+
+.pricing-table__tier--featured .pricing-table__cta:hover,
+.pricing-table__tier--featured .pricing-table__cta:focus-visible {
+    box-shadow: 0 22px 48px rgba(249, 115, 22, 0.45);
+}
+
+.pricing-table--tiers-3 .pricing-table__tier--optional {
+    display: none;
+}
+
+.pricing-table--tiers-4 .pricing-table__tier--optional {
+    display: flex;
+}
+
+@media (max-width: 1024px) {
+    .pricing-table__grid {
+        grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .pricing-table__grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .pricing-table__tier {
+        text-align: center;
+    }
+
+    .pricing-table__features {
+        justify-items: center;
+    }
+
+    .pricing-table__features li {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .pricing-table__features li::before {
+        margin-right: 0;
+        margin-bottom: 0.35rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .pricing-table__tier,
+    .pricing-table__cta {
+        transition: none;
+    }
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/theme/templates/blocks/commerce.pricing-table.php
+++ b/theme/templates/blocks/commerce.pricing-table.php
@@ -1,0 +1,254 @@
+<!-- File: commerce.pricing-table.php -->
+<!-- Template: commerce.pricing-table -->
+<templateSetting caption="Section Settings" order="1">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Heading</dt>
+        <dd><input type="text" name="custom_heading" value="Pricing plans"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Subheading</dt>
+        <dd><textarea class="form-control" name="custom_subheading">Choose the plan that fits your team today and scale whenever you're ready.</textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Number of tiers</dt>
+        <dd>
+            <select name="custom_tier_count">
+                <option value=" pricing-table--tiers-3" selected>Three tiers</option>
+                <option value=" pricing-table--tiers-4">Four tiers</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<templateSetting caption="Plan 1" order="2">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Plan name</dt>
+        <dd><input type="text" name="custom_plan1_name" value="Starter"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Price</dt>
+        <dd><input type="text" name="custom_plan1_price" value="$29"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Billing cycle</dt>
+        <dd><input type="text" name="custom_plan1_cycle" value="per month"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Feature list</dt>
+        <dd><textarea class="form-control" name="custom_plan1_features"><li>Up to 3 projects</li>
+<li>Community support</li>
+<li>Basic analytics</li></textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action text</dt>
+        <dd><input type="text" name="custom_plan1_cta" value="Start free"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action link</dt>
+        <dd><input type="text" name="custom_plan1_url" value="#"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Highlight plan</dt>
+        <dd>
+            <select name="custom_plan1_featured">
+                <option value="">No</option>
+                <option value=" pricing-table__tier--featured">Yes</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<templateSetting caption="Plan 2" order="3">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Plan name</dt>
+        <dd><input type="text" name="custom_plan2_name" value="Growth"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Price</dt>
+        <dd><input type="text" name="custom_plan2_price" value="$59"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Billing cycle</dt>
+        <dd><input type="text" name="custom_plan2_cycle" value="per month"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Feature list</dt>
+        <dd><textarea class="form-control" name="custom_plan2_features"><li>Unlimited projects</li>
+<li>Team workspaces</li>
+<li>Advanced analytics</li>
+<li>Email &amp; chat support</li></textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action text</dt>
+        <dd><input type="text" name="custom_plan2_cta" value="Upgrade"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action link</dt>
+        <dd><input type="text" name="custom_plan2_url" value="#"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Highlight plan</dt>
+        <dd>
+            <select name="custom_plan2_featured">
+                <option value="">No</option>
+                <option value=" pricing-table__tier--featured" selected>Yes</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<templateSetting caption="Plan 3" order="4">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Plan name</dt>
+        <dd><input type="text" name="custom_plan3_name" value="Scale"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Price</dt>
+        <dd><input type="text" name="custom_plan3_price" value="$129"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Billing cycle</dt>
+        <dd><input type="text" name="custom_plan3_cycle" value="per month"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Feature list</dt>
+        <dd><textarea class="form-control" name="custom_plan3_features"><li>Dedicated success manager</li>
+<li>Priority integrations</li>
+<li>Custom reporting</li>
+<li>Phone &amp; video support</li></textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action text</dt>
+        <dd><input type="text" name="custom_plan3_cta" value="Contact sales"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action link</dt>
+        <dd><input type="text" name="custom_plan3_url" value="#"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Highlight plan</dt>
+        <dd>
+            <select name="custom_plan3_featured">
+                <option value="" selected>No</option>
+                <option value=" pricing-table__tier--featured">Yes</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<templateSetting caption="Plan 4" order="5">
+    <dl class="sparkDialog _tpl-box">
+        <dt>Plan name</dt>
+        <dd><input type="text" name="custom_plan4_name" value="Enterprise"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Price</dt>
+        <dd><input type="text" name="custom_plan4_price" value="Custom"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Billing cycle</dt>
+        <dd><input type="text" name="custom_plan4_cycle" value="Contact us"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Feature list</dt>
+        <dd><textarea class="form-control" name="custom_plan4_features"><li>Enterprise-grade security</li>
+<li>99.9% uptime SLA</li>
+<li>Tailored onboarding</li>
+<li>Unlimited automation</li></textarea></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action text</dt>
+        <dd><input type="text" name="custom_plan4_cta" value="Talk to us"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Call-to-action link</dt>
+        <dd><input type="text" name="custom_plan4_url" value="#"></dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Highlight plan</dt>
+        <dd>
+            <select name="custom_plan4_featured">
+                <option value="" selected>No</option>
+                <option value=" pricing-table__tier--featured">Yes</option>
+            </select>
+        </dd>
+    </dl>
+</templateSetting>
+<section class="pricing-table{custom_tier_count}" data-tpl-tooltip="Commerce pricing table">
+    <div class="pricing-table__inner container">
+        <header class="pricing-table__header">
+            <h2 class="pricing-table__title" data-editable>{custom_heading}</h2>
+            <p class="pricing-table__subtitle" data-editable>{custom_subheading}</p>
+        </header>
+        <div class="pricing-table__grid" role="list" aria-label="Pricing tiers">
+            <article class="pricing-table__tier{custom_plan1_featured}" role="listitem" aria-labelledby="pricing-tier-1-title" aria-describedby="pricing-tier-1-summary">
+                <header class="pricing-table__tier-header">
+                    <p class="pricing-table__tier-name" id="pricing-tier-1-title" data-editable>{custom_plan1_name}</p>
+                    <p class="pricing-table__tier-summary" id="pricing-tier-1-summary">
+                        <span class="pricing-table__price" data-editable>
+                            <span class="pricing-table__price-amount">{custom_plan1_price}</span>
+                            <span class="pricing-table__price-cycle" aria-hidden="true">{custom_plan1_cycle}</span>
+                        </span>
+                        <span class="sr-only">Billed {custom_plan1_cycle}</span>
+                    </p>
+                </header>
+                <ul class="pricing-table__features" data-editable aria-label="{custom_plan1_name} plan features">
+                    {custom_plan1_features}
+                </ul>
+                <a class="pricing-table__cta" href="{custom_plan1_url}" data-editable aria-label="Select the {custom_plan1_name} plan">
+                    <span class="pricing-table__cta-text">{custom_plan1_cta}</span>
+                </a>
+            </article>
+            <article class="pricing-table__tier{custom_plan2_featured}" role="listitem" aria-labelledby="pricing-tier-2-title" aria-describedby="pricing-tier-2-summary">
+                <header class="pricing-table__tier-header">
+                    <p class="pricing-table__tier-name" id="pricing-tier-2-title" data-editable>{custom_plan2_name}</p>
+                    <p class="pricing-table__tier-summary" id="pricing-tier-2-summary">
+                        <span class="pricing-table__price" data-editable>
+                            <span class="pricing-table__price-amount">{custom_plan2_price}</span>
+                            <span class="pricing-table__price-cycle" aria-hidden="true">{custom_plan2_cycle}</span>
+                        </span>
+                        <span class="sr-only">Billed {custom_plan2_cycle}</span>
+                    </p>
+                </header>
+                <ul class="pricing-table__features" data-editable aria-label="{custom_plan2_name} plan features">
+                    {custom_plan2_features}
+                </ul>
+                <a class="pricing-table__cta" href="{custom_plan2_url}" data-editable aria-label="Select the {custom_plan2_name} plan">
+                    <span class="pricing-table__cta-text">{custom_plan2_cta}</span>
+                </a>
+            </article>
+            <article class="pricing-table__tier{custom_plan3_featured}" role="listitem" aria-labelledby="pricing-tier-3-title" aria-describedby="pricing-tier-3-summary">
+                <header class="pricing-table__tier-header">
+                    <p class="pricing-table__tier-name" id="pricing-tier-3-title" data-editable>{custom_plan3_name}</p>
+                    <p class="pricing-table__tier-summary" id="pricing-tier-3-summary">
+                        <span class="pricing-table__price" data-editable>
+                            <span class="pricing-table__price-amount">{custom_plan3_price}</span>
+                            <span class="pricing-table__price-cycle" aria-hidden="true">{custom_plan3_cycle}</span>
+                        </span>
+                        <span class="sr-only">Billed {custom_plan3_cycle}</span>
+                    </p>
+                </header>
+                <ul class="pricing-table__features" data-editable aria-label="{custom_plan3_name} plan features">
+                    {custom_plan3_features}
+                </ul>
+                <a class="pricing-table__cta" href="{custom_plan3_url}" data-editable aria-label="Select the {custom_plan3_name} plan">
+                    <span class="pricing-table__cta-text">{custom_plan3_cta}</span>
+                </a>
+            </article>
+            <article class="pricing-table__tier pricing-table__tier--optional{custom_plan4_featured}" role="listitem" aria-labelledby="pricing-tier-4-title" aria-describedby="pricing-tier-4-summary">
+                <header class="pricing-table__tier-header">
+                    <p class="pricing-table__tier-name" id="pricing-tier-4-title" data-editable>{custom_plan4_name}</p>
+                    <p class="pricing-table__tier-summary" id="pricing-tier-4-summary">
+                        <span class="pricing-table__price" data-editable>
+                            <span class="pricing-table__price-amount">{custom_plan4_price}</span>
+                            <span class="pricing-table__price-cycle" aria-hidden="true">{custom_plan4_cycle}</span>
+                        </span>
+                        <span class="sr-only">Billed {custom_plan4_cycle}</span>
+                    </p>
+                </header>
+                <ul class="pricing-table__features" data-editable aria-label="{custom_plan4_name} plan features">
+                    {custom_plan4_features}
+                </ul>
+                <a class="pricing-table__cta" href="{custom_plan4_url}" data-editable aria-label="Select the {custom_plan4_name} plan">
+                    <span class="pricing-table__cta-text">{custom_plan4_cta}</span>
+                </a>
+            </article>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add a commerce pricing table template with editor controls for tier counts, pricing, features, calls to action, and highlights
- implement responsive pricing table styles with featured tier emphasis, hover interactions, and screen reader helpers

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc93f2d23c8331b2f448730f2be6fd