### PR TITLE
Add event duplication support to Events module

### DIFF
--- a/CMS/modules/events/events.js
+++ b/CMS/modules/events/events.js
@@ -842,6 +842,9 @@
                 <button type="button" class="events-action" data-events-action="edit" data-id="${row.id}">
                     <i class="fa-solid fa-pen"></i><span class="sr-only">Edit</span>
                 </button>
+                <button type="button" class="events-action" data-events-action="copy" data-id="${row.id}">
+                    <i class="fa-solid fa-copy"></i><span class="sr-only">Copy event</span>
+                </button>
                 <button type="button" class="events-action" data-events-action="sales" data-id="${row.id}">
                     <i class="fa-solid fa-chart-column"></i><span class="sr-only">View sales</span>
                 </button>
@@ -2007,6 +2010,19 @@
             switch (action.dataset.eventsAction) {
                 case 'edit':
                     openEventModal(id);
+                    break;
+                case 'copy':
+                    fetchJSON('copy_event', { method: 'POST', body: { id } })
+                        .then((response) => {
+                            if (response?.event?.id) {
+                                state.events.set(response.event.id, response.event);
+                            }
+                            showToast('Event copied.');
+                            refreshAll();
+                        })
+                        .catch(() => {
+                            showToast('Unable to copy event.', 'error');
+                        });
                     break;
                 case 'sales':
                     document.getElementById('eventsOrdersTitle')?.scrollIntoView({ behavior: 'smooth' });

--- a/CMS/modules/events/helpers.php
+++ b/CMS/modules/events/helpers.php
@@ -73,6 +73,38 @@ if (!function_exists('events_unique_slug')) {
     }
 }
 
+if (!function_exists('events_generate_copy_title')) {
+    function events_generate_copy_title(array $events, string $originalTitle, ?string $excludeId = null): string
+    {
+        $baseTitle = trim($originalTitle) === '' ? 'Untitled Event' : trim($originalTitle);
+        $existing = [];
+        foreach ($events as $event) {
+            if (!is_array($event)) {
+                continue;
+            }
+            $id = (string) ($event['id'] ?? '');
+            if ($excludeId !== null && $id === $excludeId) {
+                continue;
+            }
+            $title = trim((string) ($event['title'] ?? ''));
+            if ($title === '') {
+                continue;
+            }
+            $existing[strtolower($title)] = true;
+        }
+
+        $base = $baseTitle . ' Copy';
+        $candidate = $base;
+        $suffix = 2;
+        while (isset($existing[strtolower($candidate)])) {
+            $candidate = $base . ' ' . $suffix;
+            $suffix++;
+        }
+
+        return $candidate;
+    }
+}
+
 if (!function_exists('events_read_events')) {
     function events_read_events(): array
     {


### PR DESCRIPTION
## Summary
- add API endpoint to duplicate events with unique titles and refreshed metadata
- expose a copy action in the events management table and surface feedback on success or failure

## Testing
- php -l CMS/modules/events/api.php
- php -l CMS/modules/events/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68def715de408331a5703cd8a74aa978