### PR TITLE
Include ticket breakdown in events order exports

### DIFF
--- a/CMS/modules/events/api.php
+++ b/CMS/modules/events/api.php
@@ -342,14 +342,24 @@ function handle_list_orders(array $orders, array $events): void
 function handle_export_orders(array $orders, array $events): void
 {
     $rows = [];
-    $rows[] = ['Order ID', 'Event', 'Buyer', 'Tickets', 'Amount', 'Status', 'Ordered At'];
+    $rows[] = ['Order ID', 'Event', 'Buyer', 'Tickets', 'Ticket Details', 'Amount', 'Status', 'Ordered At'];
     foreach ($orders as $order) {
         $summary = events_order_summary($order, $events);
+        $ticketDetails = [];
+        foreach ($summary['line_items'] ?? [] as $line) {
+            $quantity = (int) ($line['quantity'] ?? 0);
+            if ($quantity <= 0) {
+                continue;
+            }
+            $name = (string) ($line['name'] ?? 'Ticket');
+            $ticketDetails[] = sprintf('%d x %s', $quantity, $name);
+        }
         $rows[] = [
             $summary['id'] ?? '',
             $summary['event'] ?? 'Event',
             $summary['buyer_name'] ?? '',
             $summary['tickets'] ?? 0,
+            implode('; ', $ticketDetails),
             number_format((float) ($summary['amount'] ?? 0), 2, '.', ''),
             strtoupper((string) ($summary['status'] ?? 'paid')),
             $summary['ordered_at'] ?? '',


### PR DESCRIPTION
## Summary
- add a Ticket Details column to the events orders export
- list each purchased ticket name and quantity in the exported CSV rows

## Testing
- php -l CMS/modules/events/api.php

------
https://chatgpt.com/codex/tasks/task_e_68def931718483319e5214453bacb37a