### PR TITLE
Fix copy and sales actions

### DIFF
--- a/CMS/modules/events/api.php
+++ b/CMS/modules/events/api.php
@@ -212,7 +212,12 @@ function handle_save_event(array $events, array $categories): void
 
 function handle_copy_event(array $events, array $categories): void
 {
-    $id = $_POST['id'] ?? ($_GET['id'] ?? '');
+    $payload = parse_json_body();
+    if (empty($payload)) {
+        $payload = $_POST;
+    }
+
+    $id = $payload['id'] ?? ($_GET['id'] ?? '');
     $id = trim((string) $id);
     if ($id === '') {
         respond_json(['error' => 'Missing event id.'], 400);

--- a/CMS/modules/events/events.js
+++ b/CMS/modules/events/events.js
@@ -78,6 +78,12 @@
         toast: document.querySelector('[data-events-toast]'),
     };
 
+    const tabsController = {
+        activate(tabId, options) {
+            /* no-op until initialized */
+        },
+    };
+
     const state = {
         events: new Map(),
         eventRows: [],
@@ -175,6 +181,10 @@
                 tab.focus();
             }
         }
+
+        tabsController.activate = (tabId, options = {}) => {
+            activate(tabId, options);
+        };
 
         function focusByIndex(index) {
             const normalizedIndex = (index + tabButtons.length) % tabButtons.length;
@@ -2025,6 +2035,7 @@
                         });
                     break;
                 case 'sales':
+                    tabsController.activate('orders');
                     document.getElementById('eventsOrdersTitle')?.scrollIntoView({ behavior: 'smooth' });
                     if (selectors.orders.filterEvent) {
                         selectors.orders.filterEvent.value = id;


### PR DESCRIPTION
## Summary
- allow the copy event API handler to accept JSON payloads so the UI request succeeds
- expose a tab controller so the Sales quick action switches to the Orders & sales tab before scrolling

## Testing
- php -l CMS/modules/events/api.php

------
https://chatgpt.com/codex/tasks/task_e_68df2ee501bc83319685ec29547dcff2