### PR TITLE
Fix media default folder recreation

### DIFF
--- a/CMS/modules/media/list_media.php
+++ b/CMS/modules/media/list_media.php
@@ -30,9 +30,13 @@ $results = array_filter($media, function($item) use ($query, $folder) {
 });
 
 $root = dirname(__DIR__,2);
-$default = $root.'/uploads/general';
-if(!is_dir($default)) mkdir($default, 0777, true);
-$folderDirs = array_filter(glob($root.'/uploads/*'), 'is_dir');
+$uploadsDir = $root . '/uploads';
+if (!is_dir($uploadsDir)) {
+    mkdir($uploadsDir, 0777, true);
+    $defaultDir = $uploadsDir . '/general';
+    if (!is_dir($defaultDir)) mkdir($defaultDir, 0777, true);
+}
+$folderDirs = array_filter(glob($uploadsDir . '/*'), 'is_dir');
 $folders = [];
 foreach ($folderDirs as $dir) {
     $name = basename($dir);


### PR DESCRIPTION
## Summary
- ensure the media library only creates the default uploads/general folder when bootstrapping a missing uploads directory
- allow deleting the default folder without it being recreated on the next media listing

## Testing
- php -l CMS/modules/media/list_media.php

------
https://chatgpt.com/codex/tasks/task_e_68df2f0f556c8331aa7762f4b79f3796