### PR TITLE
Add analytics service and streamline analytics module

### DIFF
--- a/CMS/modules/analytics/AnalyticsService.php
+++ b/CMS/modules/analytics/AnalyticsService.php
@@ -1,0 +1,225 @@
+<?php
+// File: AnalyticsService.php
+
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/analytics.php';
+
+class AnalyticsService
+{
+    private string $pagesFile;
+    /** @var array<string,mixed>|null */
+    private ?array $cache = null;
+
+    public function __construct(?string $pagesFile = null)
+    {
+        $this->pagesFile = $pagesFile ?? __DIR__ . '/../../data/pages.json';
+    }
+
+    /**
+     * Retrieve dashboard data prepared for the analytics view.
+     *
+     * @return array<string,mixed>
+     */
+    public function getDashboardData(): array
+    {
+        $this->buildCache();
+
+        return [
+            'totalViews' => $this->cache['totalViews'],
+            'averageViews' => $this->cache['averageViews'],
+            'totalPages' => $this->cache['totalPages'],
+            'zeroViewCount' => $this->cache['zeroViewCount'],
+            'topPages' => $this->cache['topPages'],
+            'zeroViewExamples' => $this->cache['zeroViewExamples'],
+            'initialEntries' => $this->cache['initialEntries'],
+            'summaryComparisons' => $this->cache['summaryComparisons'],
+            'lastUpdatedTimestamp' => $this->cache['lastUpdatedTimestamp'],
+        ];
+    }
+
+    /**
+     * Filter ranked entries for export output.
+     *
+     * @param string $filter
+     * @param string $search
+     * @return array<int,array<string,mixed>>
+     */
+    public function filterForExport(string $filter, string $search): array
+    {
+        $this->buildCache();
+
+        $allowedFilters = ['all', 'top', 'growing', 'no-views'];
+        $filterKey = strtolower($filter);
+        if (!in_array($filterKey, $allowedFilters, true)) {
+            $filterKey = 'all';
+        }
+
+        $searchTerm = trim($search);
+
+        $filtered = array_values(array_filter($this->cache['rankedEntries'], static function (array $entry) use ($filterKey, $searchTerm) {
+            if ($filterKey !== 'all' && $entry['status'] !== $filterKey) {
+                return false;
+            }
+
+            if ($searchTerm === '') {
+                return true;
+            }
+
+            $title = $entry['title'];
+            $slug = $entry['slug'];
+            if (function_exists('mb_stripos')) {
+                $encoding = 'UTF-8';
+                return (mb_stripos($title, $searchTerm, 0, $encoding) !== false)
+                    || (mb_stripos($slug, $searchTerm, 0, $encoding) !== false);
+            }
+
+            return (stripos($title, $searchTerm) !== false)
+                || (stripos($slug, $searchTerm) !== false);
+        }));
+
+        return array_map(static function (array $entry) {
+            return [
+                'title' => $entry['title'],
+                'slug' => $entry['slug'],
+                'views' => $entry['views'],
+                'label' => $entry['label'],
+                'rank' => $entry['rank'],
+                'status' => $entry['status'],
+            ];
+        }, $filtered);
+    }
+
+    private function buildCache(): void
+    {
+        if ($this->cache !== null) {
+            return;
+        }
+
+        $rawPages = read_json_file($this->pagesFile);
+        if (!is_array($rawPages)) {
+            $rawPages = [];
+        }
+
+        $normalized = [];
+        $totalViews = 0;
+        $previousTotalViews = 0;
+        $zeroViewCount = 0;
+        $previousZeroCount = 0;
+        $lastUpdated = 0;
+
+        foreach ($rawPages as $page) {
+            if (!is_array($page)) {
+                continue;
+            }
+
+            $title = isset($page['title']) ? (string) $page['title'] : 'Untitled';
+            $slug = isset($page['slug']) ? (string) $page['slug'] : '';
+            $views = isset($page['views']) ? (int) $page['views'] : 0;
+            if ($views < 0) {
+                $views = 0;
+            }
+
+            $lastModified = isset($page['last_modified']) ? (int) $page['last_modified'] : 0;
+            if ($lastModified > $lastUpdated) {
+                $lastUpdated = $lastModified;
+            }
+
+            $previousViews = analytics_previous_views($slug, $views);
+
+            $normalized[] = [
+                'title' => $title,
+                'slug' => $slug,
+                'views' => $views,
+                'previousViews' => $previousViews,
+                'lastModified' => $lastModified,
+            ];
+
+            $totalViews += $views;
+            $previousTotalViews += $previousViews;
+            if ($views === 0) {
+                $zeroViewCount++;
+            }
+            if ($previousViews === 0) {
+                $previousZeroCount++;
+            }
+        }
+
+        usort($normalized, static function (array $a, array $b) {
+            return ($b['views'] ?? 0) <=> ($a['views'] ?? 0);
+        });
+
+        $totalPages = count($normalized);
+        $averageViews = $totalPages > 0 ? $totalViews / $totalPages : 0.0;
+        $previousAverageViews = $totalPages > 0 ? $previousTotalViews / $totalPages : 0.0;
+
+        $initialEntries = [];
+        foreach ($normalized as $entry) {
+            $initialEntries[] = [
+                'title' => $entry['title'],
+                'slug' => $entry['slug'],
+                'views' => $entry['views'],
+                'previousViews' => $entry['previousViews'],
+            ];
+        }
+
+        $rankedEntries = [];
+        foreach ($normalized as $index => $entry) {
+            $status = 'growing';
+            $label = 'Steady traffic';
+
+            if ($entry['views'] === 0) {
+                $status = 'no-views';
+                $label = 'Needs promotion';
+            } elseif ($index < 3 || $entry['views'] >= $averageViews) {
+                $status = 'top';
+                $label = 'Top performer';
+            }
+
+            $rankedEntries[] = [
+                'title' => $entry['title'],
+                'slug' => $entry['slug'],
+                'views' => $entry['views'],
+                'previousViews' => $entry['previousViews'],
+                'status' => $status,
+                'label' => $label,
+                'rank' => $index + 1,
+            ];
+        }
+
+        $zeroViewExamples = array_slice(array_values(array_filter($initialEntries, static function (array $entry) {
+            return $entry['views'] === 0;
+        })), 0, 3);
+
+        $summaryComparisons = [
+            'totalViews' => [
+                'current' => $totalViews,
+                'previous' => $previousTotalViews,
+            ],
+            'averageViews' => [
+                'current' => $averageViews,
+                'previous' => $previousAverageViews,
+            ],
+            'totalPages' => [
+                'current' => $totalPages,
+                'previous' => $totalPages,
+            ],
+            'zeroViews' => [
+                'current' => $zeroViewCount,
+                'previous' => $previousZeroCount,
+            ],
+        ];
+
+        $this->cache = [
+            'totalViews' => $totalViews,
+            'averageViews' => $averageViews,
+            'totalPages' => $totalPages,
+            'zeroViewCount' => $zeroViewCount,
+            'topPages' => array_slice($initialEntries, 0, 3),
+            'zeroViewExamples' => $zeroViewExamples,
+            'initialEntries' => $initialEntries,
+            'summaryComparisons' => $summaryComparisons,
+            'lastUpdatedTimestamp' => $lastUpdated,
+            'rankedEntries' => $rankedEntries,
+        ];
+    }
+}

--- a/CMS/modules/analytics/export.php
+++ b/CMS/modules/analytics/export.php
@@ -1,87 +1,20 @@
 <?php
 // File: export.php
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/AnalyticsService.php';
 
 require_login();
 
 $filter = isset($_GET['filter']) ? strtolower((string) $_GET['filter']) : 'all';
 $search = isset($_GET['search']) ? trim((string) $_GET['search']) : '';
 
+$service = new AnalyticsService();
 $allowedFilters = ['all', 'top', 'growing', 'no-views'];
 if (!in_array($filter, $allowedFilters, true)) {
     $filter = 'all';
 }
 
-$pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = read_json_file($pagesFile);
-
-$entries = [];
-foreach ($pages as $page) {
-    $title = isset($page['title']) ? (string) $page['title'] : 'Untitled';
-    $slug = isset($page['slug']) ? (string) $page['slug'] : '';
-    $views = isset($page['views']) ? (int) $page['views'] : 0;
-    if ($views < 0) {
-        $views = 0;
-    }
-
-    $entries[] = [
-        'title' => $title,
-        'slug' => $slug,
-        'views' => $views,
-    ];
-}
-
-usort($entries, static function ($a, $b) {
-    return ($b['views'] ?? 0) <=> ($a['views'] ?? 0);
-});
-
-$totalViews = 0;
-$totalPages = count($entries);
-foreach ($entries as $entry) {
-    $totalViews += $entry['views'];
-}
-
-$averageViews = $totalPages > 0 ? $totalViews / $totalPages : 0;
-
-foreach ($entries as $index => &$entry) {
-    $status = 'growing';
-    $label = 'Steady traffic';
-
-    if ($entry['views'] === 0) {
-        $status = 'no-views';
-        $label = 'Needs promotion';
-    } elseif ($index < 3 || $entry['views'] >= $averageViews) {
-        $status = 'top';
-        $label = 'Top performer';
-    }
-
-    $entry['status'] = $status;
-    $entry['label'] = $label;
-    $entry['rank'] = $index + 1;
-}
-unset($entry);
-
-$searchTerm = $search;
-
-$filtered = array_values(array_filter($entries, static function ($entry) use ($filter, $searchTerm) {
-    if ($filter !== 'all' && $entry['status'] !== $filter) {
-        return false;
-    }
-
-    if ($searchTerm === '') {
-        return true;
-    }
-
-    $encoding = 'UTF-8';
-    if (function_exists('mb_stripos')) {
-        return (mb_stripos($entry['title'], $searchTerm, 0, $encoding) !== false)
-            || (mb_stripos($entry['slug'], $searchTerm, 0, $encoding) !== false);
-    }
-
-    return (stripos($entry['title'], $searchTerm) !== false)
-        || (stripos($entry['slug'], $searchTerm) !== false);
-}));
+$filtered = $service->filterForExport($filter, $search);
 
 $filename = 'analytics-export-' . date('Ymd-His') . '.csv';
 

--- a/tests/analytics_service_test.php
+++ b/tests/analytics_service_test.php
@@ -1,0 +1,125 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/analytics/AnalyticsService.php';
+
+$fixture = [
+    [
+        'title' => 'Home',
+        'slug' => '',
+        'views' => 150,
+        'last_modified' => 1704067200,
+    ],
+    [
+        'title' => 'Documentation',
+        'slug' => 'docs',
+        'views' => 120,
+        'last_modified' => 1703980800,
+    ],
+    [
+        'title' => 'Welcome Blog',
+        'slug' => 'blog/welcome',
+        'views' => 90,
+        'last_modified' => 1703894400,
+    ],
+    [
+        'title' => 'Landing Page',
+        'slug' => 'landing-page',
+        'views' => 40,
+        'last_modified' => 1703808000,
+    ],
+    [
+        'title' => 'Release Notes',
+        'slug' => 'changelog',
+        'views' => 10,
+        'last_modified' => 1703721600,
+    ],
+    [
+        'title' => 'Archive',
+        'slug' => 'archive',
+        'views' => 0,
+        'last_modified' => 1703635200,
+    ],
+];
+
+$tempFile = tempnam(sys_get_temp_dir(), 'analytics');
+if ($tempFile === false) {
+    throw new RuntimeException('Unable to create temporary analytics dataset.');
+}
+
+file_put_contents($tempFile, json_encode($fixture));
+
+$service = new AnalyticsService($tempFile);
+$dashboard = $service->getDashboardData();
+
+if ($dashboard['totalViews'] !== 410) {
+    throw new RuntimeException('Total view count mismatch.');
+}
+
+if (count($dashboard['topPages']) !== 3) {
+    throw new RuntimeException('Top pages list should contain the top three entries.');
+}
+
+if ($dashboard['topPages'][0]['title'] !== 'Home') {
+    throw new RuntimeException('Top pages should be ordered by views.');
+}
+
+if ($dashboard['zeroViewCount'] !== 1) {
+    throw new RuntimeException('Zero view count should reflect entries without traffic.');
+}
+
+if ($dashboard['summaryComparisons']['totalViews']['current'] !== 410) {
+    throw new RuntimeException('Summary comparison for total views is incorrect.');
+}
+
+if ($dashboard['lastUpdatedTimestamp'] !== 1704067200) {
+    throw new RuntimeException('Last updated timestamp should match the latest modification time.');
+}
+
+$top = $service->filterForExport('top', '');
+if (count($top) !== 3) {
+    throw new RuntimeException('Top filter should include three entries.');
+}
+
+foreach ($top as $entry) {
+    if ($entry['status'] !== 'top') {
+        throw new RuntimeException('Top filter returned a non-top entry.');
+    }
+}
+
+$growing = $service->filterForExport('growing', '');
+if (count($growing) !== 2) {
+    throw new RuntimeException('Growing filter should include two entries.');
+}
+
+foreach ($growing as $entry) {
+    if ($entry['status'] !== 'growing') {
+        throw new RuntimeException('Growing filter returned an unexpected status.');
+    }
+}
+
+$noViews = $service->filterForExport('no-views', '');
+if (count($noViews) !== 1) {
+    throw new RuntimeException('No-views filter should include a single entry.');
+}
+
+if ($noViews[0]['slug'] !== 'archive') {
+    throw new RuntimeException('No-views filter should surface the archive page.');
+}
+
+$searchResults = $service->filterForExport('all', 'landing');
+if (count($searchResults) !== 1 || $searchResults[0]['slug'] !== 'landing-page') {
+    throw new RuntimeException('Search filtering did not match the expected entry.');
+}
+
+$caseInsensitive = $service->filterForExport('no-views', 'ARCH');
+if (count($caseInsensitive) !== 1 || $caseInsensitive[0]['slug'] !== 'archive') {
+    throw new RuntimeException('Search filtering should be case-insensitive.');
+}
+
+$defaulted = $service->filterForExport('unknown', 'home');
+if (count($defaulted) === 0) {
+    throw new RuntimeException('Unknown filters should default to returning results.');
+}
+
+unlink($tempFile);
+
+echo "AnalyticsService tests passed\n";


### PR DESCRIPTION
## Summary
- add an AnalyticsService that loads analytics data, prepares dashboard DTOs, and filters export datasets
- update the analytics dashboard view and export endpoints to use the centralized service logic
- add coverage for the AnalyticsService including filter combinations and summary calculations

## Testing
- php tests/analytics_service_test.php
- php tests/accessibility_report_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df40ef0d248331ae920b6160aa4ca2