### PR TITLE
Add blog repository abstraction for blog data

### DIFF
--- a/CMS/modules/blogs/BlogRepository.php
+++ b/CMS/modules/blogs/BlogRepository.php
@@ -1,0 +1,87 @@
+<?php
+// File: BlogRepository.php
+// Repository for handling blog post data and derived information such as categories.
+
+require_once __DIR__ . '/../../includes/data.php';
+
+class BlogRepository
+{
+    /**
+     * @var string
+     */
+    private $postsFile;
+
+    /**
+     * @var array|null
+     */
+    private $postsCache = null;
+
+    /**
+     * @var array|null
+     */
+    private $categoriesCache = null;
+
+    /**
+     * @param string|null $postsFile Optional path to the posts JSON file.
+     */
+    public function __construct($postsFile = null)
+    {
+        if ($postsFile === null) {
+            $postsFile = __DIR__ . '/../../data/blog_posts.json';
+        }
+        $this->postsFile = $postsFile;
+    }
+
+    /**
+     * Read blog posts as an array of associative arrays.
+     *
+     * @return array
+     */
+    public function readPosts()
+    {
+        if ($this->postsCache === null) {
+            $data = read_json_file($this->postsFile);
+            if (!is_array($data)) {
+                $data = [];
+            }
+
+            $normalized = [];
+            foreach ($data as $post) {
+                if (is_array($post)) {
+                    $normalized[] = $post;
+                }
+            }
+
+            $this->postsCache = $normalized;
+        }
+
+        return $this->postsCache;
+    }
+
+    /**
+     * List unique, non-empty categories derived from the posts data.
+     *
+     * @return array
+     */
+    public function listCategories()
+    {
+        if ($this->categoriesCache === null) {
+            $unique = [];
+            foreach ($this->readPosts() as $post) {
+                if (!is_array($post)) {
+                    continue;
+                }
+                $category = isset($post['category']) ? $post['category'] : null;
+                if (is_string($category)) {
+                    $category = trim($category);
+                    if ($category !== '') {
+                        $unique[$category] = true;
+                    }
+                }
+            }
+            $this->categoriesCache = array_values(array_keys($unique));
+        }
+
+        return $this->categoriesCache;
+    }
+}

--- a/CMS/modules/blogs/list_categories.php
+++ b/CMS/modules/blogs/list_categories.php
@@ -1,15 +1,10 @@
 <?php
 // File: list_categories.php
-require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/BlogRepository.php';
 
-$postsFile = __DIR__ . '/../../data/blog_posts.json';
-$posts = read_json_file($postsFile);
-$categories = [];
-foreach ($posts as $p) {
-    if (!empty($p['category']) && !in_array($p['category'], $categories)) {
-        $categories[] = $p['category'];
-    }
-}
+$repository = new BlogRepository();
+$categories = $repository->listCategories();
+
 header('Content-Type: application/json');
-echo json_encode(array_values($categories));
+echo json_encode($categories);
 ?>

--- a/CMS/modules/blogs/list_posts.php
+++ b/CMS/modules/blogs/list_posts.php
@@ -1,9 +1,10 @@
 <?php
 // File: list_posts.php
-require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/BlogRepository.php';
 
-$postsFile = __DIR__ . '/../../data/blog_posts.json';
-$posts = read_json_file($postsFile);
+$repository = new BlogRepository();
+$posts = $repository->readPosts();
+
 header('Content-Type: application/json');
 echo json_encode($posts);
 ?>

--- a/tests/blog_repository_demo.php
+++ b/tests/blog_repository_demo.php
@@ -1,0 +1,16 @@
+<?php
+// Demonstration script for BlogRepository unique categories output.
+require_once __DIR__ . '/../CMS/modules/blogs/BlogRepository.php';
+
+$repository = new BlogRepository(__DIR__ . '/../CMS/data/blog_posts.json');
+$categories = $repository->listCategories();
+
+$uniqueCheck = array_values(array_unique($categories));
+$isUnique = $categories === $uniqueCheck;
+
+echo "Categories (" . count($categories) . ")\n";
+foreach ($categories as $category) {
+    echo " - {$category}\n";
+}
+
+echo "\nCategories are unique: " . ($isUnique ? 'yes' : 'no') . "\n";


### PR DESCRIPTION
## Summary
- add a reusable `BlogRepository` to encapsulate post and category retrieval with memoization and normalization
- update blog list endpoints to consume the repository and consistently emit JSON
- add a demonstration script that prints the unique categories from the sample blog data

## Testing
- php tests/blog_repository_demo.php

------
https://chatgpt.com/codex/tasks/task_e_68df41ea81588331bcd026cbbb77537b