### PR TITLE
Refactor commerce dashboard with service context

### DIFF
--- a/CMS/modules/commerce/CommerceService.php
+++ b/CMS/modules/commerce/CommerceService.php
@@ -1,0 +1,793 @@
+<?php
+// File: CommerceService.php
+
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/settings.php';
+require_once __DIR__ . '/helpers.php';
+
+class CommerceService
+{
+    private string $dataFile;
+
+    public function __construct(?string $dataFile = null)
+    {
+        $this->dataFile = $dataFile ?? __DIR__ . '/../../data/commerce.json';
+    }
+
+    /**
+     * Build the context array used by the commerce dashboard template.
+     *
+     * @return array<string,mixed>
+     */
+    public function buildDashboardContext(): array
+    {
+        $rawData = $this->loadData();
+
+        $summary = $this->expectArray($rawData['summary'] ?? []);
+        $alerts = $this->expectArray($rawData['alerts'] ?? []);
+        $catalog = $this->expectArray($rawData['catalog'] ?? []);
+        $orders = $this->expectArray($rawData['orders'] ?? []);
+        $customers = $this->expectArray($rawData['customers'] ?? []);
+        $reports = $this->expectArray($rawData['reports'] ?? []);
+        $commerceSettings = $this->expectArray($rawData['settings'] ?? []);
+
+        $currency = $this->resolveCurrency($commerceSettings);
+        $currencySymbol = $this->getCurrencySymbol($currency);
+
+        $catalogContext = $this->prepareCatalog($catalog, $commerceSettings, $currencySymbol);
+        $categories = commerce_prepare_categories($rawData['categories'] ?? [], $catalogContext['productsForCategories']);
+        $categoryContext = $this->prepareCategories($categories);
+        $ordersContext = $this->prepareOrders($orders, $currencySymbol);
+        $customersContext = $this->prepareCustomers($customers, $currencySymbol);
+        $settingsContext = $this->prepareSettings($commerceSettings, $currency, $currencySymbol);
+        $channels = $this->prepareChannels($reports['top_channels'] ?? []);
+        $salesTrend = $this->prepareSalesTrend($reports['sales_trend'] ?? [], $currencySymbol);
+
+        $dataset = [
+            'summary' => $summary,
+            'alerts' => $alerts,
+            'catalog' => $catalogContext['rawCatalog'],
+            'categories' => $categories,
+            'orders' => $orders,
+            'customers' => $customers,
+            'reports' => $reports,
+            'settings' => $commerceSettings,
+            'currency' => $currency,
+        ];
+
+        $datasetJson = json_encode($dataset, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($datasetJson === false) {
+            $datasetJson = '[]';
+        }
+
+        return [
+            'currency' => $currency,
+            'currencySymbol' => $currencySymbol,
+            'heroMetrics' => $this->prepareHeroMetrics($summary, $currencySymbol),
+            'workspaces' => $this->prepareWorkspaces(),
+            'dashboard' => [
+                'channels' => $channels,
+                'alerts' => $this->prepareAlerts($alerts),
+                'salesTrend' => $salesTrend,
+            ],
+            'catalog' => [
+                'categories' => $categoryContext,
+                'stats' => $catalogContext['stats'],
+                'products' => $catalogContext['rows'],
+            ],
+            'orders' => $ordersContext,
+            'customers' => $customersContext,
+            'settings' => $settingsContext,
+            'datasetJson' => $datasetJson,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function loadData(): array
+    {
+        $data = read_json_file($this->dataFile);
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param mixed $value
+     * @return array<int|string,mixed>
+     */
+    private function expectArray($value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @param array<string,mixed> $commerceSettings
+     */
+    private function resolveCurrency(array $commerceSettings): string
+    {
+        $currency = isset($commerceSettings['currency']) && is_string($commerceSettings['currency'])
+            ? strtoupper($commerceSettings['currency'])
+            : 'USD';
+
+        return $currency !== '' ? $currency : 'USD';
+    }
+
+    private function getCurrencySymbol(string $currency): string
+    {
+        $symbols = [
+            'USD' => '$',
+            'EUR' => '€',
+            'GBP' => '£',
+            'AUD' => 'A$',
+            'CAD' => 'C$',
+        ];
+
+        return $symbols[$currency] ?? '';
+    }
+
+    /**
+     * @param array<string,mixed> $summary
+     * @return array<int,array<string,string>>
+     */
+    private function prepareHeroMetrics(array $summary, string $currencySymbol): array
+    {
+        return [
+            [
+                'label' => 'Total revenue',
+                'value' => $this->formatCurrency($summary['total_revenue'] ?? 0, $currencySymbol),
+                'meta' => '30-day view',
+            ],
+            [
+                'label' => 'Orders',
+                'value' => $this->formatNumber($summary['orders'] ?? 0),
+                'meta' => 'Open in fulfilment',
+            ],
+            [
+                'label' => 'Average order value',
+                'value' => $this->formatCurrency($summary['average_order_value'] ?? 0, $currencySymbol),
+                'meta' => 'Blended across channels',
+            ],
+            [
+                'label' => 'Conversion rate',
+                'value' => $this->formatPercent($summary['conversion_rate'] ?? 0),
+                'meta' => 'Storefront sessions',
+            ],
+            [
+                'label' => 'Repeat purchase',
+                'value' => $this->formatPercent($summary['repeat_purchase_rate'] ?? 0),
+                'meta' => 'Returning customers',
+            ],
+            [
+                'label' => 'Refund rate',
+                'value' => $this->formatPercent($summary['refund_rate'] ?? 0),
+                'meta' => '30-day average',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<int,array<string,string>>
+     */
+    private function prepareWorkspaces(): array
+    {
+        $workspaces = [
+            'dashboard' => 'Commerce Dashboard',
+            'catalog' => 'Product Catalog',
+            'orders' => 'Orders',
+            'customers' => 'Customers',
+            'settings' => 'Commerce Settings',
+        ];
+
+        $prepared = [];
+        $isFirst = true;
+        foreach ($workspaces as $key => $label) {
+            $prepared[] = [
+                'key' => $key,
+                'label' => $label,
+                'isActive' => $isFirst,
+            ];
+            $isFirst = false;
+        }
+
+        return $prepared;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $alerts
+     * @return array<int,array<string,string>>
+     */
+    private function prepareAlerts(array $alerts): array
+    {
+        $prepared = [];
+        foreach ($alerts as $alert) {
+            if (!is_array($alert)) {
+                continue;
+            }
+
+            $type = isset($alert['type']) ? (string) $alert['type'] : 'general';
+            $severity = strtolower((string) ($alert['severity'] ?? 'info'));
+            $message = isset($alert['message']) ? (string) $alert['message'] : '';
+
+            $prepared[] = [
+                'type' => $type,
+                'severity' => $severity,
+                'severityLabel' => ucfirst($severity),
+                'message' => $message,
+                'class' => 'commerce-alert-' . $severity,
+            ];
+        }
+
+        return $prepared;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $channels
+     * @return array<int,array<string,string|int>>
+     */
+    private function prepareChannels(array $channels): array
+    {
+        $prepared = [];
+        $total = 0.0;
+
+        foreach ($channels as $channel) {
+            if (!is_array($channel)) {
+                continue;
+            }
+
+            $percentage = isset($channel['percentage']) && is_numeric($channel['percentage'])
+                ? (float) $channel['percentage']
+                : 0.0;
+            $total += $percentage;
+        }
+
+        if ($total <= 0) {
+            $total = 100.0;
+        }
+
+        foreach ($channels as $channel) {
+            if (!is_array($channel)) {
+                continue;
+            }
+
+            $label = isset($channel['channel']) ? (string) $channel['channel'] : 'Unknown';
+            $percentage = isset($channel['percentage']) && is_numeric($channel['percentage'])
+                ? (float) $channel['percentage']
+                : 0.0;
+            $width = (int) round(min(100, max(0, ($percentage / $total) * 100)));
+
+            $prepared[] = [
+                'label' => $label,
+                'slug' => commerce_slugify($label),
+                'percentageLabel' => $this->formatPercent($percentage),
+                'barWidth' => $width,
+            ];
+        }
+
+        return $prepared;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $trend
+     * @return array<int,array<string,string|int>>
+     */
+    private function prepareSalesTrend(array $trend, string $currencySymbol): array
+    {
+        $prepared = [];
+        $maxRevenue = 0.0;
+        foreach ($trend as $point) {
+            if (!is_array($point)) {
+                continue;
+            }
+
+            if (isset($point['revenue']) && is_numeric($point['revenue'])) {
+                $maxRevenue = max($maxRevenue, (float) $point['revenue']);
+            }
+        }
+
+        if ($maxRevenue <= 0) {
+            $maxRevenue = 1.0;
+        }
+
+        foreach ($trend as $point) {
+            if (!is_array($point)) {
+                continue;
+            }
+
+            $label = isset($point['label']) ? (string) $point['label'] : '';
+            $revenue = isset($point['revenue']) && is_numeric($point['revenue'])
+                ? (float) $point['revenue']
+                : 0.0;
+            $height = (int) round(min(100, max(0, ($revenue / $maxRevenue) * 100)));
+
+            $prepared[] = [
+                'label' => $label,
+                'valueLabel' => $this->formatCurrency($revenue, $currencySymbol),
+                'height' => $height,
+                'ariaLabel' => trim($label . ' revenue ' . $this->formatCurrency($revenue, $currencySymbol)),
+            ];
+        }
+
+        return $prepared;
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $catalog
+     * @param array<string,mixed> $commerceSettings
+     * @return array{
+     *     rows: array<int,array<string,mixed>>,
+     *     stats: array<string,mixed>,
+     *     productsForCategories: array<int,array<string,mixed>>,
+     *     rawCatalog: array<int,array<string,mixed>>
+     * }
+     */
+    private function prepareCatalog(array $catalog, array $commerceSettings, string $currencySymbol): array
+    {
+        $rows = [];
+        $rawCatalog = [];
+        $productsForCategories = [];
+        $totalProducts = 0;
+        $activeProducts = 0;
+        $lowInventoryCount = 0;
+        $threshold = isset($commerceSettings['low_inventory_threshold']) && is_numeric($commerceSettings['low_inventory_threshold'])
+            ? (int) $commerceSettings['low_inventory_threshold']
+            : 0;
+
+        foreach ($catalog as $product) {
+            if (!is_array($product)) {
+                continue;
+            }
+
+            $sku = (string) ($product['sku'] ?? '');
+            $name = (string) ($product['name'] ?? 'Untitled product');
+            $category = (string) ($product['category'] ?? 'Uncategorised');
+            $price = $this->formatCurrency($product['price'] ?? 0, $currencySymbol);
+            $inventoryRaw = isset($product['inventory']) && is_numeric($product['inventory'])
+                ? (int) $product['inventory']
+                : 0;
+            $inventory = $inventoryRaw;
+            $status = (string) ($product['status'] ?? 'Unknown');
+            $visibility = (string) ($product['visibility'] ?? 'Unknown');
+            $updated = (string) ($product['updated'] ?? '');
+            $featuredImage = (string) ($product['featured_image'] ?? '');
+
+            $galleryList = [];
+            if (isset($product['images'])) {
+                if (is_array($product['images'])) {
+                    foreach ($product['images'] as $imageUrl) {
+                        if (is_string($imageUrl)) {
+                            $imageUrl = trim($imageUrl);
+                            if ($imageUrl !== '') {
+                                $galleryList[] = $imageUrl;
+                            }
+                        }
+                    }
+                } elseif (is_string($product['images'])) {
+                    $lines = preg_split('/\r\n|\r|\n/', $product['images']);
+                    if ($lines !== false) {
+                        foreach ($lines as $imageUrl) {
+                            $imageUrl = trim((string) $imageUrl);
+                            if ($imageUrl !== '') {
+                                $galleryList[] = $imageUrl;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if ($featuredImage === '' && !empty($galleryList)) {
+                $featuredImage = $galleryList[0];
+            }
+
+            $galleryCount = count($galleryList);
+            if ($galleryCount === 1) {
+                $galleryLabel = '1 gallery image';
+            } elseif ($galleryCount > 1) {
+                $galleryLabel = $galleryCount . ' gallery images';
+            } else {
+                $galleryLabel = 'No gallery images';
+            }
+
+            $statusClass = $this->badgeClass($status);
+
+            $rows[] = [
+                'sku' => $sku,
+                'name' => $name,
+                'category' => $category,
+                'categorySlug' => commerce_slugify($category),
+                'price' => $price,
+                'inventory' => $inventory,
+                'status' => $status,
+                'statusClass' => $statusClass,
+                'statusKey' => strtolower($status),
+                'visibility' => $visibility,
+                'visibilityKey' => strtolower($visibility),
+                'updated' => $updated,
+                'featuredImage' => $featuredImage,
+                'hasFeaturedImage' => $featuredImage !== '',
+                'galleryLabel' => $galleryLabel,
+            ];
+
+            $rawCatalog[] = $product;
+            $productsForCategories[] = ['category' => $category];
+            $totalProducts++;
+
+            if (strtolower($status) === 'active') {
+                $activeProducts++;
+            }
+
+            if ($threshold > 0 && $inventoryRaw <= $threshold) {
+                $lowInventoryCount++;
+            }
+        }
+
+        $stats = [
+            'totalProducts' => $this->formatNumber($totalProducts),
+            'activeProducts' => $this->formatNumber($activeProducts),
+            'lowInventoryThreshold' => $threshold,
+            'showLowInventory' => $threshold > 0,
+            'lowInventoryCount' => $this->formatNumber($lowInventoryCount),
+        ];
+
+        return [
+            'rows' => $rows,
+            'stats' => $stats,
+            'productsForCategories' => $productsForCategories,
+            'rawCatalog' => $rawCatalog,
+        ];
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $categories
+     * @return array<string,mixed>
+     */
+    private function prepareCategories(array $categories): array
+    {
+        $count = count($categories);
+        $label = $count === 1 ? 'category' : 'categories';
+
+        $options = [];
+        foreach ($categories as $category) {
+            if (!is_array($category)) {
+                continue;
+            }
+
+            $options[] = [
+                'id' => (string) ($category['id'] ?? ''),
+                'name' => (string) ($category['name'] ?? ''),
+                'slug' => (string) ($category['slug'] ?? ''),
+            ];
+        }
+
+        return [
+            'countLabel' => $label,
+            'countFormatted' => $this->formatNumber($count),
+            'list' => $options,
+            'hasCategories' => $count > 0,
+        ];
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $orders
+     * @return array<string,mixed>
+     */
+    private function prepareOrders(array $orders, string $currencySymbol): array
+    {
+        $rows = [];
+        foreach ($orders as $order) {
+            if (!is_array($order)) {
+                continue;
+            }
+
+            $id = (string) ($order['id'] ?? '');
+            $customer = (string) ($order['customer'] ?? '');
+            $channel = (string) ($order['channel'] ?? '');
+            $status = (string) ($order['status'] ?? '');
+            $total = $this->formatCurrency($order['total'] ?? 0, $currencySymbol);
+            $placed = (string) ($order['placed'] ?? '');
+            $fulfillment = (string) ($order['fulfillment'] ?? '');
+
+            $rows[] = [
+                'id' => $id,
+                'customer' => $customer,
+                'channel' => $channel,
+                'status' => $status,
+                'statusClass' => $this->badgeClass($status),
+                'total' => $total,
+                'placed' => $placed,
+                'fulfillment' => $fulfillment,
+                'filters' => [
+                    'status' => strtolower($status),
+                    'channel' => strtolower($channel),
+                    'customer' => strtolower($customer),
+                    'order' => strtolower($id),
+                ],
+            ];
+        }
+
+        return ['rows' => $rows];
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $customers
+     * @return array<string,mixed>
+     */
+    private function prepareCustomers(array $customers, string $currencySymbol): array
+    {
+        $rows = [];
+        $segments = [];
+        foreach ($customers as $customer) {
+            if (!is_array($customer)) {
+                continue;
+            }
+
+            $name = (string) ($customer['name'] ?? '');
+            $email = (string) ($customer['email'] ?? '');
+            $segment = (string) ($customer['segment'] ?? '');
+            $orders = isset($customer['orders']) && is_numeric($customer['orders'])
+                ? (int) $customer['orders']
+                : 0;
+            $ltv = $this->formatCurrency($customer['lifetime_value'] ?? 0, $currencySymbol);
+            $lastOrder = (string) ($customer['last_order'] ?? '');
+            $status = (string) ($customer['status'] ?? '');
+
+            if ($segment !== '') {
+                $segments[] = $segment;
+            }
+
+            $rows[] = [
+                'name' => $name,
+                'email' => $email,
+                'segment' => $segment,
+                'orders' => $orders,
+                'lifetimeValue' => $ltv,
+                'lastOrder' => $lastOrder,
+                'status' => $status,
+                'statusClass' => $this->badgeClass($status),
+                'filters' => [
+                    'segment' => strtolower($segment),
+                    'status' => strtolower($status),
+                    'name' => strtolower($name),
+                    'email' => strtolower($email),
+                ],
+            ];
+        }
+
+        $segments = array_values(array_unique($segments));
+        sort($segments, SORT_NATURAL | SORT_FLAG_CASE);
+
+        $segmentOptions = [];
+        foreach ($segments as $segment) {
+            $segmentOptions[] = [
+                'value' => strtolower($segment),
+                'label' => $segment,
+            ];
+        }
+
+        return [
+            'rows' => $rows,
+            'segments' => $segmentOptions,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $commerceSettings
+     * @return array<string,mixed>
+     */
+    private function prepareSettings(array $commerceSettings, string $currency, string $currencySymbol): array
+    {
+        $storefront = [
+            [
+                'label' => 'Status',
+                'value' => (string) ($commerceSettings['storefront_status'] ?? 'Offline'),
+                'isBadge' => true,
+                'badgeClass' => 'status-badge status-good',
+            ],
+            [
+                'label' => 'Currency',
+                'value' => $currency,
+            ],
+            [
+                'label' => 'Theme',
+                'value' => (string) ($commerceSettings['storefront_theme'] ?? 'Default'),
+            ],
+            [
+                'label' => 'Primary language',
+                'value' => (string) ($commerceSettings['default_language'] ?? 'Not set'),
+            ],
+            [
+                'label' => 'Low inventory threshold',
+                'value' => (string) ($commerceSettings['low_inventory_threshold'] ?? 0) . ' units',
+            ],
+            [
+                'label' => 'Default tax rate',
+                'value' => $this->formatPercent($commerceSettings['default_tax_rate'] ?? 0),
+            ],
+        ];
+
+        $toggleMap = [
+            'express_checkout' => 'Express checkout',
+            'allow_guest_checkout' => 'Allow guest checkout',
+            'fraud_protection' => 'Fraud protection',
+            'auto_apply_discounts' => 'Auto-apply discounts',
+            'address_verification' => 'Address verification',
+        ];
+
+        $toggles = [];
+        foreach ($toggleMap as $key => $label) {
+            $toggles[] = [
+                'key' => $key,
+                'label' => $label,
+                'checked' => !empty($commerceSettings[$key]),
+            ];
+        }
+
+        $paymentMethods = [];
+        $rawPaymentMethods = $this->expectArray($commerceSettings['payment_methods'] ?? []);
+        foreach ($rawPaymentMethods as $method) {
+            if (!is_array($method)) {
+                continue;
+            }
+
+            $label = (string) ($method['label'] ?? '');
+            $enabled = !empty($method['enabled']);
+            $paymentMethods[] = [
+                'label' => $label,
+                'status' => $enabled ? 'Enabled' : 'Disabled',
+                'statusClass' => $enabled ? 'status-badge status-good' : 'status-badge status-warning',
+            ];
+        }
+
+        $fulfillmentWindows = [];
+        $rawWindows = $this->expectArray($commerceSettings['fulfillment_windows'] ?? []);
+        foreach ($rawWindows as $window) {
+            if (!is_array($window)) {
+                continue;
+            }
+
+            $fulfillmentWindows[] = [
+                'name' => (string) ($window['name'] ?? ''),
+                'sla' => (string) ($window['sla'] ?? ''),
+            ];
+        }
+
+        $shippingPartners = [];
+        $rawPartners = $this->expectArray($commerceSettings['shipping_partners'] ?? []);
+        if (empty($rawPartners)) {
+            $shippingPartners[] = [
+                'name' => 'Partners',
+                'status' => 'No shipping partners configured',
+                'statusClass' => '',
+                'isPlaceholder' => true,
+            ];
+        }
+
+        foreach ($rawPartners as $partner) {
+            if (!is_array($partner)) {
+                continue;
+            }
+
+            $name = (string) ($partner['name'] ?? '');
+            $status = (string) ($partner['status'] ?? 'Unavailable');
+            $statusClass = $this->resolvePartnerBadgeClass($status);
+
+            $shippingPartners[] = [
+                'name' => $name,
+                'status' => $status !== '' ? $status : 'Unavailable',
+                'statusClass' => $statusClass,
+                'isPlaceholder' => false,
+            ];
+        }
+
+        $returnPolicy = $this->expectArray($commerceSettings['return_policy'] ?? []);
+        $windowDays = isset($returnPolicy['window_days']) && is_numeric($returnPolicy['window_days'])
+            ? (int) $returnPolicy['window_days']
+            : null;
+        $restockingFee = (string) ($returnPolicy['restocking_fee'] ?? '');
+        $returnShipping = (string) ($returnPolicy['return_shipping'] ?? '');
+
+        $returnPolicyList = [
+            [
+                'label' => 'Return window',
+                'value' => $windowDays !== null ? $windowDays . ' days' : 'Not specified',
+            ],
+            [
+                'label' => 'Restocking fee',
+                'value' => $restockingFee !== '' ? $restockingFee : 'None',
+            ],
+            [
+                'label' => 'Return shipping',
+                'value' => $returnShipping !== '' ? $returnShipping : 'Not specified',
+            ],
+        ];
+
+        return [
+            'storefront' => $storefront,
+            'toggles' => $toggles,
+            'paymentMethods' => $paymentMethods,
+            'fulfillmentWindows' => $fulfillmentWindows,
+            'shippingPartners' => $shippingPartners,
+            'returnPolicy' => $returnPolicyList,
+        ];
+    }
+
+    private function resolvePartnerBadgeClass(string $status): string
+    {
+        $normalized = strtolower($status);
+        if ($normalized === 'primary' || $normalized === 'active') {
+            return 'status-badge status-good';
+        }
+        if ($normalized === 'backup' || $normalized === 'limited') {
+            return 'status-badge status-warning';
+        }
+        if ($normalized === 'paused' || $normalized === 'suspended') {
+            return 'status-badge status-critical';
+        }
+        if ($normalized === 'international') {
+            return 'status-badge status-info';
+        }
+
+        return 'status-badge';
+    }
+
+    private function formatCurrency($value, string $symbol): string
+    {
+        if (!is_numeric($value)) {
+            return $symbol . '0.00';
+        }
+
+        $amount = number_format((float) $value, 2, '.', ',');
+        return $symbol !== '' ? $symbol . $amount : $amount;
+    }
+
+    private function formatPercent($value): string
+    {
+        if (!is_numeric($value)) {
+            return '0%';
+        }
+
+        $formatted = number_format((float) $value, 1, '.', '');
+        $formatted = rtrim(rtrim($formatted, '0'), '.');
+        if ($formatted === '') {
+            $formatted = '0';
+        }
+
+        return $formatted . '%';
+    }
+
+    private function formatNumber($value): string
+    {
+        if (!is_numeric($value)) {
+            return '0';
+        }
+
+        return number_format((float) $value, 0, '.', ',');
+    }
+
+    private function badgeClass(string $status): string
+    {
+        $normalized = strtolower($status);
+        switch ($normalized) {
+            case 'active':
+            case 'fulfilled':
+            case 'vip':
+                return 'status-badge status-good';
+            case 'processing':
+            case 'ready for pickup':
+            case 'support':
+            case 'new':
+            case 'loyal':
+                return 'status-badge status-warning';
+            case 'refund requested':
+            case 'pending payment':
+            case 'dormant':
+            case 'attention':
+            case 'backorder':
+            case 'restock':
+                return 'status-badge status-critical';
+            case 'preorder':
+                return 'status-badge status-info';
+            default:
+                return 'status-badge';
+        }
+    }
+}

--- a/CMS/modules/commerce/view.php
+++ b/CMS/modules/commerce/view.php
@@ -1,124 +1,11 @@
 <?php
 // File: view.php
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
-require_once __DIR__ . '/../../includes/settings.php';
-require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/CommerceService.php';
 require_login();
 
-$commerceFile = __DIR__ . '/../../data/commerce.json';
-$commerceData = read_json_file($commerceFile);
-$settings = get_site_settings();
-
-$summary = isset($commerceData['summary']) && is_array($commerceData['summary']) ? $commerceData['summary'] : [];
-$alerts = isset($commerceData['alerts']) && is_array($commerceData['alerts']) ? $commerceData['alerts'] : [];
-$catalog = isset($commerceData['catalog']) && is_array($commerceData['catalog']) ? $commerceData['catalog'] : [];
-$categories = commerce_prepare_categories($commerceData['categories'] ?? [], $catalog);
-$orders = isset($commerceData['orders']) && is_array($commerceData['orders']) ? $commerceData['orders'] : [];
-$customers = isset($commerceData['customers']) && is_array($commerceData['customers']) ? $commerceData['customers'] : [];
-$reports = isset($commerceData['reports']) && is_array($commerceData['reports']) ? $commerceData['reports'] : [];
-$commerceSettings = isset($commerceData['settings']) && is_array($commerceData['settings']) ? $commerceData['settings'] : [];
-
-$currency = isset($commerceSettings['currency']) && is_string($commerceSettings['currency']) ? strtoupper($commerceSettings['currency']) : 'USD';
-$currencySymbols = [
-    'USD' => '$',
-    'EUR' => '€',
-    'GBP' => '£',
-    'AUD' => 'A$',
-    'CAD' => 'C$',
-];
-$currencySymbol = isset($currencySymbols[$currency]) ? $currencySymbols[$currency] : '';
-
-function commerce_format_currency($value, $symbol) {
-    if (!is_numeric($value)) {
-        return $symbol . '0.00';
-    }
-    $amount = number_format((float) $value, 2);
-    return $symbol !== '' ? $symbol . $amount : $amount;
-}
-
-function commerce_format_percent($value) {
-    if (!is_numeric($value)) {
-        return '0%';
-    }
-    return rtrim(rtrim(number_format((float) $value, 1), '0'), '.') . '%';
-}
-
-function commerce_format_number($value) {
-    if (!is_numeric($value)) {
-        return '0';
-    }
-    return number_format((float) $value);
-}
-
-function commerce_badge_class($status) {
-    $normalized = strtolower((string) $status);
-    switch ($normalized) {
-        case 'active':
-        case 'fulfilled':
-        case 'vip':
-            return 'status-badge status-good';
-        case 'processing':
-        case 'ready for pickup':
-        case 'support':
-        case 'new':
-        case 'loyal':
-            return 'status-badge status-warning';
-        case 'refund requested':
-        case 'pending payment':
-        case 'dormant':
-        case 'attention':
-        case 'backorder':
-        case 'restock':
-            return 'status-badge status-critical';
-        case 'preorder':
-            return 'status-badge status-info';
-        default:
-            return 'status-badge';
-    }
-}
-
-$totalProducts = count($catalog);
-$activeProductCount = 0;
-$lowInventoryThreshold = isset($commerceSettings['low_inventory_threshold']) && is_numeric($commerceSettings['low_inventory_threshold'])
-    ? (int) $commerceSettings['low_inventory_threshold']
-    : 0;
-$lowInventoryCount = 0;
-foreach ($catalog as $productItem) {
-    $status = isset($productItem['status']) ? strtolower((string) $productItem['status']) : '';
-    if ($status === 'active') {
-        $activeProductCount++;
-    }
-    if ($lowInventoryThreshold > 0) {
-        $inventoryValue = isset($productItem['inventory']) && is_numeric($productItem['inventory'])
-            ? (int) $productItem['inventory']
-            : null;
-        if ($inventoryValue !== null && $inventoryValue <= $lowInventoryThreshold) {
-            $lowInventoryCount++;
-        }
-    }
-}
-$totalCategories = count($categories);
-
-$workspaces = [
-    'dashboard' => 'Commerce Dashboard',
-    'catalog' => 'Product Catalog',
-    'orders' => 'Orders',
-    'customers' => 'Customers',
-    'settings' => 'Commerce Settings',
-];
-
-$encodedDataset = json_encode([
-    'summary' => $summary,
-    'alerts' => $alerts,
-    'catalog' => $catalog,
-    'categories' => $categories,
-    'orders' => $orders,
-    'customers' => $customers,
-    'reports' => $reports,
-    'settings' => $commerceSettings,
-    'currency' => $currency,
-], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+$service = new CommerceService();
+$context = $service->buildDashboardContext();
 ?>
 <div class="content-section" id="commerce">
     <div class="commerce-shell a11y-dashboard">
@@ -146,38 +33,28 @@ $encodedDataset = json_encode([
                 </div>
             </div>
             <div class="commerce-metric-grid" role="list">
-<?php
-$metricMap = [
-    ['label' => 'Total revenue', 'value' => isset($summary['total_revenue']) ? commerce_format_currency($summary['total_revenue'], $currencySymbol) : commerce_format_currency(0, $currencySymbol), 'meta' => '30-day view'],
-    ['label' => 'Orders', 'value' => commerce_format_number($summary['orders'] ?? 0), 'meta' => 'Open in fulfilment'],
-    ['label' => 'Average order value', 'value' => isset($summary['average_order_value']) ? commerce_format_currency($summary['average_order_value'], $currencySymbol) : commerce_format_currency(0, $currencySymbol), 'meta' => 'Blended across channels'],
-    ['label' => 'Conversion rate', 'value' => commerce_format_percent($summary['conversion_rate'] ?? 0), 'meta' => 'Storefront sessions'],
-    ['label' => 'Repeat purchase', 'value' => commerce_format_percent($summary['repeat_purchase_rate'] ?? 0), 'meta' => 'Returning customers'],
-    ['label' => 'Refund rate', 'value' => commerce_format_percent($summary['refund_rate'] ?? 0), 'meta' => '30-day average'],
-];
-foreach ($metricMap as $metric):
-?>
+                <?php foreach ($context['heroMetrics'] as $metric): ?>
                 <article class="commerce-metric-card" role="listitem">
                     <div class="commerce-metric-label"><?php echo htmlspecialchars($metric['label']); ?></div>
                     <div class="commerce-metric-value" data-metric-value="<?php echo htmlspecialchars($metric['label']); ?>"><?php echo htmlspecialchars($metric['value']); ?></div>
                     <div class="commerce-metric-meta"><?php echo htmlspecialchars($metric['meta']); ?></div>
                 </article>
-<?php endforeach; ?>
+                <?php endforeach; ?>
             </div>
         </header>
 
         <nav class="commerce-workspace-nav" aria-label="Commerce workspaces" role="tablist">
-<?php $isFirst = true; foreach ($workspaces as $workspaceKey => $workspaceLabel): ?>
+            <?php foreach ($context['workspaces'] as $workspace): ?>
             <button type="button"
-                class="commerce-workspace-tab<?php echo $isFirst ? ' active' : ''; ?>"
+                class="commerce-workspace-tab<?php echo $workspace['isActive'] ? ' active' : ''; ?>"
                 role="tab"
-                id="commerce-tab-<?php echo htmlspecialchars($workspaceKey); ?>"
-                aria-selected="<?php echo $isFirst ? 'true' : 'false'; ?>"
-                aria-controls="commerce-panel-<?php echo htmlspecialchars($workspaceKey); ?>"
-                data-commerce-workspace="<?php echo htmlspecialchars($workspaceKey); ?>">
-                <?php echo htmlspecialchars($workspaceLabel); ?>
+                id="commerce-tab-<?php echo htmlspecialchars($workspace['key']); ?>"
+                aria-selected="<?php echo $workspace['isActive'] ? 'true' : 'false'; ?>"
+                aria-controls="commerce-panel-<?php echo htmlspecialchars($workspace['key']); ?>"
+                data-commerce-workspace="<?php echo htmlspecialchars($workspace['key']); ?>">
+                <?php echo htmlspecialchars($workspace['label']); ?>
             </button>
-<?php $isFirst = false; endforeach; ?>
+            <?php endforeach; ?>
         </nav>
 
         <div class="commerce-workspaces">
@@ -192,26 +69,17 @@ foreach ($metricMap as $metric):
                             <span class="commerce-card-meta">Auto-refresh every 15 minutes</span>
                         </header>
                         <div class="commerce-channel-list">
-<?php
-$channels = isset($reports['top_channels']) && is_array($reports['top_channels']) ? $reports['top_channels'] : [];
-$totalChannels = array_sum(array_map(function ($channel) {
-    return isset($channel['percentage']) && is_numeric($channel['percentage']) ? (float) $channel['percentage'] : 0;
-}, $channels));
-foreach ($channels as $channel):
-    $label = isset($channel['channel']) ? (string) $channel['channel'] : 'Unknown';
-    $percentage = isset($channel['percentage']) ? (float) $channel['percentage'] : 0.0;
-    $width = $totalChannels > 0 ? min(100, max(0, round(($percentage / $totalChannels) * 100))) : 0;
-?>
-                            <div class="commerce-channel-item" data-channel="<?php echo htmlspecialchars(strtolower($label)); ?>">
+                            <?php foreach ($context['dashboard']['channels'] as $channel): ?>
+                            <div class="commerce-channel-item" data-channel="<?php echo htmlspecialchars($channel['slug']); ?>">
                                 <div class="commerce-channel-label">
-                                    <span><?php echo htmlspecialchars($label); ?></span>
-                                    <strong><?php echo commerce_format_percent($percentage); ?></strong>
+                                    <span><?php echo htmlspecialchars($channel['label']); ?></span>
+                                    <strong><?php echo htmlspecialchars($channel['percentageLabel']); ?></strong>
                                 </div>
                                 <div class="commerce-channel-meter" role="presentation">
-                                    <span class="commerce-channel-bar" style="width: <?php echo $width; ?>%"></span>
+                                    <span class="commerce-channel-bar" style="width: <?php echo (int) $channel['barWidth']; ?>%"></span>
                                 </div>
                             </div>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </div>
                     </article>
                     <article class="commerce-card">
@@ -225,23 +93,19 @@ foreach ($channels as $channel):
                             </button>
                         </header>
                         <ul class="commerce-alert-list" id="commerceAlerts">
-<?php if (!$alerts): ?>
+                            <?php if (empty($context['dashboard']['alerts'])): ?>
                             <li class="commerce-alert-item is-empty">All systems are operating normally.</li>
-<?php else: ?>
-<?php foreach ($alerts as $alert):
-    $type = isset($alert['type']) ? (string) $alert['type'] : 'general';
-    $severity = isset($alert['severity']) ? strtolower((string) $alert['severity']) : 'info';
-    $message = isset($alert['message']) ? (string) $alert['message'] : '';
-?>
-                            <li class="commerce-alert-item commerce-alert-<?php echo htmlspecialchars($severity); ?>" data-alert-type="<?php echo htmlspecialchars($type); ?>">
-                                <span class="commerce-alert-indicator" aria-hidden="true"></span>
-                                <div>
-                                    <p class="commerce-alert-message"><?php echo htmlspecialchars($message); ?></p>
-                                    <span class="commerce-alert-meta">Severity: <?php echo ucfirst($severity); ?></span>
-                                </div>
-                            </li>
-<?php endforeach; ?>
-<?php endif; ?>
+                            <?php else: ?>
+                                <?php foreach ($context['dashboard']['alerts'] as $alert): ?>
+                                <li class="commerce-alert-item <?php echo htmlspecialchars($alert['class']); ?>" data-alert-type="<?php echo htmlspecialchars($alert['type']); ?>">
+                                    <span class="commerce-alert-indicator" aria-hidden="true"></span>
+                                    <div>
+                                        <p class="commerce-alert-message"><?php echo htmlspecialchars($alert['message']); ?></p>
+                                        <span class="commerce-alert-meta">Severity: <?php echo htmlspecialchars($alert['severityLabel']); ?></span>
+                                    </div>
+                                </li>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
                         </ul>
                     </article>
                     <article class="commerce-card">
@@ -252,25 +116,13 @@ foreach ($channels as $channel):
                             </div>
                         </header>
                         <div class="commerce-trend-chart" role="img" aria-label="Revenue trend over the last five months">
-<?php
-$trend = isset($reports['sales_trend']) && is_array($reports['sales_trend']) ? $reports['sales_trend'] : [];
-$maxRevenue = 0;
-foreach ($trend as $point) {
-    if (isset($point['revenue']) && is_numeric($point['revenue'])) {
-        $maxRevenue = max($maxRevenue, (float) $point['revenue']);
-    }
-}
-foreach ($trend as $point):
-    $label = isset($point['label']) ? (string) $point['label'] : '';
-    $revenue = isset($point['revenue']) ? (float) $point['revenue'] : 0.0;
-    $height = $maxRevenue > 0 ? round(($revenue / $maxRevenue) * 100) : 0;
-?>
-                            <div class="commerce-trend-bar" aria-label="<?php echo htmlspecialchars($label); ?> revenue <?php echo commerce_format_currency($revenue, $currencySymbol); ?>">
-                                <span class="commerce-trend-value"><?php echo commerce_format_currency($revenue, $currencySymbol); ?></span>
-                                <span class="commerce-trend-indicator" style="height: <?php echo $height; ?>%"></span>
-                                <span class="commerce-trend-label"><?php echo htmlspecialchars($label); ?></span>
+                            <?php foreach ($context['dashboard']['salesTrend'] as $point): ?>
+                            <div class="commerce-trend-bar" aria-label="<?php echo htmlspecialchars($point['ariaLabel']); ?>">
+                                <span class="commerce-trend-value"><?php echo htmlspecialchars($point['valueLabel']); ?></span>
+                                <span class="commerce-trend-indicator" style="height: <?php echo (int) $point['height']; ?>%"></span>
+                                <span class="commerce-trend-label"><?php echo htmlspecialchars($point['label']); ?></span>
                             </div>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </div>
                     </article>
                 </div>
@@ -282,90 +134,90 @@ foreach ($trend as $point):
                         <h3 class="commerce-panel-title">Catalogue inventory</h3>
                         <p class="commerce-panel-description">Search, filter, and review product velocity.</p>
                     </div>
-                <div class="commerce-panel-actions">
-                    <label class="commerce-search" for="commerceCatalogSearch">
-                        <i class="fa-solid fa-search" aria-hidden="true"></i>
-                        <input type="search" id="commerceCatalogSearch" placeholder="Search products" aria-controls="commerceCatalogTable">
-                    </label>
-                    <select id="commerceCatalogCategory" class="commerce-select" aria-label="Filter products by category">
-                        <option value="all">All categories</option>
-<?php foreach ($categories as $category): ?>
-                        <option value="<?php echo htmlspecialchars($category['slug']); ?>"><?php echo htmlspecialchars($category['name']); ?></option>
-<?php endforeach; ?>
-                    </select>
-                    <select id="commerceCatalogStatus" class="commerce-select" aria-label="Filter products by status">
-                        <option value="all">All statuses</option>
-                        <option value="active">Active</option>
-                        <option value="preorder">Preorder</option>
-                        <option value="backorder">Backorder</option>
-                        <option value="restock">Restock</option>
-                    </select>
+                    <div class="commerce-panel-actions">
+                        <label class="commerce-search" for="commerceCatalogSearch">
+                            <i class="fa-solid fa-search" aria-hidden="true"></i>
+                            <input type="search" id="commerceCatalogSearch" placeholder="Search products" aria-controls="commerceCatalogTable">
+                        </label>
+                        <select id="commerceCatalogCategory" class="commerce-select" aria-label="Filter products by category">
+                            <option value="all">All categories</option>
+                            <?php foreach ($context['catalog']['categories']['list'] as $category): ?>
+                            <option value="<?php echo htmlspecialchars($category['slug']); ?>"><?php echo htmlspecialchars($category['name']); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                        <select id="commerceCatalogStatus" class="commerce-select" aria-label="Filter products by status">
+                            <option value="all">All statuses</option>
+                            <option value="active">Active</option>
+                            <option value="preorder">Preorder</option>
+                            <option value="backorder">Backorder</option>
+                            <option value="restock">Restock</option>
+                        </select>
+                    </div>
+                </header>
+                <div class="commerce-management-grid">
+                    <article class="commerce-card">
+                        <header class="commerce-card-header">
+                            <div>
+                                <h4 class="commerce-card-title">Category management</h4>
+                                <p class="commerce-card-subtitle">Add new catalogue categories or rename existing ones.</p>
+                            </div>
+                        </header>
+                        <div class="commerce-card-body">
+                            <p class="commerce-card-copy">Your catalogue spans <?php echo htmlspecialchars($context['catalog']['categories']['countFormatted']); ?> <?php echo htmlspecialchars($context['catalog']['categories']['countLabel']); ?>.</p>
+                            <ul class="commerce-chip-list" id="commerceCategorySummary">
+                                <?php if ($context['catalog']['categories']['hasCategories']): ?>
+                                    <?php foreach ($context['catalog']['categories']['list'] as $category): ?>
+                                    <li class="commerce-chip" data-category-id="<?php echo htmlspecialchars($category['id']); ?>"><?php echo htmlspecialchars($category['name']); ?></li>
+                                    <?php endforeach; ?>
+                                <?php else: ?>
+                                    <li class="commerce-chip commerce-chip--empty">No categories yet</li>
+                                <?php endif; ?>
+                            </ul>
+                        </div>
+                        <div class="commerce-card-footer">
+                            <button type="button" class="a11y-btn a11y-btn--primary" data-commerce-open-modal="commerceCategoryModal">
+                                <i class="fa-solid fa-tags" aria-hidden="true"></i>
+                                <span>Manage categories</span>
+                            </button>
+                        </div>
+                    </article>
+                    <article class="commerce-card">
+                        <header class="commerce-card-header">
+                            <div>
+                                <h4 class="commerce-card-title">Product quick actions</h4>
+                                <p class="commerce-card-subtitle">Launch new items or update existing SKUs from a focused modal.</p>
+                            </div>
+                        </header>
+                        <div class="commerce-card-body">
+                            <p class="commerce-card-copy">Keep your catalogue current by adding new products or refreshing existing listings.</p>
+                            <ul class="commerce-stat-list">
+                                <li class="commerce-stat">
+                                    <span class="commerce-stat-label">Total products</span>
+                                    <span class="commerce-stat-value"><?php echo htmlspecialchars($context['catalog']['stats']['totalProducts']); ?></span>
+                                </li>
+                                <li class="commerce-stat">
+                                    <span class="commerce-stat-label">Active SKUs</span>
+                                    <span class="commerce-stat-value"><?php echo htmlspecialchars($context['catalog']['stats']['activeProducts']); ?></span>
+                                </li>
+                                <?php if ($context['catalog']['stats']['showLowInventory']): ?>
+                                <li class="commerce-stat">
+                                    <span class="commerce-stat-label">Low inventory (≤ <?php echo htmlspecialchars($context['catalog']['stats']['lowInventoryThreshold']); ?>)</span>
+                                    <span class="commerce-stat-value"><?php echo htmlspecialchars($context['catalog']['stats']['lowInventoryCount']); ?></span>
+                                </li>
+                                <?php endif; ?>
+                            </ul>
+                        </div>
+                        <div class="commerce-card-footer">
+                            <button type="button" class="a11y-btn a11y-btn--primary" data-commerce-open-modal="commerceProductModal">
+                                <i class="fa-solid fa-plus" aria-hidden="true"></i>
+                                <span>Add product</span>
+                            </button>
+                        </div>
+                    </article>
                 </div>
-            </header>
-            <div class="commerce-management-grid">
-                <article class="commerce-card">
-                    <header class="commerce-card-header">
-                        <div>
-                            <h4 class="commerce-card-title">Category management</h4>
-                            <p class="commerce-card-subtitle">Add new catalogue categories or rename existing ones.</p>
-                        </div>
-                    </header>
-                    <div class="commerce-card-body">
-                        <p class="commerce-card-copy">Your catalogue spans <?php echo commerce_format_number($totalCategories); ?> <?php echo $totalCategories === 1 ? 'category' : 'categories'; ?>.</p>
-                        <ul class="commerce-chip-list" id="commerceCategorySummary">
-<?php if (!empty($categories)): ?>
-<?php foreach ($categories as $category): ?>
-                            <li class="commerce-chip" data-category-id="<?php echo htmlspecialchars($category['id']); ?>"><?php echo htmlspecialchars($category['name']); ?></li>
-<?php endforeach; ?>
-<?php else: ?>
-                            <li class="commerce-chip commerce-chip--empty">No categories yet</li>
-<?php endif; ?>
-                        </ul>
-                    </div>
-                    <div class="commerce-card-footer">
-                        <button type="button" class="a11y-btn a11y-btn--primary" data-commerce-open-modal="commerceCategoryModal">
-                            <i class="fa-solid fa-tags" aria-hidden="true"></i>
-                            <span>Manage categories</span>
-                        </button>
-                    </div>
-                </article>
-                <article class="commerce-card">
-                    <header class="commerce-card-header">
-                        <div>
-                            <h4 class="commerce-card-title">Product quick actions</h4>
-                            <p class="commerce-card-subtitle">Launch new items or update existing SKUs from a focused modal.</p>
-                        </div>
-                    </header>
-                    <div class="commerce-card-body">
-                        <p class="commerce-card-copy">Keep your catalogue current by adding new products or refreshing existing listings.</p>
-                        <ul class="commerce-stat-list">
-                            <li class="commerce-stat">
-                                <span class="commerce-stat-label">Total products</span>
-                                <span class="commerce-stat-value"><?php echo commerce_format_number($totalProducts); ?></span>
-                            </li>
-                            <li class="commerce-stat">
-                                <span class="commerce-stat-label">Active SKUs</span>
-                                <span class="commerce-stat-value"><?php echo commerce_format_number($activeProductCount); ?></span>
-                            </li>
-<?php if ($lowInventoryThreshold > 0): ?>
-                            <li class="commerce-stat">
-                                <span class="commerce-stat-label">Low inventory (≤ <?php echo commerce_format_number($lowInventoryThreshold); ?>)</span>
-                                <span class="commerce-stat-value"><?php echo commerce_format_number($lowInventoryCount); ?></span>
-                            </li>
-<?php endif; ?>
-                        </ul>
-                    </div>
-                    <div class="commerce-card-footer">
-                        <button type="button" class="a11y-btn a11y-btn--primary" data-commerce-open-modal="commerceProductModal">
-                            <i class="fa-solid fa-plus" aria-hidden="true"></i>
-                            <span>Add product</span>
-                        </button>
-                    </div>
-                </article>
-            </div>
-            <div class="commerce-table-wrapper" role="region" aria-live="polite">
-                <table class="commerce-table" id="commerceCatalogTable">
-                    <thead>
+                <div class="commerce-table-wrapper" role="region" aria-live="polite">
+                    <table class="commerce-table" id="commerceCatalogTable">
+                        <thead>
                             <tr>
                                 <th scope="col">Product</th>
                                 <th scope="col">Category</th>
@@ -378,86 +230,46 @@ foreach ($trend as $point):
                             </tr>
                         </thead>
                         <tbody>
-<?php foreach ($catalog as $product):
-    $name = isset($product['name']) ? (string) $product['name'] : 'Untitled product';
-    $sku = isset($product['sku']) ? (string) $product['sku'] : '';
-    $category = isset($product['category']) ? (string) $product['category'] : 'Uncategorised';
-    $categorySlug = commerce_slugify($category);
-    $price = isset($product['price']) ? commerce_format_currency($product['price'], $currencySymbol) : commerce_format_currency(0, $currencySymbol);
-    $inventory = isset($product['inventory']) ? (int) $product['inventory'] : 0;
-    $status = isset($product['status']) ? (string) $product['status'] : 'Unknown';
-    $visibility = isset($product['visibility']) ? (string) $product['visibility'] : 'Unknown';
-    $updated = isset($product['updated']) ? (string) $product['updated'] : '';
-    $featuredImage = isset($product['featured_image']) ? (string) $product['featured_image'] : '';
-    $galleryList = [];
-    if (isset($product['images'])) {
-        if (is_array($product['images'])) {
-            foreach ($product['images'] as $imageUrl) {
-                if (is_string($imageUrl) && $imageUrl !== '') {
-                    $galleryList[] = $imageUrl;
-                }
-            }
-        } elseif (is_string($product['images']) && trim($product['images']) !== '') {
-            $lines = preg_split('/\r\n|\r|\n/', $product['images']);
-            foreach ($lines as $imageUrl) {
-                $imageUrl = trim((string) $imageUrl);
-                if ($imageUrl !== '') {
-                    $galleryList[] = $imageUrl;
-                }
-            }
-        }
-    }
-    if ($featuredImage === '' && !empty($galleryList)) {
-        $featuredImage = (string) $galleryList[0];
-    }
-    $galleryCount = count($galleryList);
-    if ($galleryCount === 1) {
-        $galleryLabel = '1 gallery image';
-    } elseif ($galleryCount > 1) {
-        $galleryLabel = $galleryCount . ' gallery images';
-    } else {
-        $galleryLabel = 'No gallery images';
-    }
-?>
+                            <?php foreach ($context['catalog']['products'] as $product): ?>
                             <tr data-commerce-item
-                                data-sku="<?php echo htmlspecialchars($sku); ?>"
-                                data-category="<?php echo htmlspecialchars($categorySlug); ?>"
-                                data-status="<?php echo htmlspecialchars(strtolower($status)); ?>"
-                                data-visibility="<?php echo htmlspecialchars(strtolower($visibility)); ?>"
-                                data-updated="<?php echo htmlspecialchars($updated); ?>">
+                                data-sku="<?php echo htmlspecialchars($product['sku']); ?>"
+                                data-category="<?php echo htmlspecialchars($product['categorySlug']); ?>"
+                                data-status="<?php echo htmlspecialchars($product['statusKey']); ?>"
+                                data-visibility="<?php echo htmlspecialchars($product['visibilityKey']); ?>"
+                                data-updated="<?php echo htmlspecialchars($product['updated']); ?>">
                                 <td>
                                     <div class="commerce-product-cell">
-<?php if ($featuredImage !== ''): ?>
-                                        <img src="<?php echo htmlspecialchars($featuredImage); ?>" alt="Featured image for <?php echo htmlspecialchars($name); ?>" class="commerce-product-thumb">
-<?php else: ?>
+                                        <?php if ($product['hasFeaturedImage']): ?>
+                                        <img src="<?php echo htmlspecialchars($product['featuredImage']); ?>" alt="Featured image for <?php echo htmlspecialchars($product['name']); ?>" class="commerce-product-thumb">
+                                        <?php else: ?>
                                         <div class="commerce-product-thumb-placeholder" role="img" aria-label="No featured image">
                                             <i class="fa-solid fa-image" aria-hidden="true"></i>
                                         </div>
-<?php endif; ?>
+                                        <?php endif; ?>
                                         <div class="commerce-product-details">
                                             <div class="commerce-table-primary">
-                                                <strong><?php echo htmlspecialchars($name); ?></strong>
-                                                <span class="commerce-table-meta">SKU: <?php echo htmlspecialchars($sku); ?></span>
+                                                <strong><?php echo htmlspecialchars($product['name']); ?></strong>
+                                                <span class="commerce-table-meta">SKU: <?php echo htmlspecialchars($product['sku']); ?></span>
                                             </div>
-                                            <span class="commerce-product-gallery-meta"><?php echo htmlspecialchars($galleryLabel); ?></span>
+                                            <span class="commerce-product-gallery-meta"><?php echo htmlspecialchars($product['galleryLabel']); ?></span>
                                         </div>
                                     </div>
                                 </td>
-                                <td><?php echo htmlspecialchars($category); ?></td>
-                                <td><?php echo htmlspecialchars($price); ?></td>
+                                <td><?php echo htmlspecialchars($product['category']); ?></td>
+                                <td><?php echo htmlspecialchars($product['price']); ?></td>
                                 <td>
-                                    <span class="commerce-inventory" data-inventory="<?php echo $inventory; ?>"><?php echo $inventory; ?></span>
+                                    <span class="commerce-inventory" data-inventory="<?php echo htmlspecialchars((string) $product['inventory']); ?>"><?php echo htmlspecialchars((string) $product['inventory']); ?></span>
                                 </td>
-                                <td><span class="<?php echo commerce_badge_class($status); ?>"><?php echo htmlspecialchars($status); ?></span></td>
-                                <td><?php echo htmlspecialchars($visibility); ?></td>
-                                <td><?php echo htmlspecialchars($updated); ?></td>
+                                <td><span class="<?php echo htmlspecialchars($product['statusClass']); ?>"><?php echo htmlspecialchars($product['status']); ?></span></td>
+                                <td><?php echo htmlspecialchars($product['visibility']); ?></td>
+                                <td><?php echo htmlspecialchars($product['updated']); ?></td>
                                 <td>
-                                    <button type="button" class="commerce-inline-action" data-action="edit-product" data-sku="<?php echo htmlspecialchars($sku); ?>">
+                                    <button type="button" class="commerce-inline-action" data-action="edit-product" data-sku="<?php echo htmlspecialchars($product['sku']); ?>">
                                         <span>Edit</span>
                                     </button>
                                 </td>
                             </tr>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </tbody>
                     </table>
                     <div class="commerce-empty" id="commerceCatalogEmpty" hidden>No products match the current filters.</div>
@@ -499,34 +311,26 @@ foreach ($trend as $point):
                             </tr>
                         </thead>
                         <tbody>
-<?php foreach ($orders as $order):
-    $orderId = isset($order['id']) ? (string) $order['id'] : '';
-    $customer = isset($order['customer']) ? (string) $order['customer'] : '';
-    $channel = isset($order['channel']) ? (string) $order['channel'] : '';
-    $status = isset($order['status']) ? (string) $order['status'] : '';
-    $total = isset($order['total']) ? commerce_format_currency($order['total'], $currencySymbol) : commerce_format_currency(0, $currencySymbol);
-    $placed = isset($order['placed']) ? (string) $order['placed'] : '';
-    $fulfilment = isset($order['fulfillment']) ? (string) $order['fulfillment'] : '';
-?>
+                            <?php foreach ($context['orders']['rows'] as $order): ?>
                             <tr data-commerce-order
-                                data-status="<?php echo htmlspecialchars(strtolower($status)); ?>"
-                                data-channel="<?php echo htmlspecialchars(strtolower($channel)); ?>"
-                                data-customer="<?php echo htmlspecialchars(strtolower($customer)); ?>"
-                                data-order-id="<?php echo htmlspecialchars(strtolower($orderId)); ?>">
+                                data-status="<?php echo htmlspecialchars($order['filters']['status']); ?>"
+                                data-channel="<?php echo htmlspecialchars($order['filters']['channel']); ?>"
+                                data-customer="<?php echo htmlspecialchars($order['filters']['customer']); ?>"
+                                data-order-id="<?php echo htmlspecialchars($order['filters']['order']); ?>">
                                 <td>
                                     <div class="commerce-table-primary">
-                                        <strong><?php echo htmlspecialchars($orderId); ?></strong>
-                                        <span class="commerce-table-meta">Channel: <?php echo htmlspecialchars($channel); ?></span>
+                                        <strong><?php echo htmlspecialchars($order['id']); ?></strong>
+                                        <span class="commerce-table-meta">Channel: <?php echo htmlspecialchars($order['channel']); ?></span>
                                     </div>
                                 </td>
-                                <td><?php echo htmlspecialchars($customer); ?></td>
-                                <td><?php echo htmlspecialchars($channel); ?></td>
-                                <td><span class="<?php echo commerce_badge_class($status); ?>"><?php echo htmlspecialchars($status); ?></span></td>
-                                <td><?php echo htmlspecialchars($total); ?></td>
-                                <td><?php echo htmlspecialchars($placed); ?></td>
-                                <td><?php echo htmlspecialchars($fulfilment); ?></td>
+                                <td><?php echo htmlspecialchars($order['customer']); ?></td>
+                                <td><?php echo htmlspecialchars($order['channel']); ?></td>
+                                <td><span class="<?php echo htmlspecialchars($order['statusClass']); ?>"><?php echo htmlspecialchars($order['status']); ?></span></td>
+                                <td><?php echo htmlspecialchars($order['total']); ?></td>
+                                <td><?php echo htmlspecialchars($order['placed']); ?></td>
+                                <td><?php echo htmlspecialchars($order['fulfillment']); ?></td>
                             </tr>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </tbody>
                     </table>
                     <div class="commerce-empty" id="commerceOrderEmpty" hidden>No orders match the current filters.</div>
@@ -542,19 +346,9 @@ foreach ($trend as $point):
                     <div class="commerce-panel-actions">
                         <select id="commerceCustomerSegment" class="commerce-select" aria-label="Filter customers by segment">
                             <option value="all">All segments</option>
-<?php
-$segments = [];
-foreach ($customers as $customer) {
-    if (isset($customer['segment'])) {
-        $segments[] = (string) $customer['segment'];
-    }
-}
-$segments = array_values(array_unique($segments));
-sort($segments);
-foreach ($segments as $segment):
-?>
-                            <option value="<?php echo htmlspecialchars(strtolower($segment)); ?>"><?php echo htmlspecialchars($segment); ?></option>
-<?php endforeach; ?>
+                            <?php foreach ($context['customers']['segments'] as $segment): ?>
+                            <option value="<?php echo htmlspecialchars($segment['value']); ?>"><?php echo htmlspecialchars($segment['label']); ?></option>
+                            <?php endforeach; ?>
                         </select>
                         <select id="commerceCustomerStatus" class="commerce-select" aria-label="Filter customers by status">
                             <option value="all">All statuses</option>
@@ -578,37 +372,29 @@ foreach ($segments as $segment):
                             </tr>
                         </thead>
                         <tbody>
-<?php foreach ($customers as $customer):
-    $name = isset($customer['name']) ? (string) $customer['name'] : '';
-    $email = isset($customer['email']) ? (string) $customer['email'] : '';
-    $segment = isset($customer['segment']) ? (string) $customer['segment'] : '';
-    $ordersCount = isset($customer['orders']) ? (int) $customer['orders'] : 0;
-    $ltv = isset($customer['lifetime_value']) ? commerce_format_currency($customer['lifetime_value'], $currencySymbol) : commerce_format_currency(0, $currencySymbol);
-    $lastOrder = isset($customer['last_order']) ? (string) $customer['last_order'] : '';
-    $status = isset($customer['status']) ? (string) $customer['status'] : '';
-?>
+                            <?php foreach ($context['customers']['rows'] as $customer): ?>
                             <tr data-commerce-customer
-                                data-segment="<?php echo htmlspecialchars(strtolower($segment)); ?>"
-                                data-status="<?php echo htmlspecialchars(strtolower($status)); ?>"
-                                data-name="<?php echo htmlspecialchars(strtolower($name)); ?>"
-                                data-email="<?php echo htmlspecialchars(strtolower($email)); ?>">
-                                <td><?php echo htmlspecialchars($name); ?></td>
-                                <td><a href="mailto:<?php echo htmlspecialchars($email); ?>" class="commerce-link"><?php echo htmlspecialchars($email); ?></a></td>
-                                <td><?php echo htmlspecialchars($segment); ?></td>
+                                data-segment="<?php echo htmlspecialchars($customer['filters']['segment']); ?>"
+                                data-status="<?php echo htmlspecialchars($customer['filters']['status']); ?>"
+                                data-name="<?php echo htmlspecialchars($customer['filters']['name']); ?>"
+                                data-email="<?php echo htmlspecialchars($customer['filters']['email']); ?>">
+                                <td><?php echo htmlspecialchars($customer['name']); ?></td>
+                                <td><a href="mailto:<?php echo htmlspecialchars($customer['email']); ?>" class="commerce-link"><?php echo htmlspecialchars($customer['email']); ?></a></td>
+                                <td><?php echo htmlspecialchars($customer['segment']); ?></td>
                                 <td>
                                     <button type="button"
                                         class="commerce-link commerce-link-button"
-                                        data-commerce-customer-orders="<?php echo htmlspecialchars(strtolower($name)); ?>"
-                                        data-customer-name="<?php echo htmlspecialchars($name); ?>">
-                                        <?php echo $ordersCount; ?>
-                                        <span class="sr-only"> orders for <?php echo htmlspecialchars($name); ?></span>
+                                        data-commerce-customer-orders="<?php echo htmlspecialchars($customer['filters']['name']); ?>"
+                                        data-customer-name="<?php echo htmlspecialchars($customer['name']); ?>">
+                                        <?php echo htmlspecialchars((string) $customer['orders']); ?>
+                                        <span class="sr-only"> orders for <?php echo htmlspecialchars($customer['name']); ?></span>
                                     </button>
                                 </td>
-                                <td><?php echo htmlspecialchars($ltv); ?></td>
-                                <td><?php echo htmlspecialchars($lastOrder); ?></td>
-                                <td><span class="<?php echo commerce_badge_class($status); ?>"><?php echo htmlspecialchars($status); ?></span></td>
+                                <td><?php echo htmlspecialchars($customer['lifetimeValue']); ?></td>
+                                <td><?php echo htmlspecialchars($customer['lastOrder']); ?></td>
+                                <td><span class="<?php echo htmlspecialchars($customer['statusClass']); ?>"><?php echo htmlspecialchars($customer['status']); ?></span></td>
                             </tr>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </tbody>
                     </table>
                     <div class="commerce-empty" id="commerceCustomerEmpty" hidden>No customers match the selected filters.</div>
@@ -626,144 +412,78 @@ foreach ($segments as $segment):
                     <section class="commerce-settings-group">
                         <h4 class="commerce-settings-heading">Storefront</h4>
                         <ul class="commerce-settings-list">
+                            <?php foreach ($context['settings']['storefront'] as $item): ?>
                             <li>
-                                <span class="commerce-settings-label">Status</span>
-                                <span class="commerce-settings-value status-badge status-good"><?php echo htmlspecialchars($commerceSettings['storefront_status'] ?? 'Offline'); ?></span>
+                                <span class="commerce-settings-label"><?php echo htmlspecialchars($item['label']); ?></span>
+                                <?php if (!empty($item['isBadge'])): ?>
+                                <span class="commerce-settings-value <?php echo htmlspecialchars($item['badgeClass']); ?>"><?php echo htmlspecialchars($item['value']); ?></span>
+                                <?php else: ?>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($item['value']); ?></span>
+                                <?php endif; ?>
                             </li>
-                            <li>
-                                <span class="commerce-settings-label">Currency</span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars($currency); ?></span>
-                            </li>
-                            <li>
-                                <span class="commerce-settings-label">Theme</span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars($commerceSettings['storefront_theme'] ?? 'Default'); ?></span>
-                            </li>
-                            <li>
-                                <span class="commerce-settings-label">Primary language</span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars($commerceSettings['default_language'] ?? 'Not set'); ?></span>
-                            </li>
-                            <li>
-                                <span class="commerce-settings-label">Low inventory threshold</span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars((string) ($commerceSettings['low_inventory_threshold'] ?? 0)); ?> units</span>
-                            </li>
-                            <li>
-                                <span class="commerce-settings-label">Default tax rate</span>
-                                <span class="commerce-settings-value"><?php echo commerce_format_percent($commerceSettings['default_tax_rate'] ?? 0); ?></span>
-                            </li>
+                            <?php endforeach; ?>
                         </ul>
                     </section>
                     <section class="commerce-settings-group">
                         <h4 class="commerce-settings-heading">Checkout controls</h4>
                         <ul class="commerce-toggle-list">
-<?php
-$toggleMap = [
-    'express_checkout' => 'Express checkout',
-    'allow_guest_checkout' => 'Allow guest checkout',
-    'fraud_protection' => 'Fraud protection',
-    'auto_apply_discounts' => 'Auto-apply discounts',
-    'address_verification' => 'Address verification'
-];
-foreach ($toggleMap as $key => $label):
-    $enabled = !empty($commerceSettings[$key]);
-?>
+                            <?php foreach ($context['settings']['toggles'] as $toggle): ?>
                             <li>
                                 <label class="commerce-toggle">
-                                    <input type="checkbox" <?php echo $enabled ? 'checked' : ''; ?> data-commerce-toggle="<?php echo htmlspecialchars($key); ?>">
+                                    <input type="checkbox" <?php echo $toggle['checked'] ? 'checked' : ''; ?> data-commerce-toggle="<?php echo htmlspecialchars($toggle['key']); ?>">
                                     <span class="commerce-toggle-indicator" aria-hidden="true"></span>
-                                    <span class="commerce-toggle-label"><?php echo htmlspecialchars($label); ?></span>
+                                    <span class="commerce-toggle-label"><?php echo htmlspecialchars($toggle['label']); ?></span>
                                 </label>
                             </li>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </ul>
                     </section>
                     <section class="commerce-settings-group">
                         <h4 class="commerce-settings-heading">Payment methods</h4>
                         <ul class="commerce-settings-list">
-<?php
-$paymentMethods = isset($commerceSettings['payment_methods']) && is_array($commerceSettings['payment_methods']) ? $commerceSettings['payment_methods'] : [];
-foreach ($paymentMethods as $method):
-    $label = isset($method['label']) ? (string) $method['label'] : '';
-    $enabled = !empty($method['enabled']);
-?>
+                            <?php foreach ($context['settings']['paymentMethods'] as $method): ?>
                             <li>
-                                <span class="commerce-settings-label"><?php echo htmlspecialchars($label); ?></span>
-                                <span class="commerce-settings-value <?php echo $enabled ? 'status-badge status-good' : 'status-badge status-warning'; ?>"><?php echo $enabled ? 'Enabled' : 'Disabled'; ?></span>
+                                <span class="commerce-settings-label"><?php echo htmlspecialchars($method['label']); ?></span>
+                                <span class="commerce-settings-value <?php echo htmlspecialchars($method['statusClass']); ?>"><?php echo htmlspecialchars($method['status']); ?></span>
                             </li>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </ul>
                     </section>
                     <section class="commerce-settings-group">
                         <h4 class="commerce-settings-heading">Fulfilment windows</h4>
                         <ul class="commerce-settings-list">
-<?php
-$windows = isset($commerceSettings['fulfillment_windows']) && is_array($commerceSettings['fulfillment_windows']) ? $commerceSettings['fulfillment_windows'] : [];
-foreach ($windows as $window):
-    $name = isset($window['name']) ? (string) $window['name'] : '';
-    $sla = isset($window['sla']) ? (string) $window['sla'] : '';
-?>
+                            <?php foreach ($context['settings']['fulfillmentWindows'] as $window): ?>
                             <li>
-                                <span class="commerce-settings-label"><?php echo htmlspecialchars($name); ?></span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars($sla); ?></span>
+                                <span class="commerce-settings-label"><?php echo htmlspecialchars($window['name']); ?></span>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($window['sla']); ?></span>
                             </li>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </ul>
                     </section>
                     <section class="commerce-settings-group">
                         <h4 class="commerce-settings-heading">Shipping partners</h4>
                         <ul class="commerce-settings-list">
-<?php
-$partners = isset($commerceSettings['shipping_partners']) && is_array($commerceSettings['shipping_partners']) ? $commerceSettings['shipping_partners'] : [];
-if (empty($partners)):
-?>
+                            <?php foreach ($context['settings']['shippingPartners'] as $partner): ?>
                             <li>
-                                <span class="commerce-settings-label">Partners</span>
-                                <span class="commerce-settings-value">No shipping partners configured</span>
+                                <span class="commerce-settings-label"><?php echo htmlspecialchars($partner['name']); ?></span>
+                                <?php if (!empty($partner['statusClass'])): ?>
+                                <span class="commerce-settings-value <?php echo htmlspecialchars($partner['statusClass']); ?>"><?php echo htmlspecialchars($partner['status']); ?></span>
+                                <?php else: ?>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($partner['status']); ?></span>
+                                <?php endif; ?>
                             </li>
-<?php
-endif;
-foreach ($partners as $partner):
-    $partnerName = isset($partner['name']) ? (string) $partner['name'] : '';
-    $status = isset($partner['status']) ? (string) $partner['status'] : '';
-    $normalizedStatus = strtolower($status);
-    $statusClass = 'status-badge';
-    if ($normalizedStatus === 'primary' || $normalizedStatus === 'active') {
-        $statusClass = 'status-badge status-good';
-    } elseif ($normalizedStatus === 'backup' || $normalizedStatus === 'limited') {
-        $statusClass = 'status-badge status-warning';
-    } elseif ($normalizedStatus === 'paused' || $normalizedStatus === 'suspended') {
-        $statusClass = 'status-badge status-critical';
-    } elseif ($normalizedStatus === 'international') {
-        $statusClass = 'status-badge status-info';
-    }
-?>
-                            <li>
-                                <span class="commerce-settings-label"><?php echo htmlspecialchars($partnerName); ?></span>
-                                <span class="commerce-settings-value <?php echo $statusClass; ?>"><?php echo htmlspecialchars($status !== '' ? $status : 'Unavailable'); ?></span>
-                            </li>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </ul>
                     </section>
                     <section class="commerce-settings-group">
                         <h4 class="commerce-settings-heading">Return policy</h4>
                         <ul class="commerce-settings-list">
-<?php
-$returnPolicy = isset($commerceSettings['return_policy']) && is_array($commerceSettings['return_policy']) ? $commerceSettings['return_policy'] : [];
-$returnWindow = isset($returnPolicy['window_days']) && is_numeric($returnPolicy['window_days']) ? (int) $returnPolicy['window_days'] : null;
-$restockingFee = isset($returnPolicy['restocking_fee']) ? (string) $returnPolicy['restocking_fee'] : '';
-$returnShipping = isset($returnPolicy['return_shipping']) ? (string) $returnPolicy['return_shipping'] : '';
-?>
+                            <?php foreach ($context['settings']['returnPolicy'] as $policy): ?>
                             <li>
-                                <span class="commerce-settings-label">Return window</span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars($returnWindow !== null ? $returnWindow . ' days' : 'Not specified'); ?></span>
+                                <span class="commerce-settings-label"><?php echo htmlspecialchars($policy['label']); ?></span>
+                                <span class="commerce-settings-value"><?php echo htmlspecialchars($policy['value']); ?></span>
                             </li>
-                            <li>
-                                <span class="commerce-settings-label">Restocking fee</span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars($restockingFee !== '' ? $restockingFee : 'None'); ?></span>
-                            </li>
-                            <li>
-                                <span class="commerce-settings-label">Return shipping</span>
-                                <span class="commerce-settings-value"><?php echo htmlspecialchars($returnShipping !== '' ? $returnShipping : 'Not specified'); ?></span>
-                            </li>
+                            <?php endforeach; ?>
                         </ul>
                     </section>
                 </div>
@@ -787,9 +507,9 @@ $returnShipping = isset($returnPolicy['return_shipping']) ? (string) $returnPoli
                         <label class="commerce-form-label" for="commerceCategorySelect">Edit existing category</label>
                         <select id="commerceCategorySelect" class="commerce-form-input" data-commerce-initial-focus>
                             <option value="">Create new category</option>
-<?php foreach ($categories as $category): ?>
+                            <?php foreach ($context['catalog']['categories']['list'] as $category): ?>
                             <option value="<?php echo htmlspecialchars($category['id']); ?>"><?php echo htmlspecialchars($category['name']); ?></option>
-<?php endforeach; ?>
+                            <?php endforeach; ?>
                         </select>
                         <p class="commerce-form-help">Select a category to update or choose “Create new category”.</p>
                     </div>
@@ -805,13 +525,13 @@ $returnShipping = isset($returnPolicy['return_shipping']) ? (string) $returnPoli
                 <div class="commerce-form-meta">
                     <h5 class="commerce-form-meta-title">Existing categories</h5>
                     <ul class="commerce-chip-list" id="commerceCategoryList">
-<?php if (!empty($categories)): ?>
-<?php foreach ($categories as $category): ?>
-                        <li class="commerce-chip" data-category-id="<?php echo htmlspecialchars($category['id']); ?>"><?php echo htmlspecialchars($category['name']); ?></li>
-<?php endforeach; ?>
-<?php else: ?>
-                        <li class="commerce-chip commerce-chip--empty">No categories yet</li>
-<?php endif; ?>
+                        <?php if ($context['catalog']['categories']['hasCategories']): ?>
+                            <?php foreach ($context['catalog']['categories']['list'] as $category): ?>
+                            <li class="commerce-chip" data-category-id="<?php echo htmlspecialchars($category['id']); ?>"><?php echo htmlspecialchars($category['name']); ?></li>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <li class="commerce-chip commerce-chip--empty">No categories yet</li>
+                        <?php endif; ?>
                     </ul>
                 </div>
             </div>
@@ -843,9 +563,9 @@ $returnShipping = isset($returnPolicy['return_shipping']) ? (string) $returnPoli
                             <label class="commerce-form-label" for="commerceProductCategory">Category</label>
                             <input type="text" id="commerceProductCategory" class="commerce-form-input" name="category" list="commerceProductCategoryOptions" required placeholder="Lighting">
                             <datalist id="commerceProductCategoryOptions">
-<?php foreach ($categories as $category): ?>
+                                <?php foreach ($context['catalog']['categories']['list'] as $category): ?>
                                 <option value="<?php echo htmlspecialchars($category['name']); ?>"></option>
-<?php endforeach; ?>
+                                <?php endforeach; ?>
                             </datalist>
                         </div>
                         <div class="commerce-form-group">
@@ -947,5 +667,5 @@ $returnShipping = isset($returnPolicy['return_shipping']) ? (string) $returnPoli
             </div>
         </div>
     </div>
-    <script type="application/json" id="commerceDataset"><?php echo $encodedDataset; ?></script>
+    <script type="application/json" id="commerceDataset"><?php echo $context['datasetJson']; ?></script>
 </div>

--- a/tests/commerce_service_test.php
+++ b/tests/commerce_service_test.php
@@ -1,0 +1,83 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/commerce/CommerceService.php';
+
+$fixture = [
+    'summary' => [],
+    'alerts' => [],
+    'catalog' => [
+        [
+            'sku' => 'SKU-001',
+            'name' => 'Decor Lamp',
+            'category' => 'Decor',
+            'price' => 120,
+            'inventory' => 4,
+            'status' => 'Active',
+            'visibility' => 'Published',
+        ],
+        [
+            'sku' => 'SKU-002',
+            'name' => 'Kitchen Bowl',
+            'category' => 'Kitchen',
+            'price' => 30,
+            'inventory' => 15,
+            'status' => 'Active',
+            'visibility' => 'Published',
+        ],
+        [
+            'sku' => 'SKU-003',
+            'name' => 'Decor Vase',
+            'category' => 'Decor',
+            'price' => 85,
+            'inventory' => 9,
+            'status' => 'Restock',
+            'visibility' => 'Hidden',
+        ],
+    ],
+    'categories' => [
+        ['id' => 'decor', 'name' => 'Decor', 'slug' => 'decor'],
+        ['id' => 'decor-duplicate', 'name' => 'Decor', 'slug' => 'decor'],
+        ['id' => 'kitchen', 'name' => 'Kitchen', 'slug' => 'kitchen'],
+    ],
+    'orders' => [],
+    'customers' => [],
+    'reports' => [],
+    'settings' => [
+        'currency' => 'usd',
+        'low_inventory_threshold' => 10,
+    ],
+];
+
+$tempFile = tempnam(sys_get_temp_dir(), 'commerce');
+if ($tempFile === false) {
+    throw new RuntimeException('Unable to create temporary commerce dataset.');
+}
+
+file_put_contents($tempFile, json_encode($fixture));
+
+$service = new CommerceService($tempFile);
+$context = $service->buildDashboardContext();
+
+$categorySlugs = array_map(static function (array $category) {
+    return $category['slug'];
+}, $context['catalog']['categories']['list']);
+
+if (count($categorySlugs) !== count(array_unique($categorySlugs))) {
+    throw new RuntimeException('Category slugs should be deduplicated.');
+}
+
+if (!in_array('decor', $categorySlugs, true) || !in_array('kitchen', $categorySlugs, true)) {
+    throw new RuntimeException('Expected categories are missing after normalisation.');
+}
+
+$stats = $context['catalog']['stats'];
+if ($stats['showLowInventory'] !== true) {
+    throw new RuntimeException('Low inventory indicator should be enabled when a threshold is configured.');
+}
+
+if ($stats['lowInventoryCount'] !== '2') {
+    throw new RuntimeException('Low inventory count should include products at or below the threshold.');
+}
+
+unlink($tempFile);
+
+echo "CommerceService tests passed\n";


### PR DESCRIPTION
## Summary
- add a CommerceService that loads commerce data, normalises collections, and prepares formatted dashboard context
- rewrite the commerce dashboard view to render the prepared context without inline calculations or formatter functions
- cover category slug deduplication and low-inventory detection with a new commerce service test

## Testing
- php tests/commerce_service_test.php
- php tests/analytics_service_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df43eb54a48331be3c1bf7452b54c7