### PR TITLE
Refactor drag-and-drop controller

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -1,5 +1,5 @@
 // File: builder.js
-import { initDragDrop, addBlockControls } from './modules/dragDrop.js';
+import { createDragDropController } from './modules/dragDrop.js';
 import { initSettings, openSettings, applyStoredSettings, confirmDelete } from './modules/settings.js';
 import { ensureBlockState, getSettings, setSetting } from './modules/state.js';
 import { initUndoRedo } from './modules/undoRedo.js';
@@ -434,7 +434,18 @@ document.addEventListener('DOMContentLoaded', () => {
   favorites = JSON.parse(localStorage.getItem('favoriteBlocks') || '[]');
 
 
-  initSettings({ canvas, settingsPanel, savePage: scheduleSave });
+  const dragDropController = createDragDropController({
+    palette,
+    canvas,
+    basePath: window.builderBase,
+    loggedIn: true,
+    openSettings,
+    applyStoredSettings,
+  });
+  dragDropController.init();
+  const { addBlockControls } = dragDropController;
+
+  initSettings({ canvas, settingsPanel, savePage: scheduleSave, addBlockControls });
 
   const searchInput = palette.querySelector('.palette-search');
 
@@ -452,15 +463,6 @@ document.addEventListener('DOMContentLoaded', () => {
       renderPalette(palette, filtered);
     });
   }
-
-  initDragDrop({
-    palette,
-    canvas,
-    basePath: window.builderBase,
-    loggedIn: true,
-    openSettings,
-    applyStoredSettings,
-  });
 
   const history = initUndoRedo({ canvas, onChange: scheduleSave, maxHistory: 15 });
   const undoBtn = palette.querySelector('.undo-btn');

--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -4,7 +4,7 @@ import { executeScripts } from "./executeScripts.js";
 
 const templateCache = new Map();
 
-function loadTemplate(file) {
+function loadTemplate(basePath, file) {
   const cached = templateCache.get(file);
   if (cached) {
     return typeof cached === 'string' ? Promise.resolve(cached) : cached;
@@ -21,15 +21,6 @@ function loadTemplate(file) {
   return p;
 }
 
-let palette;
-let canvas;
-let basePath = '';
-let loggedIn = false;
-let openSettings;
-let applyStoredSettings;
-
-let dragSource = null;
-let fromPalette = false;
 // caching block control markup avoids rebuilding the DOM for each block
 const controlsTemplate = `
   <span class="control edit" title="Edit"><i class="fa-solid fa-pen-to-square"></i></span>
@@ -48,14 +39,35 @@ function extractTemplateSetting(html) {
   return { ts, cleaned };
 }
 
-const placeholder = document.createElement('div');
-placeholder.className = 'block-placeholder';
-placeholder.innerHTML = '<span class="drop-text">Drop block here</span>';
-placeholder.style.pointerEvents = 'none';
+function createPlaceholder() {
+  const el = document.createElement('div');
+  el.className = 'block-placeholder';
+  el.innerHTML = '<span class="drop-text">Drop block here</span>';
+  el.style.pointerEvents = 'none';
+  return el;
+}
 
-const insertionIndicator = document.createElement('div');
-insertionIndicator.className = 'insertion-indicator';
-insertionIndicator.style.pointerEvents = 'none';
+function createInsertionIndicator() {
+  const el = document.createElement('div');
+  el.className = 'insertion-indicator';
+  el.style.pointerEvents = 'none';
+  return el;
+}
+
+export function createDragGhost(node) {
+  if (!node) return null;
+  const dragImage = node.cloneNode(true);
+  dragImage.classList.add('drag-ghost');
+  dragImage.style.position = 'absolute';
+  dragImage.style.top = '-1000px';
+  document.body.appendChild(dragImage);
+  setTimeout(() => {
+    if (dragImage.parentNode) {
+      dragImage.parentNode.removeChild(dragImage);
+    }
+  }, 0);
+  return dragImage;
+}
 
 function throttleRAF(fn) {
   let running = false;
@@ -72,153 +84,166 @@ function throttleRAF(fn) {
   };
 }
 
-export function initDragDrop(options = {}) {
-  palette = options.palette;
-  canvas = options.canvas;
-  basePath = options.basePath || '';
-  loggedIn = options.loggedIn || false;
-  openSettings = options.openSettings;
-  applyStoredSettings = options.applyStoredSettings;
+export function createDragDropController(options = {}) {
+  const state = {
+    palette: null,
+    canvas: null,
+    basePath: '',
+    loggedIn: false,
+    openSettings: null,
+    applyStoredSettings: null,
+    dragSource: null,
+    fromPalette: false,
+    placeholder: createPlaceholder(),
+    insertionIndicator: createInsertionIndicator(),
+  };
 
-  if (palette) palette.addEventListener('dragstart', paletteDragStart);
-  if (canvas) {
-    ['dragstart', 'dragenter', 'dragleave', 'dragover', 'drop', 'dragend'].forEach(
-      (ev) => canvas.addEventListener(ev, delegateDragEvents, true)
-    );
+  function setOptions(opts = {}) {
+    if ('palette' in opts) state.palette = opts.palette;
+    if ('canvas' in opts) state.canvas = opts.canvas;
+    if ('basePath' in opts) state.basePath = opts.basePath || '';
+    if ('loggedIn' in opts) state.loggedIn = !!opts.loggedIn;
+    if ('openSettings' in opts) state.openSettings = opts.openSettings;
+    if ('applyStoredSettings' in opts)
+      state.applyStoredSettings = opts.applyStoredSettings;
   }
-  setupDropArea(canvas);
-  if (canvas) {
-    canvas.querySelectorAll('.drop-area').forEach(setupDropArea);
+
+  setOptions(options);
+
+  function paletteDragStart(e) {
+    const item = e.target.closest('.block-item');
+    if (item) {
+      state.dragSource = item;
+      state.fromPalette = true;
+      e.dataTransfer.setData('text/plain', item.dataset.file || '');
+      e.dataTransfer.effectAllowed = 'copy';
+      item.classList.add('dragging');
+
+      const dragImage = createDragGhost(item);
+      if (dragImage) {
+        e.dataTransfer.setDragImage(
+          dragImage,
+          dragImage.offsetWidth / 2,
+          dragImage.offsetHeight / 2
+        );
+      }
+    }
   }
-}
 
-function paletteDragStart(e) {
-  const item = e.target.closest('.block-item');
-  if (item) {
-    dragSource = item;
-    fromPalette = true;
-    e.dataTransfer.setData('text/plain', item.dataset.file || '');
-    e.dataTransfer.effectAllowed = 'copy';
-    item.classList.add('dragging');
+  function canvasDragStart(e) {
+    const handle = e.target.closest('.control.drag');
+    if (handle) {
+      state.dragSource = handle.closest('.block-wrapper');
+      state.fromPalette = false;
+      if (!state.dragSource) return;
+      state.dragSource.classList.add('dragging');
+      e.dataTransfer.setData('text/plain', 'reorder');
+      e.dataTransfer.effectAllowed = 'move';
 
-    const dragImage = item.cloneNode(true);
-    dragImage.classList.add('drag-ghost');
-    dragImage.style.position = 'absolute';
-    dragImage.style.top = '-1000px';
-    document.body.appendChild(dragImage);
-    e.dataTransfer.setDragImage(dragImage, dragImage.offsetWidth / 2, dragImage.offsetHeight / 2);
-    setTimeout(() => document.body.removeChild(dragImage), 0);
+      const dragImage = createDragGhost(state.dragSource);
+      if (dragImage) {
+        e.dataTransfer.setDragImage(
+          dragImage,
+          dragImage.offsetWidth / 2,
+          dragImage.offsetHeight / 2
+        );
+      }
+    } else if (e.target.closest('.block-wrapper')) {
+      e.preventDefault();
+    }
   }
-}
 
-function canvasDragStart(e) {
-  const handle = e.target.closest('.control.drag');
-  if (handle) {
-    dragSource = handle.closest('.block-wrapper');
-    fromPalette = false;
-    dragSource.classList.add('dragging');
-    e.dataTransfer.setData('text/plain', 'reorder');
-    e.dataTransfer.effectAllowed = 'move';
-
-    const dragImage = dragSource.cloneNode(true);
-    dragImage.classList.add('drag-ghost');
-    dragImage.style.position = 'absolute';
-    dragImage.style.top = '-1000px';
-    document.body.appendChild(dragImage);
-    e.dataTransfer.setDragImage(dragImage, dragImage.offsetWidth / 2, dragImage.offsetHeight / 2);
-    setTimeout(() => document.body.removeChild(dragImage), 0);
-  } else if (e.target.closest('.block-wrapper')) {
-    e.preventDefault();
+  function setupDropArea(area) {
+    if (!area) return;
+    area.dataset.dropArea = 'true';
   }
-}
 
-export function addBlockControls(block) {
-  ensureBlockState(block);
-  if (applyStoredSettings) applyStoredSettings(block);
-  if (!loggedIn) {
-    const existing = block.querySelector('.block-controls');
-    if (existing) existing.remove();
+  function addBlockControls(block) {
+    if (!block) return;
+    ensureBlockState(block);
+    if (state.applyStoredSettings) state.applyStoredSettings(block);
+    if (!state.loggedIn) {
+      const existing = block.querySelector('.block-controls');
+      if (existing) existing.remove();
+      block.removeAttribute('draggable');
+      return;
+    }
+    if (!block.querySelector('.block-controls')) {
+      const controls = controlsFragment.cloneNode(true);
+      block.style.position = 'relative';
+      block.appendChild(controls);
+    }
     block.removeAttribute('draggable');
-    return;
-  }
-  if (!block.querySelector('.block-controls')) {
-    const controls = controlsFragment.cloneNode(true);
-    block.style.position = 'relative';
-    block.appendChild(controls);
-  }
-  block.removeAttribute('draggable');
-  const dragHandle = block.querySelector('.block-controls .drag');
-  if (dragHandle) dragHandle.setAttribute('draggable', 'true');
-  if (!block.dataset.original) {
-    let html = block.innerHTML;
-    const { ts, cleaned } = extractTemplateSetting(html);
-    block.dataset.original = cleaned;
-    if (ts) {
-      block.dataset.ts = btoa(ts);
+    const dragHandle = block.querySelector('.block-controls .drag');
+    if (dragHandle) dragHandle.setAttribute('draggable', 'true');
+    if (!block.dataset.original) {
+      let html = block.innerHTML;
+      const { ts, cleaned } = extractTemplateSetting(html);
+      block.dataset.original = cleaned;
+      if (ts) {
+        block.dataset.ts = btoa(ts);
+      }
+    } else {
+      const { ts, cleaned } = extractTemplateSetting(block.dataset.original);
+      block.dataset.original = cleaned;
+      if (ts && !block.dataset.ts) {
+        block.dataset.ts = btoa(ts);
+      }
     }
-  } else {
-    const { ts, cleaned } = extractTemplateSetting(block.dataset.original);
-    block.dataset.original = cleaned;
-    if (ts && !block.dataset.ts) {
-      block.dataset.ts = btoa(ts);
+    const tsEl = block.querySelector('templateSetting');
+    if (tsEl) tsEl.remove();
+    const areas = block.querySelectorAll('.drop-area');
+    areas.forEach(setupDropArea);
+    if (areas.length === 0) {
+      setupDropArea(block);
     }
   }
-  const tsEl = block.querySelector('templateSetting');
-  if (tsEl) tsEl.remove();
-  const areas = block.querySelectorAll('.drop-area');
-  areas.forEach(setupDropArea);
-  if (areas.length === 0) {
-    setupDropArea(block);
-  }
-}
 
-export function setupDropArea(area) {
-  if (!area) return;
-  area.dataset.dropArea = 'true';
-}
-
-function handleDragEnter(e) {
-  const area = e.target.closest('[data-drop-area]');
-  if (area) {
-    area.classList.add('drag-over');
+  function handleDragEnter(e) {
+    const area = e.target.closest('[data-drop-area]');
+    if (area) {
+      area.classList.add('drag-over');
+    }
   }
-}
 
-function handleDragLeave(e) {
-  const area = e.target.closest('[data-drop-area]');
-  if (area && (!e.relatedTarget || !area.contains(e.relatedTarget))) {
-    area.classList.remove('drag-over');
-    placeholder.remove();
-    insertionIndicator.remove();
+  function handleDragLeave(e) {
+    const area = e.target.closest('[data-drop-area]');
+    if (area && (!e.relatedTarget || !area.contains(e.relatedTarget))) {
+      area.classList.remove('drag-over');
+      state.placeholder.remove();
+      state.insertionIndicator.remove();
+    }
   }
-}
 
-function handleDragOver(e) {
-  const area = e.target.closest('[data-drop-area]');
-  if (!area) return;
-  e.preventDefault();
-  e.dataTransfer.dropEffect = fromPalette ? 'copy' : 'move';
-  const after = getDragAfterElement(area, e.clientY);
-  if (after == null) {
-    area.appendChild(placeholder);
-  } else {
-    area.insertBefore(placeholder, after);
+  function handleDragOver(e) {
+    const area = e.target.closest('[data-drop-area]');
+    if (!area) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = state.fromPalette ? 'copy' : 'move';
+    const after = getDragAfterElement(area, e.clientY);
+    if (after == null) {
+      area.appendChild(state.placeholder);
+    } else {
+      area.insertBefore(state.placeholder, after);
+    }
+    state.insertionIndicator.remove();
+    if (state.placeholder.parentNode) {
+      state.placeholder.parentNode.insertBefore(
+        state.insertionIndicator,
+        state.placeholder
+      );
+    }
   }
-  insertionIndicator.remove();
-  if (placeholder.parentNode) {
-    placeholder.parentNode.insertBefore(insertionIndicator, placeholder);
-  }
-}
 
-function handleDrop(e) {
-  const area = e.target.closest('[data-drop-area]');
-  if (!area) return;
-  e.preventDefault();
-  const after = getDragAfterElement(area, e.clientY);
-  if (fromPalette && dragSource) {
-    const file = dragSource.dataset.file;
-    if (file) {
-      loadTemplate(file).then((html) => {
+  function handleDrop(e) {
+    const area = e.target.closest('[data-drop-area]');
+    if (!area) return;
+    e.preventDefault();
+    const after = getDragAfterElement(area, e.clientY);
+    if (state.fromPalette && state.dragSource) {
+      const file = state.dragSource.dataset.file;
+      if (file) {
+        loadTemplate(state.basePath, file).then((html) => {
           const wrapper = document.createElement('div');
           wrapper.className = 'block-wrapper';
           wrapper.dataset.template = file;
@@ -237,73 +262,95 @@ function handleDrop(e) {
           wrapper.setAttribute('data-tpl-tooltip', label);
           wrapper.innerHTML = cleaned;
           executeScripts(wrapper);
-          if (applyStoredSettings) applyStoredSettings(wrapper);
+          if (state.applyStoredSettings) state.applyStoredSettings(wrapper);
           addBlockControls(wrapper);
           if (after == null) area.appendChild(wrapper);
           else area.insertBefore(wrapper, after);
-          
-          if (openSettings) openSettings(wrapper);
+
+          if (state.openSettings) state.openSettings(wrapper);
           document.dispatchEvent(new Event('canvasUpdated'));
         });
+      }
+    } else if (state.dragSource) {
+      state.dragSource.classList.remove('dragging');
+      if (after == null) area.appendChild(state.dragSource);
+      else area.insertBefore(state.dragSource, after);
+
+      document.dispatchEvent(new Event('canvasUpdated'));
     }
-  } else if (dragSource) {
-    dragSource.classList.remove('dragging');
-    if (after == null) area.appendChild(dragSource);
-    else area.insertBefore(dragSource, after);
-
-    document.dispatchEvent(new Event('canvasUpdated'));
+    state.placeholder.remove();
+    state.insertionIndicator.remove();
+    area.classList.remove('drag-over');
+    state.dragSource = null;
+    state.fromPalette = false;
   }
-  placeholder.remove();
-  insertionIndicator.remove();
-  area.classList.remove('drag-over');
-  dragSource = null;
-  fromPalette = false;
-}
 
-function handleDragEnd() {
-  placeholder.remove();
-  insertionIndicator.remove();
-  if (dragSource) dragSource.classList.remove('dragging');
-  dragSource = null;
-}
+  function handleDragEnd() {
+    state.placeholder.remove();
+    state.insertionIndicator.remove();
+    if (state.dragSource) state.dragSource.classList.remove('dragging');
+    state.dragSource = null;
+  }
 
-function getDragAfterElement(container, y) {
-  const els = container.querySelectorAll('.block-wrapper:not(.dragging)');
-  let closest = null;
-  let closestOffset = Number.NEGATIVE_INFINITY;
-  for (let i = 0; i < els.length; i++) {
-    const box = els[i].getBoundingClientRect();
-    const offset = y - box.top - box.height / 2;
-    if (offset < 0 && offset > closestOffset) {
-      closestOffset = offset;
-      closest = els[i];
+  function getDragAfterElement(container, y) {
+    const els = container.querySelectorAll('.block-wrapper:not(.dragging)');
+    let closest = null;
+    let closestOffset = Number.NEGATIVE_INFINITY;
+    for (let i = 0; i < els.length; i++) {
+      const box = els[i].getBoundingClientRect();
+      const offset = y - box.top - box.height / 2;
+      if (offset < 0 && offset > closestOffset) {
+        closestOffset = offset;
+        closest = els[i];
+      }
+    }
+    return closest;
+  }
+
+  const throttledDragOver = throttleRAF(handleDragOver);
+  const throttledDrop = throttleRAF(handleDrop);
+
+  function delegateDragEvents(e) {
+    switch (e.type) {
+      case 'dragstart':
+        canvasDragStart(e);
+        break;
+      case 'dragenter':
+        handleDragEnter(e);
+        break;
+      case 'dragleave':
+        handleDragLeave(e);
+        break;
+      case 'dragover':
+        throttledDragOver(e);
+        break;
+      case 'drop':
+        throttledDrop(e);
+        break;
+      case 'dragend':
+        handleDragEnd(e);
+        break;
     }
   }
-  return closest;
-}
 
-const throttledDragOver = throttleRAF(handleDragOver);
-const throttledDrop = throttleRAF(handleDrop);
-
-function delegateDragEvents(e) {
-  switch (e.type) {
-    case 'dragstart':
-      canvasDragStart(e);
-      break;
-    case 'dragenter':
-      handleDragEnter(e);
-      break;
-    case 'dragleave':
-      handleDragLeave(e);
-      break;
-    case 'dragover':
-      throttledDragOver(e);
-      break;
-    case 'drop':
-      throttledDrop(e);
-      break;
-    case 'dragend':
-      handleDragEnd(e);
-      break;
+  function init(initOptions = {}) {
+    setOptions(initOptions);
+    if (state.palette) state.palette.addEventListener('dragstart', paletteDragStart);
+    if (state.canvas) {
+      ['dragstart', 'dragenter', 'dragleave', 'dragover', 'drop', 'dragend'].forEach(
+        (ev) => state.canvas.addEventListener(ev, delegateDragEvents, true)
+      );
+    }
+    setupDropArea(state.canvas);
+    if (state.canvas) {
+      state.canvas.querySelectorAll('.drop-area').forEach(setupDropArea);
+    }
   }
+
+  return {
+    init,
+    setOptions,
+    addBlockControls,
+    setupDropArea,
+  };
 }

--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -1,6 +1,5 @@
 // File: settings.js
 import { ensureBlockState, getSetting, setSetting, getSettings } from './state.js';
-import { addBlockControls } from './dragDrop.js';
 import { executeScripts } from "./executeScripts.js";
 
 let canvas;
@@ -8,6 +7,7 @@ let settingsPanel;
 let settingsContent;
 let savePageFn;
 let renderDebounce;
+let addBlockControlsFn;
 
 const FORMS_SELECT_ATTR = 'data-forms-select';
 let cachedForms = null;
@@ -138,6 +138,7 @@ export function initSettings(options = {}) {
   canvas = options.canvas;
   settingsPanel = options.settingsPanel;
   savePageFn = options.savePage || function () {};
+  addBlockControlsFn = options.addBlockControls;
   if (settingsPanel) {
     settingsContent = settingsPanel.querySelector('.settings-content');
     settingsPanel.addEventListener('click', (e) => {
@@ -394,5 +395,7 @@ function applySettings(template, block) {
     setSetting(block, name, value);
   });
   renderBlock(block);
-  addBlockControls(block);
+  if (typeof addBlockControlsFn === 'function') {
+    addBlockControlsFn(block);
+  }
 }


### PR DESCRIPTION
## Summary
- wrap drag-and-drop logic in a controller factory that owns runtime state and shared drag ghost helper
- update the builder to instantiate the controller, reuse its block control helper, and pass it into settings management
- allow the settings module to use the injected block control callback after applying changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df45f9d0048331a1a9036c18e28f4c