### PR TITLE
Refactor block settings helpers

### DIFF
--- a/liveed/modules/altText.js
+++ b/liveed/modules/altText.js
@@ -1,0 +1,35 @@
+// File: altText.js
+import { getSetting, setSetting } from './state.js';
+
+export function deriveAltText(src) {
+  if (!src) return '';
+  let name = src.split('/').pop();
+  name = name.split('?')[0];
+  name = name.replace(/\.[^/.]+$/, '');
+  name = name.replace(/[-_]+/g, ' ').trim();
+  if (!name) return '';
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+export function suggestAltText(block, {
+  altName = 'custom_alt',
+  srcName = 'custom_src',
+  updateInput = false,
+  panel = null,
+} = {}) {
+  const src = getSetting(block, srcName, '').trim();
+  const alt = getSetting(block, altName, '').trim();
+  const suggestion = deriveAltText(src);
+  if (!suggestion || alt) return suggestion;
+
+  setSetting(block, altName, suggestion);
+
+  if (updateInput && panel) {
+    const input = panel.querySelector(`input[name="${altName}"]`);
+    if (input && !input.value) {
+      input.value = suggestion;
+    }
+  }
+
+  return suggestion;
+}

--- a/liveed/modules/forms.js
+++ b/liveed/modules/forms.js
@@ -1,0 +1,80 @@
+// File: forms.js
+import { getSetting } from './state.js';
+
+const FORMS_SELECT_ATTR = 'data-forms-select';
+let cachedForms = null;
+let formsRequest = null;
+
+function getFormsEndpoint() {
+  const base = (window.builderBase || window.cmsBase || '').replace(/\/$/, '');
+  return (base || '') + '/CMS/modules/forms/list_forms.php';
+}
+
+export function fetchFormsList() {
+  if (cachedForms) return Promise.resolve(cachedForms);
+  if (formsRequest) return formsRequest;
+
+  const endpoint = getFormsEndpoint();
+  formsRequest = fetch(endpoint, { credentials: 'same-origin' })
+    .then((response) => {
+      if (!response.ok) throw new Error('Failed to load forms');
+      return response.json();
+    })
+    .then((data) => {
+      cachedForms = Array.isArray(data) ? data : [];
+      return cachedForms;
+    })
+    .catch(() => {
+      cachedForms = [];
+      return cachedForms;
+    });
+
+  return formsRequest;
+}
+
+export function populateFormsSelects(container, block) {
+  if (!container) return;
+
+  const selects = container.querySelectorAll(`select[${FORMS_SELECT_ATTR}]`);
+  if (!selects.length) return;
+
+  fetchFormsList().then((forms) => {
+    selects.forEach((select) => {
+      const placeholder = select.dataset.placeholder || 'Select a form...';
+      const storedValue = block ? getSetting(block, select.name) : select.value;
+      const fragment = document.createDocumentFragment();
+      const placeholderOption = document.createElement('option');
+      placeholderOption.value = '';
+      placeholderOption.textContent = placeholder;
+      fragment.appendChild(placeholderOption);
+
+      forms.forEach((form) => {
+        if (!form || typeof form !== 'object') return;
+        const option = document.createElement('option');
+        option.value = String(form.id ?? '');
+        option.textContent = form.name || `Form ${form.id}`;
+        fragment.appendChild(option);
+      });
+
+      const previousValue = select.value;
+      select.innerHTML = '';
+      select.appendChild(fragment);
+      const targetValue = storedValue || previousValue || '';
+      if (targetValue) {
+        select.value = targetValue;
+        if (select.value !== targetValue) {
+          const manualOption = document.createElement('option');
+          manualOption.value = targetValue;
+          manualOption.textContent = targetValue;
+          select.appendChild(manualOption);
+          select.value = targetValue;
+        }
+      }
+    });
+  });
+}
+
+export function resetFormsCache() {
+  cachedForms = null;
+  formsRequest = null;
+}

--- a/liveed/modules/templateRender.js
+++ b/liveed/modules/templateRender.js
@@ -1,0 +1,41 @@
+// File: templateRender.js
+export function renderTemplate({
+  originalHTML,
+  templateSetting,
+  settings,
+  readValue,
+}) {
+  if (!templateSetting) {
+    return { html: originalHTML, values: {} };
+  }
+
+  const inputs = templateSetting.querySelectorAll('input[name], textarea[name], select[name]');
+  const processed = new Set();
+  const values = {};
+
+  inputs.forEach((input) => {
+    const { name } = input;
+    if (!name || processed.has(name)) return;
+
+    let value = settings && Object.prototype.hasOwnProperty.call(settings, name)
+      ? settings[name]
+      : undefined;
+
+    if (value === undefined && typeof readValue === 'function') {
+      value = readValue(input, templateSetting);
+    }
+
+    values[name] = value ?? '';
+    processed.add(name);
+  });
+
+  let html = originalHTML;
+  Object.entries(values).forEach(([name, value]) => {
+    const replacement = value ?? '';
+    html = html.split(`{${name}}`).join(replacement);
+  });
+
+  html = html.replace(/<templateSetting[^>]*>[\s\S]*?<\/templateSetting>/i, '');
+
+  return { html, values };
+}


### PR DESCRIPTION
## Summary
- extract form-loading, alt text suggestion, and template rendering helpers into dedicated modules
- streamline settings event handling with reusable input value utilities and centralized render orchestration
- keep block DOM updates localized in renderBlock while preserving autosave and toggle behavior

## Testing
- not run (environment only provides unitless JS modules)


------
https://chatgpt.com/codex/tasks/task_e_68df45fa6a348331b81d6f447abf3ea9