### PR TITLE
Introduce form repository and analytics context

### DIFF
--- a/CMS/modules/forms/FormAnalytics.php
+++ b/CMS/modules/forms/FormAnalytics.php
@@ -1,0 +1,87 @@
+<?php
+// File: FormAnalytics.php
+// Provides aggregated metrics for the forms dashboard.
+
+require_once __DIR__ . '/FormRepository.php';
+
+class FormAnalytics
+{
+    /** @var FormRepository */
+    private $repository;
+
+    /** @var int */
+    private $referenceTime;
+
+    /**
+     * @param FormRepository $repository
+     * @param int|null $referenceTime
+     */
+    public function __construct(FormRepository $repository, ?int $referenceTime = null)
+    {
+        $this->repository = $repository;
+        $this->referenceTime = $referenceTime ?? time();
+    }
+
+    /**
+     * Build the dashboard statistics context used by the view.
+     *
+     * @return array{
+     *     totalForms:int,
+     *     totalSubmissions:int,
+     *     recentSubmissions:int,
+     *     activeForms:int,
+     *     lastSubmissionTimestamp:?int,
+     *     lastSubmissionLabel:string
+     * }
+     */
+    public function getDashboardContext(): array
+    {
+        $forms = $this->repository->getForms();
+        $submissions = $this->repository->getSubmissions();
+
+        $totalForms = count($forms);
+        $totalSubmissions = count($submissions);
+
+        $activeForms = [];
+        $recentSubmissions = 0;
+        $latestSubmission = 0;
+
+        $threshold = $this->referenceTime - (30 * 24 * 60 * 60);
+
+        foreach ($submissions as $submission) {
+            if (!is_array($submission)) {
+                continue;
+            }
+
+            if (isset($submission['form_id'])) {
+                $activeForms[(int) $submission['form_id']] = true;
+            }
+
+            $timestamp = FormRepository::extractTimestamp($submission);
+            if ($timestamp <= 0) {
+                continue;
+            }
+
+            if ($timestamp > $latestSubmission) {
+                $latestSubmission = $timestamp;
+            }
+
+            if ($timestamp >= $threshold) {
+                $recentSubmissions++;
+            }
+        }
+
+        $lastSubmissionLabel = $latestSubmission > 0
+            ? date('M j, Y g:i A', $latestSubmission)
+            : 'No submissions yet';
+
+        return [
+            'totalForms' => $totalForms,
+            'totalSubmissions' => $totalSubmissions,
+            'recentSubmissions' => $recentSubmissions,
+            'activeForms' => count($activeForms),
+            'lastSubmissionTimestamp' => $latestSubmission > 0 ? $latestSubmission : null,
+            'lastSubmissionLabel' => $lastSubmissionLabel,
+        ];
+    }
+}

--- a/CMS/modules/forms/FormRepository.php
+++ b/CMS/modules/forms/FormRepository.php
@@ -1,0 +1,274 @@
+<?php
+// File: FormRepository.php
+// Repository for managing forms and their submissions, including timestamp utilities.
+
+require_once __DIR__ . '/../../includes/data.php';
+
+class FormRepository
+{
+    /** @var string */
+    private $formsFile;
+
+    /** @var string */
+    private $submissionsFile;
+
+    /** @var array<int,array<string,mixed>>|null */
+    private $formsCache = null;
+
+    /** @var array<int,array<string,mixed>>|null */
+    private $submissionsCache = null;
+
+    /**
+     * @param string|null $formsFile
+     * @param string|null $submissionsFile
+     */
+    public function __construct($formsFile = null, $submissionsFile = null)
+    {
+        if ($formsFile === null) {
+            $formsFile = __DIR__ . '/../../data/forms.json';
+        }
+        if ($submissionsFile === null) {
+            $submissionsFile = __DIR__ . '/../../data/form_submissions.json';
+        }
+
+        $this->formsFile = $formsFile;
+        $this->submissionsFile = $submissionsFile;
+
+        $this->ensureStorageFile($this->formsFile);
+        $this->ensureStorageFile($this->submissionsFile);
+    }
+
+    /**
+     * Retrieve all stored forms.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getForms(): array
+    {
+        if ($this->formsCache === null) {
+            $this->formsCache = $this->loadCollection($this->formsFile);
+        }
+
+        return $this->formsCache;
+    }
+
+    /**
+     * Retrieve all stored submissions, optionally filtered by form ID.
+     *
+     * @param int|null $formId
+     * @return array<int,array<string,mixed>>
+     */
+    public function getSubmissions(?int $formId = null): array
+    {
+        if ($this->submissionsCache === null) {
+            $this->submissionsCache = $this->loadCollection($this->submissionsFile);
+        }
+
+        if ($formId === null) {
+            return $this->submissionsCache;
+        }
+
+        $formId = (int) $formId;
+        if ($formId <= 0) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $this->submissionsCache,
+            static function ($submission) use ($formId) {
+                return is_array($submission) && isset($submission['form_id']) && (int) $submission['form_id'] === $formId;
+            }
+        ));
+    }
+
+    /**
+     * Persist the provided forms dataset.
+     *
+     * @param array<int,array<string,mixed>> $forms
+     * @return void
+     */
+    public function saveForms(array $forms): void
+    {
+        $normalized = $this->filterArrayCollection($forms);
+        write_json_file($this->formsFile, $normalized);
+        $this->formsCache = $normalized;
+    }
+
+    /**
+     * Persist the provided submissions dataset.
+     *
+     * @param array<int,array<string,mixed>> $submissions
+     * @return void
+     */
+    public function saveSubmissions(array $submissions): void
+    {
+        $normalized = $this->filterArrayCollection($submissions);
+        write_json_file($this->submissionsFile, $normalized);
+        $this->submissionsCache = $normalized;
+    }
+
+    /**
+     * Retrieve submissions normalized for API responses.
+     *
+     * @param int|null $formId
+     * @return array<int,array<string,mixed>>
+     */
+    public function getNormalizedSubmissions(?int $formId = null): array
+    {
+        $submissions = $this->getSubmissions($formId);
+
+        usort($submissions, static function ($a, $b) {
+            $left = is_array($a) ? self::extractTimestamp($a) : 0;
+            $right = is_array($b) ? self::extractTimestamp($b) : 0;
+            return $right <=> $left;
+        });
+
+        $normalized = [];
+        foreach ($submissions as $submission) {
+            if (!is_array($submission)) {
+                continue;
+            }
+            $normalized[] = $this->normalizeSubmissionRecord($submission);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Extract the best timestamp candidate from a submission-like entry.
+     *
+     * @param array<string,mixed> $entry
+     * @return int
+     */
+    public static function extractTimestamp(array $entry): int
+    {
+        $candidates = ['submitted_at', 'created_at', 'timestamp'];
+        foreach ($candidates as $key) {
+            if (!array_key_exists($key, $entry)) {
+                continue;
+            }
+            $value = $entry[$key];
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            if (is_numeric($value)) {
+                $numeric = (float) $value;
+                if ($numeric <= 0) {
+                    continue;
+                }
+                if ($numeric < 1_000_000_000_000) {
+                    return (int) round($numeric);
+                }
+                return (int) round($numeric / 1000);
+            }
+
+            $time = strtotime((string) $value);
+            if ($time !== false) {
+                return $time;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Normalize a persisted submission for API consumption.
+     *
+     * @param array<string,mixed> $submission
+     * @return array<string,mixed>
+     */
+    private function normalizeSubmissionRecord(array $submission): array
+    {
+        $normalized = [
+            'id' => $submission['id'] ?? null,
+            'form_id' => isset($submission['form_id']) ? (int) $submission['form_id'] : null,
+        ];
+
+        $data = $submission['data'] ?? [];
+        if (!is_array($data)) {
+            $data = [];
+        }
+        $normalized['data'] = (object) $data;
+
+        $meta = $submission['meta'] ?? [];
+        if (!is_array($meta)) {
+            $meta = [];
+        }
+        if (isset($submission['ip']) && !isset($meta['ip'])) {
+            $meta['ip'] = $submission['ip'];
+        }
+        $normalized['meta'] = (object) $meta;
+
+        $timestamp = self::extractTimestamp($submission);
+        if ($timestamp > 0) {
+            $normalized['submitted_at'] = date(DATE_ATOM, $timestamp);
+        } else {
+            $fallback = null;
+            foreach (['submitted_at', 'created_at', 'timestamp'] as $key) {
+                if (!empty($submission[$key])) {
+                    $fallback = (string) $submission[$key];
+                    break;
+                }
+            }
+            $normalized['submitted_at'] = $fallback;
+        }
+
+        if (isset($submission['source'])) {
+            $normalized['source'] = $submission['source'];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Ensure the storage file and parent directory exist.
+     *
+     * @param string $path
+     * @return void
+     */
+    private function ensureStorageFile(string $path): void
+    {
+        $directory = dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+        if (!file_exists($path)) {
+            write_json_file($path, []);
+        }
+    }
+
+    /**
+     * Load a collection of array entries from disk.
+     *
+     * @param string $path
+     * @return array<int,array<string,mixed>>
+     */
+    private function loadCollection(string $path): array
+    {
+        $data = read_json_file($path);
+        if (!is_array($data)) {
+            return [];
+        }
+
+        return $this->filterArrayCollection($data);
+    }
+
+    /**
+     * Filter a mixed dataset down to array entries only.
+     *
+     * @param array<int,mixed> $items
+     * @return array<int,array<string,mixed>>
+     */
+    private function filterArrayCollection(array $items): array
+    {
+        $filtered = [];
+        foreach ($items as $item) {
+            if (is_array($item)) {
+                $filtered[] = $item;
+            }
+        }
+
+        return $filtered;
+    }
+}

--- a/CMS/modules/forms/list_submissions.php
+++ b/CMS/modules/forms/list_submissions.php
@@ -2,99 +2,16 @@
 // File: list_submissions.php
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/FormRepository.php';
 require_login();
 
 $formId = isset($_GET['form_id']) ? (int)$_GET['form_id'] : null;
-$submissionsFile = __DIR__ . '/../../data/form_submissions.json';
-$submissions = read_json_file($submissionsFile);
-
-if (!is_array($submissions)) {
-    $submissions = [];
+$repository = new FormRepository();
+if ($formId !== null && $formId <= 0) {
+    $formId = null;
 }
 
-if ($formId) {
-    $submissions = array_values(array_filter($submissions, function ($submission) use ($formId) {
-        if (!is_array($submission)) {
-            return false;
-        }
-        if (!isset($submission['form_id'])) {
-            return false;
-        }
-        return (int)$submission['form_id'] === $formId;
-    }));
-} else {
-    $submissions = array_values(array_filter($submissions, 'is_array'));
-}
-
-$extractTimestamp = function (array $entry): int {
-    $candidates = ['submitted_at', 'created_at', 'timestamp'];
-    foreach ($candidates as $key) {
-        if (empty($entry[$key])) {
-            continue;
-        }
-        $value = $entry[$key];
-        if (is_numeric($value)) {
-            $value = (float) $value;
-            if ($value > 0) {
-                return $value < 1_000_000_000_000 ? (int) round($value) : (int) round($value / 1000);
-            }
-            continue;
-        }
-        $time = strtotime((string) $value);
-        if ($time !== false) {
-            return $time;
-        }
-    }
-    return 0;
-};
-
-usort($submissions, function ($a, $b) use ($extractTimestamp) {
-    return $extractTimestamp($b) <=> $extractTimestamp($a);
-});
-
-$normalized = array_map(function ($submission) use ($extractTimestamp) {
-    $normalized = [
-        'id' => $submission['id'] ?? null,
-        'form_id' => isset($submission['form_id']) ? (int) $submission['form_id'] : null,
-    ];
-
-    $data = $submission['data'] ?? [];
-    if (!is_array($data)) {
-        $data = [];
-    }
-    $normalized['data'] = (object) $data;
-
-    $meta = $submission['meta'] ?? [];
-    if (!is_array($meta)) {
-        $meta = [];
-    }
-
-    if (isset($submission['ip']) && !isset($meta['ip'])) {
-        $meta['ip'] = $submission['ip'];
-    }
-
-    $normalized['meta'] = (object) $meta;
-
-    $timestamp = $extractTimestamp($submission);
-    if ($timestamp > 0) {
-        $normalized['submitted_at'] = date(DATE_ATOM, $timestamp);
-    } else {
-        $fallback = null;
-        foreach (['submitted_at', 'created_at', 'timestamp'] as $key) {
-            if (!empty($submission[$key])) {
-                $fallback = (string) $submission[$key];
-                break;
-            }
-        }
-        $normalized['submitted_at'] = $fallback;
-    }
-
-    if (isset($submission['source'])) {
-        $normalized['source'] = $submission['source'];
-    }
-
-    return $normalized;
-}, $submissions);
+$normalized = $repository->getNormalizedSubmissions($formId);
 
 header('Content-Type: application/json');
 echo json_encode($normalized, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/tests/forms_repository_test.php
+++ b/tests/forms_repository_test.php
@@ -1,0 +1,121 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/forms/FormRepository.php';
+require_once __DIR__ . '/../CMS/modules/forms/FormAnalytics.php';
+
+$formsFile = tempnam(sys_get_temp_dir(), 'forms');
+$submissionsFile = tempnam(sys_get_temp_dir(), 'submissions');
+
+if ($formsFile === false || $submissionsFile === false) {
+    throw new RuntimeException('Unable to create temporary dataset.');
+}
+
+$formsFixture = [
+    ['id' => 10, 'name' => 'Contact'],
+    ['id' => 11, 'name' => 'Support'],
+];
+
+$submissionsFixture = [
+    [
+        'id' => 1,
+        'form_id' => 10,
+        'submitted_at' => '2024-01-15T12:00:00Z',
+        'data' => ['email' => 'one@example.com'],
+        'meta' => ['user_agent' => 'Mozilla'],
+    ],
+    [
+        'id' => 2,
+        'form_id' => 10,
+        'created_at' => 1705600000000,
+        'data' => ['email' => 'two@example.com'],
+        'meta' => ['ip' => '10.0.0.2'],
+    ],
+    [
+        'id' => 3,
+        'form_id' => 10,
+        'timestamp' => 1703000000,
+        'ip' => '203.0.113.5',
+        'source' => 'Landing page',
+    ],
+    [
+        'id' => 4,
+        'form_id' => 10,
+        'submitted_at' => 'not-a-date',
+        'data' => ['email' => 'invalid@example.com'],
+    ],
+    [
+        'id' => 5,
+        'form_id' => 99,
+        'submitted_at' => '2023-12-01T00:00:00Z',
+    ],
+];
+
+$repository = new FormRepository($formsFile, $submissionsFile);
+$repository->saveForms($formsFixture);
+$repository->saveSubmissions($submissionsFixture);
+
+$normalized = $repository->getNormalizedSubmissions(10);
+
+if (count($normalized) !== 4) {
+    throw new RuntimeException('Filtered submissions should include four entries.');
+}
+
+if ($normalized[0]['id'] !== 2) {
+    throw new RuntimeException('Submissions should be sorted by most recent timestamp.');
+}
+
+if ($normalized[0]['submitted_at'] !== date(DATE_ATOM, 1705600000)) {
+    throw new RuntimeException('Millisecond timestamps should normalize to seconds and ISO 8601.');
+}
+
+if (!($normalized[0]['data'] instanceof stdClass)) {
+    throw new RuntimeException('Submission data should be converted to an object.');
+}
+
+if (!($normalized[0]['meta'] instanceof stdClass)) {
+    throw new RuntimeException('Submission meta should be converted to an object.');
+}
+
+if (!property_exists($normalized[2]['meta'], 'ip') || $normalized[2]['meta']->ip !== '203.0.113.5') {
+    throw new RuntimeException('Standalone IP addresses should be merged into the meta payload.');
+}
+
+if ($normalized[3]['submitted_at'] !== 'not-a-date') {
+    throw new RuntimeException('Unparseable timestamps should retain their original value.');
+}
+
+$allNormalized = $repository->getNormalizedSubmissions();
+if (count($allNormalized) !== 5) {
+    throw new RuntimeException('Requesting all submissions should include every record.');
+}
+
+$analytics = new FormAnalytics($repository, 1706000000);
+$context = $analytics->getDashboardContext();
+
+if ($context['totalForms'] !== 2) {
+    throw new RuntimeException('Total forms count is incorrect.');
+}
+
+if ($context['totalSubmissions'] !== 5) {
+    throw new RuntimeException('Total submissions count is incorrect.');
+}
+
+if ($context['recentSubmissions'] !== 2) {
+    throw new RuntimeException('Recent submissions count should include entries within 30 days.');
+}
+
+if ($context['activeForms'] !== 2) {
+    throw new RuntimeException('Active forms should match the number of unique form IDs with submissions.');
+}
+
+if ($context['lastSubmissionTimestamp'] !== 1705600000) {
+    throw new RuntimeException('Last submission timestamp did not match the latest entry.');
+}
+
+if ($context['lastSubmissionLabel'] !== date('M j, Y g:i A', 1705600000)) {
+    throw new RuntimeException('Last submission label should use a friendly formatted date.');
+}
+
+unlink($formsFile);
+unlink($submissionsFile);
+
+echo "FormRepository and FormAnalytics tests passed\n";


### PR DESCRIPTION
## Summary
- add a FormRepository for loading/saving form definitions and submissions with shared timestamp handling
- compute dashboard metrics through a new FormAnalytics service and update the forms view to consume it
- reuse the repository normalization from list_submissions and cover normalization plus analytics with tests

## Testing
- php tests/forms_repository_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df49b71308833182d63fc28b3d9d33