### PR TITLE
Refactor import/export module around manager class

### DIFF
--- a/CMS/modules/import_export/ImportExportManager.php
+++ b/CMS/modules/import_export/ImportExportManager.php
@@ -1,0 +1,432 @@
+<?php
+// File: ImportExportManager.php
+
+require_once __DIR__ . '/../../includes/data.php';
+
+class ImportExportManager
+{
+    private string $dataDir;
+    private string $statsFile;
+    private array $datasetMap;
+    private array $datasetMetadata;
+    private int $historyLimit;
+
+    public function __construct(?string $dataDir = null, ?array $datasetMap = null, ?array $datasetMetadata = null, int $historyLimit = 20)
+    {
+        $this->dataDir = $dataDir !== null ? $this->resolvePath($dataDir) : $this->resolvePath(__DIR__ . '/../../data');
+        $this->statsFile = $this->dataDir . '/import_export_status.json';
+        $this->datasetMap = $datasetMap ?? $this->getDefaultDatasetMap();
+        $this->datasetMetadata = $datasetMetadata ?? $this->getDefaultDatasetMetadata();
+        $this->historyLimit = $historyLimit > 0 ? $historyLimit : 20;
+    }
+
+    public function getDataDir(): string
+    {
+        return $this->dataDir;
+    }
+
+    public function getStatsFile(): string
+    {
+        return $this->statsFile;
+    }
+
+    public function getDatasetMap(): array
+    {
+        return $this->datasetMap;
+    }
+
+    public function getDatasetMetadata(): array
+    {
+        return $this->datasetMetadata;
+    }
+
+    public function getDatasetFilename(string $key): ?string
+    {
+        return $this->datasetMap[$key] ?? null;
+    }
+
+    public function getAvailableDatasets(bool $includeDrafts = true): array
+    {
+        $datasets = array_keys($this->datasetMap);
+
+        if ($includeDrafts && $this->hasDrafts()) {
+            $datasets[] = 'drafts';
+        }
+
+        return $datasets;
+    }
+
+    public function getDatasetDetails(array $datasetKeys): array
+    {
+        $details = [];
+        foreach ($datasetKeys as $key) {
+            $meta = $this->datasetMetadata[$key] ?? [];
+            $details[] = [
+                'key' => $key,
+                'label' => isset($meta['label']) ? (string) $meta['label'] : $this->formatDatasetLabel($key),
+                'description' => isset($meta['description']) ? (string) $meta['description'] : '',
+            ];
+        }
+
+        return $details;
+    }
+
+    public function collectExportDatasets(): array
+    {
+        $datasets = [];
+        foreach ($this->datasetMap as $key => $filename) {
+            $datasets[$key] = read_json_file($this->dataDir . '/' . $filename);
+        }
+
+        $drafts = $this->readDrafts();
+        if (!empty($drafts)) {
+            $datasets['drafts'] = $drafts;
+        }
+
+        return $datasets;
+    }
+
+    public function importDatasets(array $datasets): array
+    {
+        $this->ensureDirectory($this->dataDir);
+
+        $importedKeys = [];
+        foreach ($this->datasetMap as $key => $filename) {
+            if (!array_key_exists($key, $datasets)) {
+                continue;
+            }
+
+            $path = $this->dataDir . '/' . $filename;
+            if (write_json_file($path, $datasets[$key]) === false) {
+                throw new RuntimeException('Failed to update the ' . $this->formatDatasetLabel($key) . ' data set.');
+            }
+            $importedKeys[] = $key;
+        }
+
+        if (array_key_exists('drafts', $datasets)) {
+            $draftData = is_array($datasets['drafts']) ? $datasets['drafts'] : [];
+            $this->writeDrafts($draftData);
+            $importedKeys[] = 'drafts';
+        }
+
+        return array_values(array_unique($importedKeys));
+    }
+
+    public function readStats(): array
+    {
+        $stats = read_json_file($this->statsFile);
+        return is_array($stats) ? $stats : [];
+    }
+
+    public function writeStats(array $stats): bool
+    {
+        $this->ensureDirectory($this->dataDir);
+        return write_json_file($this->statsFile, $stats) !== false;
+    }
+
+    public function appendHistoryEntry(array $stats, array $entry, ?int $limit = null): array
+    {
+        if (!isset($stats['history']) || !is_array($stats['history'])) {
+            $stats['history'] = [];
+        }
+
+        array_unshift($stats['history'], $this->normalizeHistoryEntry($entry));
+
+        $limit = $limit ?? $this->historyLimit;
+        if ($limit > 0 && count($stats['history']) > $limit) {
+            $stats['history'] = array_slice($stats['history'], 0, $limit);
+        }
+
+        return $stats;
+    }
+
+    public function recordExport(string $filename, int $datasetCount): bool
+    {
+        $timestamp = gmdate('c');
+        $stats = $this->readStats();
+        $stats['last_export_at'] = $timestamp;
+        $stats['last_export_file'] = $filename;
+        $stats['export_count'] = isset($stats['export_count']) ? (int) $stats['export_count'] + 1 : 1;
+
+        $stats = $this->appendHistoryEntry($stats, [
+            'type' => 'export',
+            'timestamp' => $timestamp,
+            'label' => 'Export generated',
+            'summary' => $filename . ' • ' . $this->formatDatasetCountLabel($datasetCount),
+            'file' => $filename,
+            'dataset_count' => $datasetCount,
+        ]);
+
+        return $this->writeStats($stats);
+    }
+
+    public function recordImport(string $filename, int $datasetCount, array $meta = []): bool
+    {
+        $timestamp = gmdate('c');
+        $stats = $this->readStats();
+
+        $stats['last_import_at'] = $timestamp;
+        $stats['last_import_file'] = $filename;
+
+        if (isset($meta['available_profiles'])) {
+            $stats['available_profiles'] = (int) $meta['available_profiles'];
+        }
+
+        $summaryParts = [];
+        if ($filename !== '') {
+            $summaryParts[] = $filename;
+        }
+
+        if ($datasetCount > 0) {
+            $summaryParts[] = $this->formatDatasetCountLabel($datasetCount);
+        }
+
+        if (isset($meta['site_name']) && (string) $meta['site_name'] !== '') {
+            $summaryParts[] = (string) $meta['site_name'];
+        }
+
+        $stats = $this->appendHistoryEntry($stats, [
+            'type' => 'import',
+            'timestamp' => $timestamp,
+            'label' => 'Import completed',
+            'summary' => implode(' • ', $summaryParts),
+            'file' => $filename,
+            'dataset_count' => $datasetCount,
+        ]);
+
+        return $this->writeStats($stats);
+    }
+
+    public function getHistory(?array $stats = null): array
+    {
+        $stats = $stats ?? $this->readStats();
+        if (!isset($stats['history']) || !is_array($stats['history'])) {
+            return [];
+        }
+
+        $history = [];
+        foreach ($stats['history'] as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            $history[] = $this->normalizeHistoryEntry($entry);
+        }
+
+        return $history;
+    }
+
+    public function formatDatasetLabel(string $key): string
+    {
+        if ($key === '') {
+            return '';
+        }
+
+        $parts = preg_split('/[_\s]+/', $key);
+        if ($parts === false) {
+            return $key;
+        }
+
+        $labelParts = array_map(static function ($part) {
+            $part = strtolower((string) $part);
+            return $part !== '' ? ucfirst($part) : $part;
+        }, $parts);
+
+        return trim(implode(' ', $labelParts));
+    }
+
+    public function formatDatasetCountLabel(int $count): string
+    {
+        if ($count === 1) {
+            return '1 data set';
+        }
+
+        return number_format(max($count, 0)) . ' data sets';
+    }
+
+    public function sanitizeDatasetKey(string $key): string
+    {
+        $sanitized = preg_replace('/[^A-Za-z0-9_-]+/', '-', $key);
+        if ($sanitized === null) {
+            $sanitized = $key;
+        }
+
+        $sanitized = trim($sanitized, '-_');
+
+        return $sanitized;
+    }
+
+    public function hasDrafts(): bool
+    {
+        $draftsDir = $this->getDraftsDir();
+        if (!is_dir($draftsDir)) {
+            return false;
+        }
+
+        $draftFiles = glob($draftsDir . '/*.json');
+        return $draftFiles !== false && count($draftFiles) > 0;
+    }
+
+    public function getDraftsDir(): string
+    {
+        return $this->dataDir . '/drafts';
+    }
+
+    private function resolvePath(string $path): string
+    {
+        $resolved = realpath($path);
+        return $resolved !== false ? $resolved : rtrim($path, '/');
+    }
+
+    private function ensureDirectory(string $directory): void
+    {
+        if (is_dir($directory)) {
+            return;
+        }
+
+        if (!mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new RuntimeException('Unable to prepare the data directory for import.');
+        }
+    }
+
+    private function readDrafts(): array
+    {
+        $draftsDir = $this->getDraftsDir();
+        if (!is_dir($draftsDir)) {
+            return [];
+        }
+
+        $draftFiles = glob($draftsDir . '/*.json');
+        if ($draftFiles === false || count($draftFiles) === 0) {
+            return [];
+        }
+
+        $drafts = [];
+        foreach ($draftFiles as $draftFile) {
+            $drafts[basename($draftFile, '.json')] = read_json_file($draftFile);
+        }
+
+        return $drafts;
+    }
+
+    private function writeDrafts(array $drafts): void
+    {
+        $draftsDir = $this->getDraftsDir();
+        $this->ensureDirectory($draftsDir);
+
+        $existingDrafts = glob($draftsDir . '/*.json');
+        if ($existingDrafts !== false) {
+            foreach ($existingDrafts as $draftFile) {
+                if (is_file($draftFile)) {
+                    @unlink($draftFile);
+                }
+            }
+        }
+
+        foreach ($drafts as $draftKey => $draftValue) {
+            $safeKey = $this->sanitizeDatasetKey((string) $draftKey);
+            if ($safeKey === '') {
+                continue;
+            }
+
+            $draftPath = $draftsDir . '/' . $safeKey . '.json';
+            if (write_json_file($draftPath, $draftValue) === false) {
+                throw new RuntimeException('Failed to update draft content during import.');
+            }
+        }
+    }
+
+    private function normalizeHistoryEntry(array $entry): array
+    {
+        $type = isset($entry['type']) && (string) $entry['type'] !== '' ? (string) $entry['type'] : 'activity';
+
+        $label = 'Activity recorded';
+        if (isset($entry['label']) && trim((string) $entry['label']) !== '') {
+            $label = (string) $entry['label'];
+        } elseif ($type === 'import') {
+            $label = 'Import completed';
+        } elseif ($type === 'export') {
+            $label = 'Export completed';
+        }
+
+        $timestamp = isset($entry['timestamp']) && (string) $entry['timestamp'] !== '' ? (string) $entry['timestamp'] : null;
+        $summary = isset($entry['summary']) ? (string) $entry['summary'] : '';
+        $file = isset($entry['file']) && (string) $entry['file'] !== '' ? (string) $entry['file'] : null;
+        $datasetCount = isset($entry['dataset_count']) ? (int) $entry['dataset_count'] : null;
+
+        return [
+            'type' => $type,
+            'timestamp' => $timestamp,
+            'label' => $label,
+            'summary' => $summary,
+            'file' => $file,
+            'dataset_count' => $datasetCount,
+        ];
+    }
+
+    private function getDefaultDatasetMap(): array
+    {
+        return [
+            'settings' => 'settings.json',
+            'pages' => 'pages.json',
+            'page_history' => 'page_history.json',
+            'menus' => 'menus.json',
+            'media' => 'media.json',
+            'blog_posts' => 'blog_posts.json',
+            'forms' => 'forms.json',
+            'form_submissions' => 'form_submissions.json',
+            'users' => 'users.json',
+            'speed_snapshot' => 'speed_snapshot.json',
+        ];
+    }
+
+    private function getDefaultDatasetMetadata(): array
+    {
+        return [
+            'settings' => [
+                'label' => 'Site settings',
+                'description' => 'Site-wide configuration such as the site name, metadata, themes, and integrations.',
+            ],
+            'pages' => [
+                'label' => 'Pages',
+                'description' => 'Published page content, layouts, SEO fields, and routing information.',
+            ],
+            'page_history' => [
+                'label' => 'Page history',
+                'description' => 'Revision history for pages, enabling rollbacks to previous versions.',
+            ],
+            'menus' => [
+                'label' => 'Navigation menus',
+                'description' => 'Menu structures, links, and hierarchy used throughout the site.',
+            ],
+            'media' => [
+                'label' => 'Media library',
+                'description' => 'Records for uploaded images, documents, and other media assets.',
+            ],
+            'blog_posts' => [
+                'label' => 'Blog posts',
+                'description' => 'Blog post articles, metadata, authorship, and publishing status.',
+            ],
+            'forms' => [
+                'label' => 'Forms',
+                'description' => 'Form definitions including fields, validations, and notification settings.',
+            ],
+            'form_submissions' => [
+                'label' => 'Form submissions',
+                'description' => 'Entries submitted through site forms with captured response data.',
+            ],
+            'users' => [
+                'label' => 'Users',
+                'description' => 'User accounts, roles, and access permissions for the CMS.',
+            ],
+            'speed_snapshot' => [
+                'label' => 'Speed snapshots',
+                'description' => 'Performance metrics collected from site speed monitoring tools.',
+            ],
+            'drafts' => [
+                'label' => 'Draft content',
+                'description' => 'Unpublished draft items stored for future editing or review.',
+            ],
+        ];
+    }
+}

--- a/CMS/modules/import_export/export.php
+++ b/CMS/modules/import_export/export.php
@@ -1,14 +1,12 @@
 <?php
 // File: export.php
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/settings.php';
-require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/ImportExportManager.php';
 
 require_login();
 
-$dataDir = import_export_get_data_dir();
-$datasetMap = import_export_get_dataset_map();
+$manager = new ImportExportManager();
 
 $export = [
     'meta' => [
@@ -23,22 +21,7 @@ if (!empty($settings['site_name'])) {
     $export['meta']['site_name'] = (string) $settings['site_name'];
 }
 
-foreach ($datasetMap as $key => $filename) {
-    $path = $dataDir . '/' . $filename;
-    $export['data'][$key] = read_json_file($path);
-}
-
-$draftsDir = $dataDir . '/drafts';
-if (is_dir($draftsDir)) {
-    $draftFiles = glob($draftsDir . '/*.json');
-    if ($draftFiles !== false && count($draftFiles) > 0) {
-        $drafts = [];
-        foreach ($draftFiles as $draftFile) {
-            $drafts[basename($draftFile, '.json')] = read_json_file($draftFile);
-        }
-        $export['data']['drafts'] = $drafts;
-    }
-}
+$export['data'] = $manager->collectExportDatasets();
 
 $export['meta']['dataset_count'] = count($export['data']);
 $export['meta']['datasets'] = array_keys($export['data']);
@@ -53,24 +36,8 @@ if ($json === false) {
 
 $filename = 'sparkcms-export-' . date('Ymd-His') . '.json';
 
-$statsFile = import_export_get_stats_file();
-$stats = read_json_file($statsFile);
-if (!is_array($stats)) {
-    $stats = [];
-}
-$stats['last_export_at'] = gmdate('c');
-$stats['last_export_file'] = $filename;
-$stats['export_count'] = isset($stats['export_count']) ? (int) $stats['export_count'] + 1 : 1;
 $datasetCount = isset($export['meta']['dataset_count']) ? (int) $export['meta']['dataset_count'] : 0;
-$stats = import_export_append_history_entry($stats, [
-    'type' => 'export',
-    'timestamp' => $stats['last_export_at'],
-    'label' => 'Export generated',
-    'summary' => $filename . ' • ' . import_export_format_dataset_count_label($datasetCount),
-    'file' => $filename,
-    'dataset_count' => $datasetCount,
-]);
-write_json_file($statsFile, $stats);
+$manager->recordExport($filename, $datasetCount);
 
 header('Content-Type: application/json; charset=UTF-8');
 header('Content-Disposition: attachment; filename="' . $filename . '"');

--- a/CMS/modules/import_export/helpers.php
+++ b/CMS/modules/import_export/helpers.php
@@ -1,137 +1,66 @@
 <?php
 // File: helpers.php
 
+require_once __DIR__ . '/ImportExportManager.php';
+
+if (!function_exists('import_export_manager')) {
+    function import_export_manager(): ImportExportManager
+    {
+        static $manager = null;
+
+        if ($manager === null) {
+            $manager = new ImportExportManager();
+        }
+
+        return $manager;
+    }
+}
+
 if (!function_exists('import_export_get_data_dir')) {
     function import_export_get_data_dir(): string
     {
-        $path = __DIR__ . '/../../data';
-        $resolved = realpath($path);
-        return $resolved !== false ? $resolved : $path;
+        return import_export_manager()->getDataDir();
     }
 }
 
 if (!function_exists('import_export_get_dataset_map')) {
     function import_export_get_dataset_map(): array
     {
-        return [
-            'settings' => 'settings.json',
-            'pages' => 'pages.json',
-            'page_history' => 'page_history.json',
-            'menus' => 'menus.json',
-            'media' => 'media.json',
-            'blog_posts' => 'blog_posts.json',
-            'forms' => 'forms.json',
-            'form_submissions' => 'form_submissions.json',
-            'users' => 'users.json',
-            'speed_snapshot' => 'speed_snapshot.json',
-        ];
+        return import_export_manager()->getDatasetMap();
     }
 }
 
 if (!function_exists('import_export_get_dataset_metadata')) {
     function import_export_get_dataset_metadata(): array
     {
-        return [
-            'settings' => [
-                'label' => 'Site settings',
-                'description' => 'Site-wide configuration such as the site name, metadata, themes, and integrations.',
-            ],
-            'pages' => [
-                'label' => 'Pages',
-                'description' => 'Published page content, layouts, SEO fields, and routing information.',
-            ],
-            'page_history' => [
-                'label' => 'Page history',
-                'description' => 'Revision history for pages, enabling rollbacks to previous versions.',
-            ],
-            'menus' => [
-                'label' => 'Navigation menus',
-                'description' => 'Menu structures, links, and hierarchy used throughout the site.',
-            ],
-            'media' => [
-                'label' => 'Media library',
-                'description' => 'Records for uploaded images, documents, and other media assets.',
-            ],
-            'blog_posts' => [
-                'label' => 'Blog posts',
-                'description' => 'Blog post articles, metadata, authorship, and publishing status.',
-            ],
-            'forms' => [
-                'label' => 'Forms',
-                'description' => 'Form definitions including fields, validations, and notification settings.',
-            ],
-            'form_submissions' => [
-                'label' => 'Form submissions',
-                'description' => 'Entries submitted through site forms with captured response data.',
-            ],
-            'users' => [
-                'label' => 'Users',
-                'description' => 'User accounts, roles, and access permissions for the CMS.',
-            ],
-            'speed_snapshot' => [
-                'label' => 'Speed snapshots',
-                'description' => 'Performance metrics collected from site speed monitoring tools.',
-            ],
-            'drafts' => [
-                'label' => 'Draft content',
-                'description' => 'Unpublished draft items stored for future editing or review.',
-            ],
-        ];
+        return import_export_manager()->getDatasetMetadata();
     }
 }
 
 if (!function_exists('import_export_format_dataset_label')) {
     function import_export_format_dataset_label(string $key): string
     {
-        if ($key === '') {
-            return '';
-        }
-
-        $parts = preg_split('/[_\s]+/', $key);
-        if ($parts === false) {
-            return $key;
-        }
-
-        $labelParts = array_map(static function ($part) {
-            $part = strtolower((string) $part);
-            return $part !== '' ? ucfirst($part) : $part;
-        }, $parts);
-
-        return trim(implode(' ', $labelParts));
+        return import_export_manager()->formatDatasetLabel($key);
     }
 }
 
 if (!function_exists('import_export_get_stats_file')) {
     function import_export_get_stats_file(): string
     {
-        return import_export_get_data_dir() . '/import_export_status.json';
+        return import_export_manager()->getStatsFile();
     }
 }
 
 if (!function_exists('import_export_format_dataset_count_label')) {
     function import_export_format_dataset_count_label(int $count): string
     {
-        if ($count === 1) {
-            return '1 data set';
-        }
-
-        return number_format(max($count, 0)) . ' data sets';
+        return import_export_manager()->formatDatasetCountLabel($count);
     }
 }
 
 if (!function_exists('import_export_append_history_entry')) {
     function import_export_append_history_entry(array $stats, array $entry, int $maxEntries = 20): array
     {
-        if (!isset($stats['history']) || !is_array($stats['history'])) {
-            $stats['history'] = [];
-        }
-
-        array_unshift($stats['history'], $entry);
-
-        if ($maxEntries > 0 && count($stats['history']) > $maxEntries) {
-            $stats['history'] = array_slice($stats['history'], 0, $maxEntries);
-        }
-
-        return $stats;
+        return import_export_manager()->appendHistoryEntry($stats, $entry, $maxEntries);
     }
 }

--- a/CMS/modules/import_export/import.php
+++ b/CMS/modules/import_export/import.php
@@ -1,8 +1,7 @@
 <?php
 // File: import.php
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
-require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/ImportExportManager.php';
 
 require_login();
 
@@ -79,68 +78,14 @@ if (!isset($data['data']) || !is_array($data['data'])) {
 }
 
 $datasets = $data['data'];
-$dataDir = import_export_get_data_dir();
-if (!is_dir($dataDir)) {
-    if (!mkdir($dataDir, 0775, true) && !is_dir($dataDir)) {
-        http_response_code(500);
-        echo json_encode(['error' => 'Unable to prepare the data directory for import.']);
-        exit;
-    }
-}
+$manager = new ImportExportManager();
 
-$datasetMap = import_export_get_dataset_map();
-$importedKeys = [];
-
-foreach ($datasetMap as $key => $filename) {
-    if (!array_key_exists($key, $datasets)) {
-        continue;
-    }
-
-    $path = $dataDir . '/' . $filename;
-    if (write_json_file($path, $datasets[$key]) === false) {
-        http_response_code(500);
-        echo json_encode(['error' => 'Failed to update the ' . import_export_format_dataset_label($key) . ' data set.']);
-        exit;
-    }
-    $importedKeys[] = $key;
-}
-
-$draftsDir = $dataDir . '/drafts';
-if (array_key_exists('drafts', $datasets)) {
-    $drafts = is_array($datasets['drafts']) ? $datasets['drafts'] : [];
-
-    if (!is_dir($draftsDir)) {
-        if (!mkdir($draftsDir, 0775, true) && !is_dir($draftsDir)) {
-            http_response_code(500);
-            echo json_encode(['error' => 'Unable to prepare the drafts directory for import.']);
-            exit;
-        }
-    }
-
-    $existingDrafts = glob($draftsDir . '/*.json');
-    if ($existingDrafts !== false) {
-        foreach ($existingDrafts as $draftFile) {
-            if (is_file($draftFile)) {
-                @unlink($draftFile);
-            }
-        }
-    }
-
-    foreach ($drafts as $draftKey => $draftValue) {
-        $safeKey = preg_replace('/[^A-Za-z0-9_-]+/', '-', (string) $draftKey);
-        $safeKey = trim($safeKey, '-_');
-        if ($safeKey === '') {
-            continue;
-        }
-        $draftPath = $draftsDir . '/' . $safeKey . '.json';
-        if (write_json_file($draftPath, $draftValue) === false) {
-            http_response_code(500);
-            echo json_encode(['error' => 'Failed to update draft content during import.']);
-            exit;
-        }
-    }
-
-    $importedKeys[] = 'drafts';
+try {
+    $importedKeys = $manager->importDatasets($datasets);
+} catch (RuntimeException $exception) {
+    http_response_code(500);
+    echo json_encode(['error' => $exception->getMessage()]);
+    exit;
 }
 
 if (empty($importedKeys)) {
@@ -149,46 +94,16 @@ if (empty($importedKeys)) {
     exit;
 }
 
-$timestamp = gmdate('c');
 $originalName = isset($upload['name']) ? basename((string) $upload['name']) : 'import.json';
 $datasetCount = count(array_unique($importedKeys));
-$datasetLabel = import_export_format_dataset_count_label($datasetCount);
+$datasetLabel = $manager->formatDatasetCountLabel($datasetCount);
 
-$statsFile = import_export_get_stats_file();
-$stats = read_json_file($statsFile);
-if (!is_array($stats)) {
-    $stats = [];
+$meta = isset($data['meta']) && is_array($data['meta']) ? $data['meta'] : [];
+if (isset($meta['site_name'])) {
+    $meta['site_name'] = (string) $meta['site_name'];
 }
 
-$stats['last_import_at'] = $timestamp;
-$stats['last_import_file'] = $originalName;
-if (isset($data['meta']) && is_array($data['meta'])) {
-    if (isset($data['meta']['available_profiles'])) {
-        $stats['available_profiles'] = (int) $data['meta']['available_profiles'];
-    }
-}
-
-$summaryParts = [];
-if ($originalName !== '') {
-    $summaryParts[] = $originalName;
-}
-if ($datasetCount > 0) {
-    $summaryParts[] = $datasetLabel;
-}
-if (isset($data['meta']['site_name']) && $data['meta']['site_name'] !== '') {
-    $summaryParts[] = (string) $data['meta']['site_name'];
-}
-
-$stats = import_export_append_history_entry($stats, [
-    'type' => 'import',
-    'timestamp' => $timestamp,
-    'label' => 'Import completed',
-    'summary' => implode(' • ', $summaryParts),
-    'file' => $originalName,
-    'dataset_count' => $datasetCount,
-]);
-
-if (write_json_file($statsFile, $stats) === false) {
+if (!$manager->recordImport($originalName, $datasetCount, $meta)) {
     http_response_code(500);
     echo json_encode(['error' => 'Unable to record import history.']);
     exit;

--- a/CMS/modules/import_export/status.php
+++ b/CMS/modules/import_export/status.php
@@ -1,60 +1,18 @@
 <?php
 // File: status.php
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
-require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/ImportExportManager.php';
 
 require_login();
 
 header('Content-Type: application/json; charset=UTF-8');
 
-$statsFile = import_export_get_stats_file();
-$stats = read_json_file($statsFile);
-if (!is_array($stats)) {
-    $stats = [];
-}
-
-$datasetMap = import_export_get_dataset_map();
-$datasets = array_keys($datasetMap);
-$datasetMetadata = import_export_get_dataset_metadata();
-
-$dataDir = import_export_get_data_dir();
-$draftsDir = $dataDir . '/drafts';
-if (is_dir($draftsDir)) {
-    $draftFiles = glob($draftsDir . '/*.json');
-    if ($draftFiles !== false && count($draftFiles) > 0) {
-        $datasets[] = 'drafts';
-    }
-}
-
-$datasetDetails = [];
-foreach ($datasets as $datasetKey) {
-    $meta = $datasetMetadata[$datasetKey] ?? [];
-    $datasetDetails[] = [
-        'key' => $datasetKey,
-        'label' => isset($meta['label']) ? (string) $meta['label'] : import_export_format_dataset_label($datasetKey),
-        'description' => isset($meta['description']) ? (string) $meta['description'] : '',
-    ];
-}
-
-$historyEntries = [];
-if (isset($stats['history']) && is_array($stats['history'])) {
-    foreach ($stats['history'] as $entry) {
-        if (!is_array($entry)) {
-            continue;
-        }
-
-        $type = isset($entry['type']) ? (string) $entry['type'] : 'activity';
-        $historyEntries[] = [
-            'type' => $type,
-            'timestamp' => isset($entry['timestamp']) && $entry['timestamp'] !== '' ? (string) $entry['timestamp'] : null,
-            'label' => isset($entry['label']) && $entry['label'] !== '' ? (string) $entry['label'] : ($type === 'import' ? 'Import completed' : ($type === 'export' ? 'Export completed' : 'Activity recorded')),
-            'summary' => isset($entry['summary']) ? (string) $entry['summary'] : '',
-            'file' => isset($entry['file']) ? (string) $entry['file'] : null,
-            'dataset_count' => isset($entry['dataset_count']) ? (int) $entry['dataset_count'] : null,
-        ];
-    }
-}
+$manager = new ImportExportManager();
+$stats = $manager->readStats();
+$datasets = $manager->getAvailableDatasets();
+$datasetDetails = $manager->getDatasetDetails($datasets);
+$historyEntries = $manager->getHistory($stats);
+$datasetCount = count($datasets);
 
 $response = [
     'last_export_at' => isset($stats['last_export_at']) && $stats['last_export_at'] !== '' ? $stats['last_export_at'] : null,
@@ -63,8 +21,8 @@ $response = [
     'available_profiles' => isset($stats['available_profiles']) ? (int) $stats['available_profiles'] : 0,
     'datasets' => $datasets,
     'dataset_details' => $datasetDetails,
-    'dataset_count' => count($datasets),
-    'dataset_count_label' => import_export_format_dataset_count_label(count($datasets)),
+    'dataset_count' => $datasetCount,
+    'dataset_count_label' => $manager->formatDatasetCountLabel($datasetCount),
     'history' => $historyEntries,
     'history_count' => count($historyEntries),
 ];

--- a/tests/import_export_manager_test.php
+++ b/tests/import_export_manager_test.php
@@ -1,0 +1,151 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/import_export/ImportExportManager.php';
+
+function remove_directory(string $directory): void
+{
+    if (!is_dir($directory)) {
+        return;
+    }
+
+    $items = scandir($directory);
+    if ($items === false) {
+        return;
+    }
+
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+
+        $path = $directory . DIRECTORY_SEPARATOR . $item;
+        if (is_dir($path)) {
+            remove_directory($path);
+        } elseif (is_file($path)) {
+            @unlink($path);
+        }
+    }
+
+    @rmdir($directory);
+}
+
+$baseDir = sys_get_temp_dir() . '/sparkcms_ie_' . uniqid('', true);
+$sourceDir = $baseDir . '/source';
+$targetDir = $baseDir . '/target';
+
+$managerSource = new ImportExportManager($sourceDir);
+
+$fixtures = [
+    'settings' => ['site_name' => 'Example Site'],
+    'pages' => [
+        ['id' => 1, 'title' => 'Home'],
+        ['id' => 2, 'title' => 'About'],
+    ],
+    'forms' => [
+        ['id' => 10, 'name' => 'Contact'],
+    ],
+    'drafts' => [
+        'Landing Page Draft' => ['id' => 101, 'title' => 'Landing'],
+        '!! invalid key !!' => ['id' => 102, 'title' => 'Offer'],
+        '   ' => ['id' => 103, 'title' => 'Whitespace'],
+    ],
+];
+
+$managerSource->importDatasets($fixtures);
+
+$exportedData = $managerSource->collectExportDatasets();
+
+if (!isset($exportedData['drafts']) || count($exportedData['drafts']) !== 2) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Export should include sanitized draft entries.');
+}
+
+if (!isset($exportedData['settings']['site_name']) || $exportedData['settings']['site_name'] !== 'Example Site') {
+    remove_directory($baseDir);
+    throw new RuntimeException('Settings dataset did not round-trip correctly during export.');
+}
+
+$managerTarget = new ImportExportManager($targetDir);
+$importedKeys = $managerTarget->importDatasets($exportedData);
+
+if (!in_array('drafts', $importedKeys, true)) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Draft datasets were not recorded during import.');
+}
+
+$roundTripData = $managerTarget->collectExportDatasets();
+
+if ($roundTripData['pages'][1]['title'] !== 'About') {
+    remove_directory($baseDir);
+    throw new RuntimeException('Page dataset lost information during import.');
+}
+
+if (!isset($roundTripData['drafts']['Landing-Page-Draft'])) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Draft keys should be sanitized consistently.');
+}
+
+$draftFiles = glob($targetDir . '/drafts/*.json');
+if ($draftFiles === false || count($draftFiles) !== 2) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Draft directory should contain exactly two sanitized files.');
+}
+
+sort($draftFiles);
+if (basename($draftFiles[0]) !== 'Landing-Page-Draft.json' || basename($draftFiles[1]) !== 'invalid-key.json') {
+    remove_directory($baseDir);
+    throw new RuntimeException('Draft filenames were not sanitized as expected.');
+}
+
+$datasetCount = count($roundTripData);
+if ($managerTarget->formatDatasetCountLabel($datasetCount) === '') {
+    remove_directory($baseDir);
+    throw new RuntimeException('Dataset count labels should not be empty.');
+}
+
+if (!$managerTarget->recordExport('test-export.json', $datasetCount)) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Failed to record export statistics.');
+}
+
+if (!$managerTarget->recordImport('test-import.json', $datasetCount, ['site_name' => 'Example Site', 'available_profiles' => 3])) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Failed to record import statistics.');
+}
+
+$stats = $managerTarget->readStats();
+
+if (!isset($stats['export_count']) || $stats['export_count'] !== 1) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Export statistics were not persisted correctly.');
+}
+
+if (!isset($stats['last_import_file']) || $stats['last_import_file'] !== 'test-import.json') {
+    remove_directory($baseDir);
+    throw new RuntimeException('Import metadata was not persisted correctly.');
+}
+
+if (!isset($stats['available_profiles']) || $stats['available_profiles'] !== 3) {
+    remove_directory($baseDir);
+    throw new RuntimeException('Available profile metadata should be retained.');
+}
+
+$history = $managerTarget->getHistory($stats);
+
+if (count($history) < 2) {
+    remove_directory($baseDir);
+    throw new RuntimeException('History entries should include the recorded export and import.');
+}
+
+if ($history[0]['type'] !== 'import' || $history[0]['label'] !== 'Import completed') {
+    remove_directory($baseDir);
+    throw new RuntimeException('Latest history entry should reflect the import operation.');
+}
+
+if ($history[1]['type'] !== 'export') {
+    remove_directory($baseDir);
+    throw new RuntimeException('Second history entry should reflect the export operation.');
+}
+
+remove_directory($baseDir);
+
+echo "ImportExportManager integration tests passed\n";


### PR DESCRIPTION
## Summary
- add an ImportExportManager that centralizes dataset metadata, history tracking, and directory utilities
- update the import/export/status endpoints to use the manager APIs for reading, writing, and statistics
- provide helper wrappers and a new integration test that exercises an export/import round trip

## Testing
- php tests/import_export_manager_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4af78fd88331b97390f1022a692a