### PR TITLE
Add log formatter for logs module

### DIFF
--- a/CMS/modules/logs/LogFormatter.php
+++ b/CMS/modules/logs/LogFormatter.php
@@ -1,0 +1,158 @@
+<?php
+
+class LogFormatter
+{
+    /**
+     * @var array<string|int, string>
+     */
+    private array $pageTitleCache = [];
+
+    /**
+     * @param array<int, array<string, mixed>> $pages
+     */
+    public function __construct(array $pages)
+    {
+        foreach ($pages as $page) {
+            if (!is_array($page)) {
+                continue;
+            }
+
+            if (!array_key_exists('id', $page)) {
+                continue;
+            }
+
+            $id = $page['id'];
+            if (!is_string($id) && !is_int($id)) {
+                continue;
+            }
+
+            $title = isset($page['title']) ? (string) $page['title'] : '';
+            if ($title === '') {
+                $title = 'Untitled';
+            }
+
+            $this->pageTitleCache[$id] = $title;
+        }
+    }
+
+    /**
+     * @param array<string|int, array<int, array<string, mixed>>> $history
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function format(array $history): array
+    {
+        $logs = [];
+
+        foreach ($history as $entityId => $entries) {
+            if (!is_array($entries)) {
+                continue;
+            }
+
+            foreach ($entries as $entry) {
+                if (!is_array($entry)) {
+                    continue;
+                }
+
+                $normalized = $this->normalizeEntry($entityId, $entry);
+                $logs[] = $normalized;
+            }
+        }
+
+        usort($logs, static function (array $a, array $b): int {
+            return $b['time'] <=> $a['time'];
+        });
+
+        return $logs;
+    }
+
+    /**
+     * @param string|int $entityId
+     * @param array<string, mixed> $entry
+     *
+     * @return array<string, mixed>
+     */
+    private function normalizeEntry($entityId, array $entry): array
+    {
+        $actionLabel = $this->normalizeActionLabel($entry['action'] ?? null);
+        $context = $this->normalizeContext($entityId, $entry['context'] ?? null);
+        $details = $this->normalizeDetails($entry['details'] ?? []);
+        $pageTitle = $this->resolvePageTitle($entityId, $context, $entry['page_title'] ?? null);
+
+        return [
+            'time' => (int) ($entry['time'] ?? 0),
+            'user' => isset($entry['user']) ? (string) $entry['user'] : '',
+            'page_title' => $pageTitle,
+            'action' => $actionLabel,
+            'action_slug' => $this->slugifyActionLabel($actionLabel),
+            'details' => $details,
+            'context' => $context,
+            'meta' => $entry['meta'] ?? new stdClass(),
+        ];
+    }
+
+    private function normalizeActionLabel(?string $action): string
+    {
+        $label = trim((string) ($action ?? ''));
+        return $label !== '' ? $label : 'Updated content';
+    }
+
+    /**
+     * @param string|int $entityId
+     */
+    private function normalizeContext($entityId, ?string $context): string
+    {
+        $context = trim((string) ($context ?? ''));
+        if ($context !== '') {
+            return $context;
+        }
+
+        return is_numeric($entityId) ? 'page' : 'system';
+    }
+
+    /**
+     * @param mixed $details
+     * @return array<int|string, mixed>
+     */
+    private function normalizeDetails($details): array
+    {
+        if (is_array($details)) {
+            return $details;
+        }
+
+        if ($details === null || $details === '') {
+            return [];
+        }
+
+        return [$details];
+    }
+
+    /**
+     * @param string|int $entityId
+     */
+    private function resolvePageTitle($entityId, string $context, $providedTitle): string
+    {
+        $providedTitle = $providedTitle ?? '';
+        if ($providedTitle !== '') {
+            return (string) $providedTitle;
+        }
+
+        if ($context === 'system') {
+            return 'System activity';
+        }
+
+        if (array_key_exists($entityId, $this->pageTitleCache)) {
+            return $this->pageTitleCache[$entityId];
+        }
+
+        return 'Unknown';
+    }
+
+    private function slugifyActionLabel(string $label): string
+    {
+        $slug = strtolower((string) preg_replace('/[^a-z0-9]+/i', '-', $label));
+        $slug = trim($slug, '-');
+
+        return $slug !== '' ? $slug : 'unknown';
+    }
+}

--- a/CMS/modules/logs/list_logs.php
+++ b/CMS/modules/logs/list_logs.php
@@ -2,60 +2,18 @@
 // File: list_logs.php
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/LogFormatter.php';
+
 require_login();
 
 $pagesFile = __DIR__ . '/../../data/pages.json';
 $pages = read_json_file($pagesFile);
-$pageLookup = [];
-foreach ($pages as $p) {
-    $pageLookup[$p['id']] = $p['title'];
-}
 
 $historyFile = __DIR__ . '/../../data/page_history.json';
 $historyData = read_json_file($historyFile);
 
-$logs = [];
+$formatter = new LogFormatter($pages);
+$logs = $formatter->format($historyData);
 
-function normalize_action_label(?string $action): string {
-    $label = trim((string)($action ?? ''));
-    return $label !== '' ? $label : 'Updated content';
-}
-
-function slugify_action_label(string $label): string {
-    $slug = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $label));
-    $slug = trim($slug ?? '', '-');
-    return $slug !== '' ? $slug : 'unknown';
-}
-
-foreach ($historyData as $pid => $entries) {
-    foreach ($entries as $entry) {
-        $actionLabel = normalize_action_label($entry['action'] ?? '');
-        $context = $entry['context'] ?? (is_numeric($pid) ? 'page' : 'system');
-        $details = $entry['details'] ?? [];
-        if (!is_array($details)) {
-            $details = $details !== '' ? [$details] : [];
-        }
-        $pageTitle = $entry['page_title'] ?? null;
-        if ($pageTitle === null) {
-            if ($context === 'system') {
-                $pageTitle = 'System activity';
-            } else {
-                $pageTitle = $pageLookup[$pid] ?? 'Unknown';
-            }
-        }
-        $logs[] = [
-            'time' => (int)($entry['time'] ?? 0),
-            'user' => $entry['user'] ?? '',
-            'page_title' => $pageTitle,
-            'action' => $actionLabel,
-            'action_slug' => slugify_action_label($actionLabel),
-            'details' => $details,
-            'context' => $context,
-            'meta' => $entry['meta'] ?? new stdClass(),
-        ];
-    }
-}
-
-usort($logs, function($a, $b){ return $b['time'] <=> $a['time']; });
 header('Content-Type: application/json');
 echo json_encode($logs);

--- a/tests/log_formatter_test.php
+++ b/tests/log_formatter_test.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/logs/LogFormatter.php';
+
+$pages = [
+    ['id' => 101, 'title' => 'About Us'],
+    ['id' => 202, 'title' => 'Contact'],
+];
+
+$history = [
+    101 => [
+        [
+            'time' => 1704067200,
+            'user' => 'alice',
+            'action' => 'Published page',
+            'details' => ['status' => 'published'],
+        ],
+        [
+            'time' => 1704153600,
+            'user' => 'bob',
+            'action' => '',
+        ],
+    ],
+    'system' => [
+        [
+            'time' => 1704110400,
+            'user' => 'system',
+            'details' => 'Cache cleared',
+        ],
+    ],
+];
+
+$formatter = new LogFormatter($pages);
+$logs = $formatter->format($history);
+
+if (count($logs) !== 3) {
+    throw new RuntimeException('Expected three log entries.');
+}
+
+if ($logs[0]['time'] !== 1704153600) {
+    throw new RuntimeException('Logs should be sorted by timestamp descending.');
+}
+
+if ($logs[0]['action'] !== 'Updated content') {
+    throw new RuntimeException('Missing action labels should default to "Updated content".');
+}
+
+if ($logs[0]['action_slug'] !== 'updated-content') {
+    throw new RuntimeException('Slug should be generated from the normalized label.');
+}
+
+if ($logs[0]['page_title'] !== 'About Us') {
+    throw new RuntimeException('Page title should be resolved from the page dataset.');
+}
+
+if ($logs[1]['page_title'] !== 'System activity') {
+    throw new RuntimeException('System context should default to the system activity label.');
+}
+
+if ($logs[1]['details'] !== ['Cache cleared']) {
+    throw new RuntimeException('String details should be normalized into an array.');
+}
+
+echo "LogFormatter tests passed\n";


### PR DESCRIPTION
## Summary
- introduce a LogFormatter class to normalize and sort log history data
- update the logs listing endpoint to use the new formatter for JSON output
- add tests covering default labels, slug generation, and sorting behavior

## Testing
- php tests/log_formatter_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4dfe10e88331ba280e0a6abd2839