### PR TITLE
Refactor menu saving to use MenuBuilder normalization

### DIFF
--- a/CMS/modules/menus/MenuBuilder.php
+++ b/CMS/modules/menus/MenuBuilder.php
@@ -1,0 +1,143 @@
+<?php
+require_once __DIR__ . '/../../includes/sanitize.php';
+
+class MenuBuilder
+{
+    /**
+     * Normalize raw menu items into the persisted structure.
+     *
+     * @param mixed $rawItems
+     * @param array $pages
+     * @return array
+     */
+    public function normalizeItems($rawItems, array $pages): array
+    {
+        $pageIndex = $this->indexPages($pages);
+        return $this->normalizeLevel($rawItems, $pageIndex);
+    }
+
+    /**
+     * Prepare stored items for UI editing, keeping parity with normalizeItems.
+     *
+     * @param array $storedItems
+     * @param array $pages
+     * @return array
+     */
+    public function denormalizeItems(array $storedItems, array $pages): array
+    {
+        $pageIndex = $this->indexPages($pages);
+        return $this->denormalizeLevel($storedItems, $pageIndex);
+    }
+
+    private function normalizeLevel($rawItems, array $pageIndex): array
+    {
+        if (!is_array($rawItems)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($rawItems as $rawItem) {
+            if (!is_array($rawItem)) {
+                continue;
+            }
+
+            $type = strtolower(sanitize_text($rawItem['type'] ?? 'custom'));
+            $label = sanitize_text($rawItem['label'] ?? '');
+            $newTab = !empty($rawItem['new_tab']);
+
+            if ($type === 'page') {
+                $pageId = isset($rawItem['page']) ? (int)$rawItem['page'] : 0;
+                if ($pageId === 0 || !isset($pageIndex[$pageId]['slug'])) {
+                    continue;
+                }
+
+                $slug = (string)$pageIndex[$pageId]['slug'];
+                if ($slug === '') {
+                    continue;
+                }
+
+                $item = [
+                    'label' => $label !== '' ? $label : $slug,
+                    'type' => 'page',
+                    'page' => $pageId,
+                    'link' => '/' . ltrim($slug, '/'),
+                    'new_tab' => $newTab,
+                ];
+            } else {
+                $link = isset($rawItem['link']) ? sanitize_url($rawItem['link']) : '';
+                if ($link === '') {
+                    continue;
+                }
+
+                $item = [
+                    'label' => $label !== '' ? $label : $link,
+                    'type' => 'custom',
+                    'link' => $link,
+                    'new_tab' => $newTab,
+                ];
+            }
+
+            if (!empty($rawItem['children'])) {
+                $children = $this->normalizeLevel($rawItem['children'], $pageIndex);
+                if (!empty($children)) {
+                    $item['children'] = $children;
+                }
+            }
+
+            $items[] = $item;
+        }
+
+        return $items;
+    }
+
+    private function denormalizeLevel(array $storedItems, array $pageIndex): array
+    {
+        $result = [];
+        foreach ($storedItems as $storedItem) {
+            if (!is_array($storedItem)) {
+                continue;
+            }
+
+            $type = isset($storedItem['type']) ? (string)$storedItem['type'] : 'custom';
+            $denormalized = [
+                'label' => isset($storedItem['label']) ? (string)$storedItem['label'] : '',
+                'type' => $type,
+                'new_tab' => !empty($storedItem['new_tab']),
+            ];
+
+            if ($type === 'page') {
+                $pageId = isset($storedItem['page']) ? (int)$storedItem['page'] : 0;
+                $denormalized['page'] = $pageId;
+                if ($pageId && isset($pageIndex[$pageId]['slug'])) {
+                    $denormalized['link'] = '/' . ltrim((string)$pageIndex[$pageId]['slug'], '/');
+                } elseif (isset($storedItem['link'])) {
+                    $denormalized['link'] = (string)$storedItem['link'];
+                } else {
+                    $denormalized['link'] = '';
+                }
+            } else {
+                $denormalized['link'] = isset($storedItem['link']) ? (string)$storedItem['link'] : '';
+            }
+
+            if (!empty($storedItem['children']) && is_array($storedItem['children'])) {
+                $denormalized['children'] = $this->denormalizeLevel($storedItem['children'], $pageIndex);
+            }
+
+            $result[] = $denormalized;
+        }
+
+        return $result;
+    }
+
+    private function indexPages(array $pages): array
+    {
+        $index = [];
+        foreach ($pages as $page) {
+            if (is_array($page) && isset($page['id'])) {
+                $index[(int)$page['id']] = $page;
+            }
+        }
+
+        return $index;
+    }
+}

--- a/CMS/modules/menus/save_menu.php
+++ b/CMS/modules/menus/save_menu.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/MenuBuilder.php';
 require_login();
 
 $menusFile = __DIR__ . '/../../data/menus.json';
@@ -15,47 +16,8 @@ $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
 $name = sanitize_text($_POST['name'] ?? '');
 $itemsData = isset($_POST['items']) ? json_decode($_POST['items'], true) : [];
 
-$items = process_items($itemsData, $pages);
-
-function process_items($itemsData, $pages){
-    $items = [];
-    if(!is_array($itemsData)) return $items;
-    foreach ($itemsData as $it) {
-        $label = sanitize_text($it['label'] ?? '');
-        $type = sanitize_text($it['type'] ?? 'custom');
-        $newTab = !empty($it['new_tab']);
-        if ($type === 'page') {
-            $pageId = (int)($it['page'] ?? 0);
-            $slug = '';
-            foreach ($pages as $p) {
-                if ($p['id'] == $pageId) { $slug = $p['slug']; break; }
-            }
-            if ($slug === '') continue;
-            $item = [
-                'label' => $label !== '' ? $label : $slug,
-                'type' => 'page',
-                'page' => $pageId,
-                'link' => '/' . $slug,
-                'new_tab' => $newTab
-            ];
-        } else {
-            $link = sanitize_url($it['link'] ?? '');
-            if ($link === '') continue;
-            $item = [
-                'label' => $label !== '' ? $label : $link,
-                'type' => 'custom',
-                'link' => $link,
-                'new_tab' => $newTab
-            ];
-        }
-        if (!empty($it['children'])) {
-            $children = process_items($it['children'], $pages);
-            if (!empty($children)) $item['children'] = $children;
-        }
-        $items[] = $item;
-    }
-    return $items;
-}
+$builder = new MenuBuilder();
+$items = $builder->normalizeItems($itemsData, $pages);
 
 if ($name === '') {
     http_response_code(400);

--- a/tests/menu_builder_test.php
+++ b/tests/menu_builder_test.php
@@ -1,0 +1,88 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/menus/MenuBuilder.php';
+
+$pages = [
+    ['id' => 1, 'slug' => 'home'],
+    ['id' => 2, 'slug' => 'about-us'],
+    ['id' => 3, 'slug' => 'contact'],
+];
+
+$builder = new MenuBuilder();
+
+$rawItems = [
+    [
+        'label' => ' Main Menu ',
+        'type' => 'page',
+        'page' => '2',
+        'new_tab' => 'yes',
+        'children' => [
+            [
+                'type' => 'custom',
+                'link' => ' https://example.com/path ',
+            ],
+            [
+                'label' => 'Invalid',
+                'type' => 'page',
+                'page' => 999,
+            ],
+        ],
+    ],
+    [
+        'type' => 'custom',
+        'link' => '   ',
+    ],
+    [
+        'type' => 'page',
+        'page' => 3,
+        'label' => '',
+    ],
+    'not-an-array',
+];
+
+$normalized = $builder->normalizeItems($rawItems, $pages);
+
+if (count($normalized) !== 2) {
+    throw new RuntimeException('Normalization should drop invalid top-level entries.');
+}
+
+$parent = $normalized[0];
+if ($parent['label'] !== 'Main Menu') {
+    throw new RuntimeException('Labels should be sanitized and preserved for page items.');
+}
+
+if ($parent['link'] !== '/about-us') {
+    throw new RuntimeException('Page links should resolve to the page slug.');
+}
+
+if ($parent['new_tab'] !== true) {
+    throw new RuntimeException('Boolean flags should be normalized to booleans.');
+}
+
+if (!isset($parent['children']) || count($parent['children']) !== 1) {
+    throw new RuntimeException('Child normalization should recurse and drop invalid entries.');
+}
+
+$child = $parent['children'][0];
+if ($child['label'] !== 'https://example.com/path') {
+    throw new RuntimeException('Custom links should use the link as a default label when blank.');
+}
+
+if ($child['new_tab'] !== false) {
+    throw new RuntimeException('Missing boolean flags should default to false.');
+}
+
+$pageWithDefaultLabel = $normalized[1];
+if ($pageWithDefaultLabel['label'] !== 'contact') {
+    throw new RuntimeException('Page items without a label should use the slug as a fallback.');
+}
+
+if (isset($pageWithDefaultLabel['children'])) {
+    throw new RuntimeException('Items without children should not emit an empty children array.');
+}
+
+$emptyResult = $builder->normalizeItems('invalid', $pages);
+if ($emptyResult !== []) {
+    throw new RuntimeException('Normalization should return an empty array for invalid input.');
+}
+
+echo "MenuBuilder normalization tests passed\n";


### PR DESCRIPTION
## Summary
- add a MenuBuilder helper for normalizing menu payloads and prepare for future reverse transforms
- refactor the menu save handler to delegate item sanitation to the builder
- add coverage for nested, missing, and default menu item normalization cases

## Testing
- php tests/menu_builder_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4e1138f88331827a52c5e8552f5b