### PR TITLE
Refactor sitemap generation into reusable service

### DIFF
--- a/CMS/modules/sitemap/SitemapGenerator.php
+++ b/CMS/modules/sitemap/SitemapGenerator.php
@@ -1,0 +1,166 @@
+<?php
+
+class SitemapGenerator
+{
+    private string $sitemapPath;
+
+    public function __construct(?string $sitemapPath = null)
+    {
+        $this->sitemapPath = $sitemapPath ?? __DIR__ . '/../../../sitemap.xml';
+    }
+
+    /**
+     * @param array<int|string, array<string, mixed>> $pages
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    public function generate(array $pages, array $options = []): array
+    {
+        $baseUrl = isset($options['baseUrl']) && is_string($options['baseUrl'])
+            ? rtrim($options['baseUrl'], '/')
+            : rtrim($this->determineBaseUrl(), '/');
+        if ($baseUrl === '') {
+            $baseUrl = 'http://localhost';
+        }
+
+        $published = array_values(array_filter($pages, function ($page) {
+            return is_array($page) && !empty($page['published']);
+        }));
+
+        $entries = [];
+        foreach ($published as $page) {
+            $slug = '';
+            if (isset($page['slug'])) {
+                $slug = ltrim((string)$page['slug'], '/');
+            }
+            $url = $slug === '' ? $baseUrl . '/' : $baseUrl . '/' . $slug;
+            $lastModified = isset($page['last_modified']) ? (int)$page['last_modified'] : time();
+            $lastmodDate = date('Y-m-d', $lastModified);
+
+            $entries[] = [
+                'title' => isset($page['title']) ? (string)$page['title'] : '',
+                'slug' => $slug,
+                'url' => $url,
+                'lastmodHuman' => date('F j, Y', $lastModified),
+                'lastmod' => $lastmodDate,
+            ];
+        }
+
+        $useDom = $this->shouldUseDom($options);
+
+        $this->ensureDirectoryExists();
+
+        if ($useDom) {
+            $this->writeWithDom($entries);
+        } else {
+            $this->writeManually($entries);
+        }
+
+        $generatedAt = @filemtime($this->sitemapPath) ?: time();
+
+        return [
+            'success' => true,
+            'message' => 'Sitemap regenerated successfully.',
+            'entryCount' => count($entries),
+            'generatedAt' => $generatedAt,
+            'generatedAtFormatted' => date('F j, Y g:i a', $generatedAt),
+            'entries' => $entries,
+            'sitemapUrl' => $baseUrl . '/sitemap.xml',
+            'sitemapPath' => $this->sitemapPath,
+            'generator' => $useDom ? 'dom' : 'simple',
+        ];
+    }
+
+    private function determineBaseUrl(): string
+    {
+        $https = $_SERVER['HTTPS'] ?? '';
+        $scheme = ($https && strtolower((string)$https) !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $scriptName = isset($_SERVER['SCRIPT_NAME']) ? (string)$_SERVER['SCRIPT_NAME'] : '';
+        $scriptBase = str_replace('\\', '/', dirname($scriptName));
+        $scriptBase = rtrim($scriptBase, '/');
+        if (substr($scriptBase, -4) === '/CMS') {
+            $scriptBase = substr($scriptBase, 0, -4);
+        }
+        $scriptBase = rtrim((string)$scriptBase, '/');
+
+        return $scheme . '://' . $host . $scriptBase;
+    }
+
+    /**
+     * @param array<int, array<string, string>> $entries
+     */
+    private function writeWithDom(array $entries): void
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $urlset = $dom->createElement('urlset');
+        $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+        foreach ($entries as $entry) {
+            $url = $dom->createElement('url');
+            $loc = $dom->createElement('loc', $entry['url']);
+            $lastmod = $dom->createElement('lastmod', $entry['lastmod']);
+
+            $url->appendChild($loc);
+            $url->appendChild($lastmod);
+            $urlset->appendChild($url);
+        }
+
+        $dom->appendChild($urlset);
+        $dom->formatOutput = true;
+
+        if ($dom->save($this->sitemapPath) === false) {
+            throw new RuntimeException('Unable to write sitemap file.');
+        }
+    }
+
+    /**
+     * @param array<int, array<string, string>> $entries
+     */
+    private function writeManually(array $entries): void
+    {
+        $lines = [
+            '<?xml version="1.0" encoding="UTF-8"?>',
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+        ];
+
+        foreach ($entries as $entry) {
+            $loc = htmlspecialchars($entry['url'], ENT_XML1);
+            $lastmod = htmlspecialchars($entry['lastmod'], ENT_XML1);
+            $lines[] = '  <url>';
+            $lines[] = '    <loc>' . $loc . '</loc>';
+            $lines[] = '    <lastmod>' . $lastmod . '</lastmod>';
+            $lines[] = '  </url>';
+        }
+
+        $lines[] = '</urlset>';
+        $xml = implode("\n", $lines);
+
+        if (file_put_contents($this->sitemapPath, $xml) === false) {
+            throw new RuntimeException('Unable to write sitemap file.');
+        }
+    }
+
+    private function ensureDirectoryExists(): void
+    {
+        $directory = dirname($this->sitemapPath);
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, 0777, true) && !is_dir($directory)) {
+                throw new RuntimeException('Unable to create sitemap directory.');
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function shouldUseDom(array $options): bool
+    {
+        if (isset($options['useDom'])) {
+            return (bool)$options['useDom'] && class_exists('DOMDocument');
+        }
+
+        return class_exists('DOMDocument');
+    }
+}

--- a/CMS/modules/sitemap/generate.php
+++ b/CMS/modules/sitemap/generate.php
@@ -3,6 +3,7 @@
 // Generate sitemap.xml listing all published pages
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/SitemapGenerator.php';
 require_login();
 
 header('Content-Type: application/json');
@@ -14,93 +15,10 @@ try {
         $pages = [];
     }
 
-    $published = array_values(array_filter($pages, function ($page) {
-        return !empty($page['published']);
-    }));
+    $generator = new SitemapGenerator(__DIR__ . '/../../../sitemap.xml');
+    $result = $generator->generate($pages);
 
-    $scheme = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
-    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-    $scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
-    if (substr($scriptBase, -4) === '/CMS') {
-        $scriptBase = substr($scriptBase, 0, -4);
-    }
-    $scriptBase = rtrim($scriptBase, '/');
-    $baseUrl = $scheme . '://' . $host . $scriptBase;
-
-    $entries = [];
-    foreach ($published as $page) {
-        $slug = ltrim((string)($page['slug'] ?? ''), '/');
-        $lastModified = isset($page['last_modified']) ? (int)$page['last_modified'] : time();
-        $lastmodDate = date('Y-m-d', $lastModified);
-
-        $entries[] = [
-            'title' => (string)($page['title'] ?? ''),
-            'slug' => $slug,
-            'url' => $baseUrl . '/' . $slug,
-            'lastmodHuman' => date('F j, Y', $lastModified),
-            'lastmod' => $lastmodDate,
-        ];
-    }
-
-    $sitemapPath = __DIR__ . '/../../../sitemap.xml';
-    $domAvailable = class_exists('DOMDocument');
-
-    if ($domAvailable) {
-        $dom = new DOMDocument('1.0', 'UTF-8');
-        $urlset = $dom->createElement('urlset');
-        $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-
-        foreach ($entries as $entry) {
-            $url = $dom->createElement('url');
-            $loc = $dom->createElement('loc', $entry['url']);
-            $lastmod = $dom->createElement('lastmod', $entry['lastmod']);
-
-            $url->appendChild($loc);
-            $url->appendChild($lastmod);
-            $urlset->appendChild($url);
-        }
-
-        $dom->appendChild($urlset);
-        $dom->formatOutput = true;
-
-        if ($dom->save($sitemapPath) === false) {
-            throw new RuntimeException('Unable to write sitemap file.');
-        }
-    } else {
-        $lines = [
-            '<?xml version="1.0" encoding="UTF-8"?>',
-            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
-        ];
-
-        foreach ($entries as $entry) {
-            $loc = htmlspecialchars($entry['url'], ENT_XML1);
-            $lastmod = htmlspecialchars($entry['lastmod'], ENT_XML1);
-            $lines[] = '  <url>';
-            $lines[] = '    <loc>' . $loc . '</loc>';
-            $lines[] = '    <lastmod>' . $lastmod . '</lastmod>';
-            $lines[] = '  </url>';
-        }
-
-        $lines[] = '</urlset>';
-        $xml = implode("\n", $lines);
-
-        if (file_put_contents($sitemapPath, $xml) === false) {
-            throw new RuntimeException('Unable to write sitemap file.');
-        }
-    }
-
-    $generatedAt = filemtime($sitemapPath) ?: time();
-
-    echo json_encode([
-        'success' => true,
-        'message' => 'Sitemap regenerated successfully.',
-        'entryCount' => count($entries),
-        'generatedAt' => $generatedAt,
-        'generatedAtFormatted' => date('F j, Y g:i a', $generatedAt),
-        'entries' => $entries,
-        'sitemapUrl' => $baseUrl . '/sitemap.xml',
-        'generator' => $domAvailable ? 'dom' : 'simple',
-    ]);
+    echo json_encode($result);
 } catch (Throwable $exception) {
     http_response_code(500);
     echo json_encode([

--- a/tests/sitemap_generator_test.php
+++ b/tests/sitemap_generator_test.php
@@ -1,0 +1,115 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/sitemap/SitemapGenerator.php';
+
+if (!class_exists('DOMDocument')) {
+    throw new RuntimeException('DOMDocument extension is required for sitemap tests.');
+}
+
+$pages = [
+    [
+        'id' => 1,
+        'title' => 'Home',
+        'slug' => '',
+        'published' => true,
+        'last_modified' => strtotime('2024-01-15 12:30:00'),
+    ],
+    [
+        'id' => 2,
+        'title' => 'About Us',
+        'slug' => '/about',
+        'published' => true,
+        'last_modified' => strtotime('2024-02-20 09:15:00'),
+    ],
+    [
+        'id' => 3,
+        'title' => 'Draft Page',
+        'slug' => 'draft',
+        'published' => false,
+        'last_modified' => strtotime('2024-03-01 08:00:00'),
+    ],
+];
+
+$domFile = tempnam(sys_get_temp_dir(), 'sitemap-dom-');
+$manualFile = tempnam(sys_get_temp_dir(), 'sitemap-manual-');
+
+if ($domFile === false || $manualFile === false) {
+    throw new RuntimeException('Unable to create temporary sitemap paths.');
+}
+
+$generatorDom = new SitemapGenerator($domFile);
+$domResult = $generatorDom->generate($pages, [
+    'baseUrl' => 'https://example.com',
+    'useDom' => true,
+]);
+
+if (!isset($domResult['success']) || $domResult['success'] !== true) {
+    throw new RuntimeException('DOM-based generation should succeed.');
+}
+
+if ($domResult['entryCount'] !== 2) {
+    throw new RuntimeException('Sitemap should only include published pages.');
+}
+
+$dom = new DOMDocument();
+$domContent = file_get_contents($domFile);
+if ($domContent === false || $domContent === '') {
+    throw new RuntimeException('DOM-based sitemap should write XML content.');
+}
+
+if ($dom->loadXML($domContent) === false) {
+    throw new RuntimeException('DOM-based sitemap should produce valid XML.');
+}
+
+$urlNodes = $dom->getElementsByTagName('url');
+if ($urlNodes->length !== 2) {
+    throw new RuntimeException('DOM-based sitemap should include two URL entries.');
+}
+
+$firstLoc = $urlNodes->item(0)->getElementsByTagName('loc')->item(0)->textContent ?? '';
+if ($firstLoc !== 'https://example.com/') {
+    throw new RuntimeException('Root page should resolve to the base URL with trailing slash.');
+}
+
+$secondLoc = $urlNodes->item(1)->getElementsByTagName('loc')->item(0)->textContent ?? '';
+if ($secondLoc !== 'https://example.com/about') {
+    throw new RuntimeException('Slugged pages should append to the base URL.');
+}
+
+$manualGenerator = new SitemapGenerator($manualFile);
+$manualResult = $manualGenerator->generate($pages, [
+    'baseUrl' => 'https://example.com',
+    'useDom' => false,
+]);
+
+if (!isset($manualResult['success']) || $manualResult['success'] !== true) {
+    throw new RuntimeException('Manual sitemap generation should succeed.');
+}
+
+$manualContent = file_get_contents($manualFile);
+if ($manualContent === false) {
+    throw new RuntimeException('Manual sitemap file should be readable.');
+}
+
+$expectedLines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    '  <url>',
+    '    <loc>https://example.com/</loc>',
+    '    <lastmod>2024-01-15</lastmod>',
+    '  </url>',
+    '  <url>',
+    '    <loc>https://example.com/about</loc>',
+    '    <lastmod>2024-02-20</lastmod>',
+    '  </url>',
+    '</urlset>',
+];
+$expectedContent = implode("\n", $expectedLines);
+
+if ($manualContent !== $expectedContent) {
+    throw new RuntimeException('Manual sitemap output did not match the expected XML structure.');
+}
+
+unlink($domFile);
+unlink($manualFile);
+
+echo "SitemapGenerator tests passed\n";


### PR DESCRIPTION
## Summary
- add a reusable `SitemapGenerator` for producing sitemap XML files
- update the sitemap endpoint and page save workflow to invoke the generator directly
- add coverage for DOM-based and manual sitemap generation outputs

## Testing
- php tests/sitemap_generator_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4e35fd3c8331a50c5e541a35b6d2