### PR TITLE
Refactor media listing into media library

### DIFF
--- a/CMS/modules/media/MediaLibrary.php
+++ b/CMS/modules/media/MediaLibrary.php
@@ -1,0 +1,250 @@
+<?php
+
+require_once __DIR__ . '/../../includes/data.php';
+
+class MediaLibrary
+{
+    public const DEFAULT_SORT = 'custom';
+    public const ALLOWED_SORTS = ['custom', 'name', 'date', 'type', 'size', 'tags', 'dimensions'];
+
+    private string $mediaFile;
+    private string $rootDir;
+    private string $uploadsDir;
+    private ?array $mediaData = null;
+
+    public function __construct(string $mediaFile, string $rootDir)
+    {
+        $this->mediaFile = $mediaFile;
+        $this->rootDir = rtrim($rootDir, '/');
+        $this->uploadsDir = $this->rootDir . '/uploads';
+        $this->ensureUploadStructure();
+    }
+
+    public function listMedia(array $filters = []): array
+    {
+        $media = $this->loadMedia();
+
+        usort($media, function ($a, $b) {
+            return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);
+        });
+
+        $query = strtolower($filters['query'] ?? '');
+        $folder = $filters['folder'] ?? '';
+        $sort = strtolower($filters['sort'] ?? self::DEFAULT_SORT);
+        if (!in_array($sort, self::ALLOWED_SORTS, true)) {
+            $sort = self::DEFAULT_SORT;
+        }
+        $order = strtolower($filters['order'] ?? 'asc') === 'desc' ? 'desc' : 'asc';
+        $limit = isset($filters['limit']) ? max(0, (int) $filters['limit']) : 0;
+        $offset = isset($filters['offset']) ? max(0, (int) $filters['offset']) : 0;
+
+        $results = array_filter($media, function ($item) use ($query, $folder) {
+            if ($folder !== '' && ($item['folder'] ?? '') !== $folder) {
+                return false;
+            }
+            if ($query !== '') {
+                $nameMatch = isset($item['name']) && stripos($item['name'], $query) !== false;
+                $tagsMatch = false;
+                if (isset($item['tags'])) {
+                    $tags = is_array($item['tags']) ? $item['tags'] : [$item['tags']];
+                    $tagsMatch = stripos(implode(',', $tags), $query) !== false;
+                }
+                if (!$nameMatch && !$tagsMatch) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        $results = array_map(function ($item) {
+            return $this->enrichMediaItem($item);
+        }, array_values($results));
+
+        $results = $this->sortResults($results, $sort);
+
+        if ($order === 'desc') {
+            $results = array_reverse($results);
+        }
+
+        $results = array_values($results);
+
+        $totalCount = count($results);
+        $totalBytes = array_reduce($results, function ($carry, $item) {
+            return $carry + (int) ($item['size'] ?? 0);
+        }, 0);
+
+        $lastModified = 0;
+        foreach ($results as $resultItem) {
+            if (isset($resultItem['modified_at']) && $resultItem['modified_at'] > $lastModified) {
+                $lastModified = $resultItem['modified_at'];
+            }
+        }
+
+        $pagedResults = $results;
+        if ($limit > 0) {
+            $pagedResults = array_slice($results, $offset, $limit);
+        } elseif ($offset > 0) {
+            $pagedResults = array_slice($results, $offset);
+        }
+
+        return [
+            'media' => array_values($pagedResults),
+            'total' => $totalCount,
+            'total_size' => $totalBytes,
+            'last_modified' => $lastModified,
+        ];
+    }
+
+    public function listFolders(): array
+    {
+        $media = $this->loadMedia();
+        $directories = glob($this->uploadsDir . '/*');
+        if ($directories === false) {
+            $directories = [];
+        }
+        $directories = array_filter($directories, 'is_dir');
+        $folders = [];
+
+        foreach ($directories as $dir) {
+            $name = basename($dir);
+            $folders[] = [
+                'name' => $name,
+                'thumbnail' => $this->resolveFolderThumbnail($name, $dir, $media),
+            ];
+        }
+
+        return $folders;
+    }
+
+    private function ensureUploadStructure(): void
+    {
+        if (!is_dir($this->uploadsDir)) {
+            mkdir($this->uploadsDir, 0777, true);
+        }
+        $defaultDir = $this->uploadsDir . '/general';
+        if (!is_dir($defaultDir)) {
+            mkdir($defaultDir, 0777, true);
+        }
+    }
+
+    private function loadMedia(): array
+    {
+        if ($this->mediaData === null) {
+            $this->mediaData = read_json_file($this->mediaFile);
+            if (!is_array($this->mediaData)) {
+                $this->mediaData = [];
+            }
+        }
+        return $this->mediaData;
+    }
+
+    private function enrichMediaItem(array $item): array
+    {
+        $relativePath = $item['file'] ?? '';
+        if ($relativePath === '') {
+            return $item;
+        }
+        $path = $this->rootDir . '/' . ltrim($relativePath, '/');
+        if (is_file($path)) {
+            $item['modified_at'] = filemtime($path);
+            if (($item['type'] ?? '') === 'images') {
+                $info = @getimagesize($path);
+                if ($info) {
+                    $item['width'] = $info[0];
+                    $item['height'] = $info[1];
+                }
+            }
+        }
+        return $item;
+    }
+
+    private function sortResults(array $results, string $sort): array
+    {
+        switch ($sort) {
+            case 'name':
+                usort($results, function ($a, $b) {
+                    return strcasecmp($a['name'] ?? '', $b['name'] ?? '');
+                });
+                break;
+            case 'date':
+                usort($results, function ($a, $b) {
+                    $aTime = $a['modified_at'] ?? ($a['uploaded_at'] ?? 0);
+                    $bTime = $b['modified_at'] ?? ($b['uploaded_at'] ?? 0);
+                    return $aTime <=> $bTime;
+                });
+                break;
+            case 'type':
+                usort($results, function ($a, $b) {
+                    return strcasecmp($a['type'] ?? '', $b['type'] ?? '');
+                });
+                break;
+            case 'size':
+                usort($results, function ($a, $b) {
+                    return ((int) ($a['size'] ?? 0)) <=> ((int) ($b['size'] ?? 0));
+                });
+                break;
+            case 'tags':
+                usort($results, function ($a, $b) {
+                    $aTags = isset($a['tags']) ? implode(',', (array) $a['tags']) : '';
+                    $bTags = isset($b['tags']) ? implode(',', (array) $b['tags']) : '';
+                    return strcasecmp($aTags, $bTags);
+                });
+                break;
+            case 'dimensions':
+                usort($results, function ($a, $b) {
+                    $aDim = ((int) ($a['width'] ?? 0)) * ((int) ($a['height'] ?? 0));
+                    $bDim = ((int) ($b['width'] ?? 0)) * ((int) ($b['height'] ?? 0));
+                    return $aDim <=> $bDim;
+                });
+                break;
+            default:
+                usort($results, function ($a, $b) {
+                    return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);
+                });
+        }
+
+        return $results;
+    }
+
+    private function resolveFolderThumbnail(string $folderName, string $directory, array $media): ?string
+    {
+        foreach ($media as $item) {
+            if (($item['folder'] ?? '') !== $folderName) {
+                continue;
+            }
+            if (($item['type'] ?? '') !== 'images') {
+                continue;
+            }
+            $thumb = $item['thumbnail'] ?? '';
+            if ($thumb === '' && !empty($item['file'])) {
+                $thumb = $item['file'];
+            }
+            if ($thumb !== '') {
+                return $thumb;
+            }
+        }
+
+        $patterns = [
+            $directory . '/thumbs/*.{jpg,jpeg,png,gif,webp}',
+            $directory . '/*.{jpg,jpeg,png,gif,webp}',
+        ];
+
+        foreach ($patterns as $pattern) {
+            $matches = glob($pattern, GLOB_BRACE);
+            if (!empty($matches)) {
+                return $this->relativePath($matches[0]);
+            }
+        }
+
+        return null;
+    }
+
+    private function relativePath(string $absolutePath): string
+    {
+        $normalizedRoot = rtrim($this->rootDir, '/') . '/';
+        if (strpos($absolutePath, $normalizedRoot) === 0) {
+            return ltrim(substr($absolutePath, strlen($normalizedRoot)), '/');
+        }
+        return ltrim($absolutePath, '/');
+    }
+}

--- a/CMS/modules/media/list_media.php
+++ b/CMS/modules/media/list_media.php
@@ -1,149 +1,45 @@
 <?php
 // File: list_media.php
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/MediaLibrary.php';
+
 require_login();
 
 $mediaFile = __DIR__ . '/../../data/media.json';
-$media = read_json_file($mediaFile);
-$query = strtolower(sanitize_text($_GET['q'] ?? ''));
+$rootDir = dirname(__DIR__, 2);
+
+$query = sanitize_text($_GET['q'] ?? '');
 $folder = sanitize_text($_GET['folder'] ?? '');
-$sort = strtolower(sanitize_text($_GET['sort'] ?? 'custom'));
-$allowedSorts = ['custom','name','date','type','size','tags','dimensions'];
-if (!in_array($sort, $allowedSorts, true)) {
-    $sort = 'custom';
+$sort = strtolower(sanitize_text($_GET['sort'] ?? MediaLibrary::DEFAULT_SORT));
+if (!in_array($sort, MediaLibrary::ALLOWED_SORTS, true)) {
+    $sort = MediaLibrary::DEFAULT_SORT;
 }
-$order = strtolower($_GET['order'] ?? 'asc') === 'desc' ? 'desc' : 'asc';
-$limit = isset($_GET['limit']) ? max(0, (int)$_GET['limit']) : 0;
-$offset = isset($_GET['offset']) ? max(0, (int)$_GET['offset']) : 0;
+$order = strtolower(sanitize_text($_GET['order'] ?? 'asc')) === 'desc' ? 'desc' : 'asc';
 
-usort($media, function($a,$b){
-    return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);
-});
-
-$results = array_filter($media, function($item) use ($query, $folder) {
-    if ($folder !== '' && $item['folder'] !== $folder) return false;
-    if ($query && stripos($item['name'], $query) === false &&
-        (!isset($item['tags']) || stripos(implode(',', $item['tags']), $query) === false)) return false;
-    return true;
-});
-
-$root = dirname(__DIR__,2);
-$uploadsDir = $root . '/uploads';
-if (!is_dir($uploadsDir)) {
-    mkdir($uploadsDir, 0777, true);
-    $defaultDir = $uploadsDir . '/general';
-    if (!is_dir($defaultDir)) mkdir($defaultDir, 0777, true);
+$limit = 0;
+if (isset($_GET['limit'])) {
+    $limitValue = filter_var($_GET['limit'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+    $limit = $limitValue !== false ? $limitValue : 0;
 }
-$folderDirs = array_filter(glob($uploadsDir . '/*'), 'is_dir');
-$folders = [];
-foreach ($folderDirs as $dir) {
-    $name = basename($dir);
-    $thumb = null;
-    foreach ($media as $m) {
-        if (($m['folder'] ?? '') === $name && ($m['type'] ?? '') === 'images') {
-            $thumb = $m['thumbnail'] ?: $m['file'];
-            break;
-        }
-    }
-    if (!$thumb) {
-        $candidates = glob($dir . '/thumbs/*.{jpg,jpeg,png,gif,webp}', GLOB_BRACE);
-        if (!$candidates) $candidates = glob($dir.'/*.{jpg,jpeg,png,gif,webp}', GLOB_BRACE);
-        if ($candidates) {
-            $thumb = str_replace($root.'/', '', $candidates[0]);
-        }
-    }
-    $folders[] = ['name' => $name, 'thumbnail' => $thumb];
+$offset = 0;
+if (isset($_GET['offset'])) {
+    $offsetValue = filter_var($_GET['offset'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+    $offset = $offsetValue !== false ? $offsetValue : 0;
 }
 
-foreach ($results as &$item) {
-    $path = $root . '/' . $item['file'];
-    if (is_file($path)) {
-        $item['modified_at'] = filemtime($path);
-        if ($item['type'] === 'images') {
-            $info = @getimagesize($path);
-            if ($info) {
-                $item['width'] = $info[0];
-                $item['height'] = $info[1];
-            }
-        }
-    }
-}
-unset($item);
+$library = new MediaLibrary($mediaFile, $rootDir);
 
-switch ($sort) {
-    case 'name':
-        usort($results, function($a, $b) {
-            return strcasecmp($a['name'] ?? '', $b['name'] ?? '');
-        });
-        break;
-    case 'date':
-        usort($results, function($a, $b) {
-            $aTime = $a['modified_at'] ?? ($a['uploaded_at'] ?? 0);
-            $bTime = $b['modified_at'] ?? ($b['uploaded_at'] ?? 0);
-            return $aTime <=> $bTime;
-        });
-        break;
-    case 'type':
-        usort($results, function($a, $b) {
-            return strcasecmp($a['type'] ?? '', $b['type'] ?? '');
-        });
-        break;
-    case 'size':
-        usort($results, function($a, $b) {
-            return ((int)($a['size'] ?? 0)) <=> ((int)($b['size'] ?? 0));
-        });
-        break;
-    case 'tags':
-        usort($results, function($a, $b) {
-            $aTags = isset($a['tags']) ? implode(',', (array)$a['tags']) : '';
-            $bTags = isset($b['tags']) ? implode(',', (array)$b['tags']) : '';
-            return strcasecmp($aTags, $bTags);
-        });
-        break;
-    case 'dimensions':
-        usort($results, function($a, $b) {
-            $aDim = ((int)($a['width'] ?? 0)) * ((int)($a['height'] ?? 0));
-            $bDim = ((int)($b['width'] ?? 0)) * ((int)($b['height'] ?? 0));
-            return $aDim <=> $bDim;
-        });
-        break;
-    default:
-        usort($results, function($a, $b) {
-            return ($a['order'] ?? 0) <=> ($b['order'] ?? 0);
-        });
-}
-
-if ($order === 'desc') {
-    $results = array_reverse($results);
-}
-
-$results = array_values($results);
-$totalCount = count($results);
-$totalBytes = array_reduce($results, function($carry, $item) {
-    return $carry + (int)($item['size'] ?? 0);
-}, 0);
-$lastModified = 0;
-foreach ($results as $resultItem) {
-    if (isset($resultItem['modified_at']) && $resultItem['modified_at'] > $lastModified) {
-        $lastModified = $resultItem['modified_at'];
-    }
-}
-
-$pagedResults = $results;
-if ($limit > 0) {
-    $pagedResults = array_slice($results, $offset, $limit);
-} elseif ($offset > 0) {
-    $pagedResults = array_slice($results, $offset);
-}
+$response = $library->listMedia([
+    'query' => $query,
+    'folder' => $folder,
+    'sort' => $sort,
+    'order' => $order,
+    'limit' => $limit,
+    'offset' => $offset,
+]);
+$response['folders'] = $library->listFolders();
 
 header('Content-Type: application/json');
-echo json_encode([
-    'media' => array_values($pagedResults),
-    'folders' => $folders,
-    'total' => $totalCount,
-    'total_size' => $totalBytes,
-    'last_modified' => $lastModified
-]);
+echo json_encode($response);
 ?>

--- a/tests/media_library_test.php
+++ b/tests/media_library_test.php
@@ -1,0 +1,162 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/media/MediaLibrary.php';
+
+function create_sample_image(): string {
+    $base64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Yz4yfsAAAAASUVORK5CYII=';
+    return base64_decode($base64);
+}
+
+function rrmdir(string $dir): void {
+    if (!is_dir($dir)) {
+        return;
+    }
+    $items = scandir($dir);
+    if ($items === false) {
+        return;
+    }
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+        $path = $dir . DIRECTORY_SEPARATOR . $item;
+        if (is_dir($path)) {
+            rrmdir($path);
+        } else {
+            unlink($path);
+        }
+    }
+    rmdir($dir);
+}
+
+$rootDir = sys_get_temp_dir() . '/media_library_' . uniqid();
+$uploadsDir = $rootDir . '/uploads';
+$generalDir = $uploadsDir . '/general';
+$generalThumbs = $generalDir . '/thumbs';
+$galleryDir = $uploadsDir . '/gallery';
+$galleryThumbs = $galleryDir . '/thumbs';
+$samplesThumbs = $uploadsDir . '/samples/thumbs';
+
+mkdir($generalThumbs, 0777, true);
+mkdir($galleryThumbs, 0777, true);
+mkdir($samplesThumbs, 0777, true);
+
+$imageData = create_sample_image();
+file_put_contents($generalThumbs . '/alpha.png', $imageData);
+file_put_contents($samplesThumbs . '/example.jpg', $imageData);
+
+$bravoPath = $generalDir . '/bravo.pdf';
+file_put_contents($bravoPath, 'Sample document');
+touch($bravoPath, 1700000005);
+
+$mediaFile = $rootDir . '/media.json';
+$dataset = [
+    [
+        'id' => 1,
+        'name' => 'Bravo doc',
+        'folder' => 'general',
+        'type' => 'documents',
+        'file' => 'uploads/general/bravo.pdf',
+        'size' => 1200,
+        'tags' => ['report'],
+        'order' => 2,
+        'uploaded_at' => 1700000002,
+    ],
+    [
+        'id' => 2,
+        'name' => 'Alpha',
+        'folder' => 'general',
+        'type' => 'images',
+        'file' => 'uploads/general/alpha.png',
+        'thumbnail' => 'uploads/general/thumbs/alpha.png',
+        'size' => 500,
+        'tags' => ['first', 'featured'],
+        'order' => 1,
+        'uploaded_at' => 1700000000,
+        'width' => 100,
+        'height' => 100,
+    ],
+    [
+        'id' => 3,
+        'name' => 'Charlie',
+        'folder' => 'gallery',
+        'type' => 'images',
+        'file' => 'uploads/gallery/charlie.png',
+        'size' => 800,
+        'tags' => ['gallery'],
+        'order' => 3,
+        'uploaded_at' => 1700000005,
+        'width' => 50,
+        'height' => 60,
+    ],
+];
+
+file_put_contents($mediaFile, json_encode($dataset));
+
+$library = new MediaLibrary($mediaFile, $rootDir);
+
+$sortExpectations = [
+    'custom' => ['Alpha', 'Bravo doc', 'Charlie'],
+    'name' => ['Alpha', 'Bravo doc', 'Charlie'],
+    'date' => ['Alpha', 'Bravo doc', 'Charlie'],
+    'type' => ['Bravo doc', 'Alpha', 'Charlie'],
+    'size' => ['Alpha', 'Charlie', 'Bravo doc'],
+    'tags' => ['Alpha', 'Charlie', 'Bravo doc'],
+    'dimensions' => ['Bravo doc', 'Charlie', 'Alpha'],
+];
+
+foreach ($sortExpectations as $sort => $expectedNames) {
+    $result = $library->listMedia(['sort' => $sort]);
+    $names = array_column($result['media'], 'name');
+    if ($names !== $expectedNames) {
+        rrmdir($rootDir);
+        throw new RuntimeException("Unexpected order for sort '{$sort}'.");
+    }
+}
+
+$descResult = $library->listMedia(['sort' => 'size', 'order' => 'desc']);
+$descNames = array_column($descResult['media'], 'name');
+if ($descNames !== array_reverse($sortExpectations['size'])) {
+    rrmdir($rootDir);
+    throw new RuntimeException('Descending sort order failed.');
+}
+
+$baseResult = $library->listMedia(['sort' => 'custom']);
+if ($baseResult['total'] !== 3) {
+    rrmdir($rootDir);
+    throw new RuntimeException('Total count mismatch.');
+}
+
+if ($baseResult['total_size'] !== (500 + 1200 + 800)) {
+    rrmdir($rootDir);
+    throw new RuntimeException('Total size calculation is incorrect.');
+}
+
+if ($baseResult['last_modified'] !== 1700000005) {
+    rrmdir($rootDir);
+    throw new RuntimeException('Last modified timestamp should reflect the latest file update.');
+}
+
+$folders = $library->listFolders();
+$folderMap = [];
+foreach ($folders as $folderInfo) {
+    $folderMap[$folderInfo['name']] = $folderInfo['thumbnail'];
+}
+
+if (!isset($folderMap['general']) || $folderMap['general'] !== 'uploads/general/thumbs/alpha.png') {
+    rrmdir($rootDir);
+    throw new RuntimeException('General folder thumbnail should use the media thumbnail.');
+}
+
+if (!isset($folderMap['gallery']) || $folderMap['gallery'] !== 'uploads/gallery/charlie.png') {
+    rrmdir($rootDir);
+    throw new RuntimeException('Gallery folder thumbnail should fall back to the media file.');
+}
+
+if (!isset($folderMap['samples']) || $folderMap['samples'] !== 'uploads/samples/thumbs/example.jpg') {
+    rrmdir($rootDir);
+    throw new RuntimeException('Samples folder thumbnail should use the filesystem fallback.');
+}
+
+rrmdir($rootDir);
+
+echo "MediaLibrary tests passed\n";


### PR DESCRIPTION
## Summary
- add a reusable MediaLibrary class for media queries, metadata enrichment, and folder discovery
- update list_media.php to sanitize inputs and delegate to the library methods
- add a regression test covering all sort modes and folder thumbnail fallbacks

## Testing
- php tests/media_library_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4e10213883319be461820e166e69