### PR TITLE
Refactor page saving workflow and sitemap regeneration

### DIFF
--- a/CMS/modules/pages/PageService.php
+++ b/CMS/modules/pages/PageService.php
@@ -1,0 +1,310 @@
+<?php
+require_once __DIR__ . '/../../includes/data.php';
+
+class PageService
+{
+    private string $pagesFile;
+    private string $historyFile;
+    /** @var callable */
+    private $sitemapRegenerator;
+
+    public function __construct(string $pagesFile, string $historyFile, callable $sitemapRegenerator)
+    {
+        $this->pagesFile = $pagesFile;
+        $this->historyFile = $historyFile;
+        $this->sitemapRegenerator = $sitemapRegenerator;
+    }
+
+    /**
+     * Save a page payload to the dataset and regenerate the sitemap.
+     *
+     * @param array  $payload  Sanitized page data.
+     * @param string $username Username responsible for the change.
+     *
+     * @return array
+     */
+    public function save(array $payload, string $username): array
+    {
+        try {
+            $pages = $this->loadPages();
+            $id = isset($payload['id']) && $payload['id'] !== '' ? (int)$payload['id'] : null;
+            $title = trim((string)($payload['title'] ?? ''));
+            if ($title === '') {
+                return $this->failureResponse('Title is required.', 400);
+            }
+
+            $slug = $this->normalizeSlug($title, (string)($payload['slug'] ?? ''));
+            $content = (string)($payload['content'] ?? '');
+            $published = !empty($payload['published']);
+            $templateRaw = (string)($payload['template'] ?? '');
+            $template = $templateRaw !== '' ? $templateRaw : 'page.php';
+            $metaTitle = (string)($payload['meta_title'] ?? '');
+            $metaDescription = (string)($payload['meta_description'] ?? '');
+            $canonicalUrl = (string)($payload['canonical_url'] ?? '');
+            $ogTitle = (string)($payload['og_title'] ?? '');
+            $ogDescription = (string)($payload['og_description'] ?? '');
+            $ogImage = (string)($payload['og_image'] ?? '');
+            $access = (string)($payload['access'] ?? 'public');
+
+            $timestamp = time();
+            $isUpdate = $id !== null;
+            $savedPage = null;
+            $oldPage = null;
+
+            if ($isUpdate) {
+                foreach ($pages as &$page) {
+                    if ((int)$page['id'] === $id) {
+                        $oldPage = $page;
+                        $page['title'] = $title;
+                        $page['slug'] = $slug;
+                        $page['content'] = $content;
+                        $page['published'] = $published;
+                        $page['template'] = $template;
+                        $page['meta_title'] = $metaTitle;
+                        $page['meta_description'] = $metaDescription;
+                        $page['canonical_url'] = $canonicalUrl;
+                        $page['og_title'] = $ogTitle;
+                        $page['og_description'] = $ogDescription;
+                        $page['og_image'] = $ogImage;
+                        $page['access'] = $access;
+                        $page['last_modified'] = $timestamp;
+                        $savedPage = $page;
+                        break;
+                    }
+                }
+                unset($page);
+
+                if ($savedPage === null) {
+                    return $this->failureResponse('Page not found.', 404);
+                }
+            } else {
+                $id = $this->nextId($pages);
+                $savedPage = [
+                    'id' => $id,
+                    'title' => $title,
+                    'slug' => $slug,
+                    'content' => $content,
+                    'published' => $published,
+                    'template' => $template,
+                    'meta_title' => $metaTitle,
+                    'meta_description' => $metaDescription,
+                    'canonical_url' => $canonicalUrl,
+                    'og_title' => $ogTitle,
+                    'og_description' => $ogDescription,
+                    'og_image' => $ogImage,
+                    'access' => $access,
+                    'views' => 0,
+                    'last_modified' => $timestamp,
+                ];
+                $pages[] = $savedPage;
+            }
+
+            if (!write_json_file($this->pagesFile, $pages)) {
+                throw new RuntimeException('Unable to persist pages dataset.');
+            }
+
+            [$action, $details] = $this->buildHistoryDetails($oldPage, $savedPage, $template, $published, $access);
+            $pageHistoryEntry = [
+                'time' => $timestamp,
+                'user' => $username !== '' ? $username : 'Unknown',
+                'action' => $action,
+                'details' => $details,
+                'context' => 'page',
+                'page_id' => $id,
+            ];
+
+            $historyData = read_json_file($this->historyFile);
+            if (!is_array($historyData)) {
+                $historyData = [];
+            }
+            if (!isset($historyData[$id]) || !is_array($historyData[$id])) {
+                $historyData[$id] = [];
+            }
+            $historyData[$id][] = $pageHistoryEntry;
+            $historyData[$id] = array_slice($historyData[$id], -20);
+
+            try {
+                $sitemapResult = call_user_func($this->sitemapRegenerator);
+            } catch (Throwable $exception) {
+                $sitemapResult = [
+                    'success' => false,
+                    'message' => 'Failed to regenerate sitemap.',
+                    'error' => $exception->getMessage(),
+                ];
+            }
+
+            $systemHistoryEntry = $this->buildSystemHistoryEntry($title, $slug, $id, $sitemapResult);
+            if (!isset($historyData['__system__']) || !is_array($historyData['__system__'])) {
+                $historyData['__system__'] = [];
+            }
+            $historyData['__system__'][] = $systemHistoryEntry;
+            $historyData['__system__'] = array_slice($historyData['__system__'], -50);
+
+            if (!write_json_file($this->historyFile, $historyData)) {
+                throw new RuntimeException('Unable to persist history dataset.');
+            }
+
+            if (($sitemapResult['success'] ?? false) !== true) {
+                return $this->failureResponse(
+                    $sitemapResult['message'] ?? 'Failed to regenerate sitemap.',
+                    500,
+                    [
+                        'page' => $savedPage,
+                        'historyEntry' => $pageHistoryEntry,
+                        'systemHistoryEntry' => $systemHistoryEntry,
+                        'sitemap' => $sitemapResult,
+                    ]
+                );
+            }
+
+            return [
+                'success' => true,
+                'status' => $isUpdate ? 200 : 201,
+                'message' => $isUpdate ? 'Page updated successfully.' : 'Page created successfully.',
+                'page' => $savedPage,
+                'historyEntry' => $pageHistoryEntry,
+                'systemHistoryEntry' => $systemHistoryEntry,
+                'sitemap' => $sitemapResult,
+            ];
+        } catch (Throwable $exception) {
+            return $this->failureResponse(
+                'Unable to save page.',
+                500,
+                ['error' => $exception->getMessage()]
+            );
+        }
+    }
+
+    private function loadPages(): array
+    {
+        $pages = read_json_file($this->pagesFile);
+        return is_array($pages) ? $pages : [];
+    }
+
+    private function nextId(array $pages): int
+    {
+        $max = 0;
+        foreach ($pages as $page) {
+            if (isset($page['id']) && (int)$page['id'] > $max) {
+                $max = (int)$page['id'];
+            }
+        }
+        return $max + 1;
+    }
+
+    private function normalizeSlug(string $title, string $slug): string
+    {
+        $slug = trim($slug);
+        if ($slug === '') {
+            $slug = $title;
+        }
+        return $this->slugify($slug);
+    }
+
+    private function slugify(string $text): string
+    {
+        $text = strtolower(trim($text));
+        $text = preg_replace('/[^a-z0-9]+/', '-', $text);
+        $text = trim($text, '-');
+        return $text !== '' ? $text : 'page';
+    }
+
+    private function buildHistoryDetails(?array $oldPage, array $newPage, string $template, bool $published, string $access): array
+    {
+        if ($oldPage === null) {
+            return [
+                'created page with template ' . $template,
+                [
+                    'Initial template: ' . $template,
+                    'Visibility: ' . ($published ? 'Published' : 'Unpublished'),
+                    'Access: ' . $access,
+                ],
+            ];
+        }
+
+        $changes = [];
+        $details = [];
+
+        if (($oldPage['title'] ?? '') !== ($newPage['title'] ?? '')) {
+            $details[] = 'Title: "' . ($oldPage['title'] ?? '') . '" → "' . ($newPage['title'] ?? '') . '"';
+        }
+        if (($oldPage['slug'] ?? '') !== ($newPage['slug'] ?? '')) {
+            $details[] = 'Slug: ' . ($oldPage['slug'] ?? '') . ' → ' . ($newPage['slug'] ?? '');
+        }
+        if (($oldPage['template'] ?? '') !== ($newPage['template'] ?? '')) {
+            $details[] = 'Template: ' . ($oldPage['template'] ?? '') . ' → ' . ($newPage['template'] ?? '');
+            $changes[] = 'Changed template';
+        }
+        if (!empty($oldPage['published']) !== $published) {
+            $details[] = 'Visibility: ' . (!empty($oldPage['published']) ? 'Published' : 'Unpublished') . ' → ' . ($published ? 'Published' : 'Unpublished');
+            $changes[] = $published ? 'Published page' : 'Unpublished page';
+        }
+        if (($oldPage['meta_title'] ?? '') !== ($newPage['meta_title'] ?? '')) {
+            $details[] = 'Meta title updated';
+        }
+        if (($oldPage['meta_description'] ?? '') !== ($newPage['meta_description'] ?? '')) {
+            $details[] = 'Meta description updated';
+        }
+        if (($oldPage['canonical_url'] ?? '') !== ($newPage['canonical_url'] ?? '')) {
+            $details[] = 'Canonical URL: ' . (($oldPage['canonical_url'] ?? '') !== '' ? ($oldPage['canonical_url'] ?? '') : 'none') . ' → ' . (($newPage['canonical_url'] ?? '') !== '' ? ($newPage['canonical_url'] ?? '') : 'none');
+        }
+        if (($oldPage['og_title'] ?? '') !== ($newPage['og_title'] ?? '')) {
+            $details[] = 'OG title: "' . ($oldPage['og_title'] ?? '') . '" → "' . ($newPage['og_title'] ?? '') . '"';
+        }
+        if (($oldPage['og_description'] ?? '') !== ($newPage['og_description'] ?? '')) {
+            $details[] = 'OG description updated';
+        }
+        if (($oldPage['og_image'] ?? '') !== ($newPage['og_image'] ?? '')) {
+            $details[] = 'OG image: ' . (($oldPage['og_image'] ?? '') !== '' ? ($oldPage['og_image'] ?? '') : 'none') . ' → ' . (($newPage['og_image'] ?? '') !== '' ? ($newPage['og_image'] ?? '') : 'none');
+        }
+        if (($oldPage['access'] ?? 'public') !== ($newPage['access'] ?? 'public')) {
+            $details[] = 'Access: ' . ($oldPage['access'] ?? 'public') . ' → ' . ($newPage['access'] ?? 'public');
+        }
+
+        if (!$changes) {
+            $changes[] = 'Updated page settings';
+        }
+        if (!$details) {
+            $details[] = 'Saved without changing any settings.';
+        }
+
+        return [implode('; ', $changes), $details];
+    }
+
+    private function buildSystemHistoryEntry(string $title, string $slug, int $pageId, array $sitemapResult): array
+    {
+        $success = ($sitemapResult['success'] ?? false) === true;
+        $details = [
+            ($success ? 'Automatic sitemap refresh after updating ' : 'Failed sitemap refresh while updating ') . '"' . $title . '" (' . $slug . ')',
+        ];
+        if (!$success && isset($sitemapResult['error'])) {
+            $details[] = 'Error: ' . $sitemapResult['error'];
+        }
+
+        return [
+            'time' => time(),
+            'user' => '',
+            'action' => $success ? 'Regenerated sitemap' : 'Sitemap regeneration failed',
+            'details' => $details,
+            'context' => 'system',
+            'meta' => [
+                'trigger' => 'sitemap_regeneration',
+                'page_id' => $pageId,
+                'status' => $success ? 'success' : 'error',
+            ],
+            'page_title' => 'CMS Backend',
+        ];
+    }
+
+    private function failureResponse(string $message, int $status, array $extra = []): array
+    {
+        return array_merge(
+            [
+                'success' => false,
+                'status' => $status,
+                'message' => $message,
+            ],
+            $extra
+        );
+    }
+}

--- a/CMS/modules/pages/save_page.php
+++ b/CMS/modules/pages/save_page.php
@@ -3,35 +3,20 @@
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/../sitemap/SitemapService.php';
+require_once __DIR__ . '/PageService.php';
+
 $pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = [];
-if (file_exists($pagesFile)) {
-    $pages = read_json_file($pagesFile);
-}
+$historyFile = __DIR__ . '/../../data/page_history.json';
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
 $title = sanitize_text($_POST['title'] ?? '');
 $slug = sanitize_text($_POST['slug'] ?? '');
-
-function slugify($text){
-    $text = strtolower(trim($text));
-    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
-    $text = trim($text, '-');
-    return $text ?: 'page';
-}
-
-if ($slug === '') {
-    $slug = $title;
-}
-$slug = slugify($slug);
 $content = trim($_POST['content'] ?? '');
 // strip script tags to avoid XSS in stored content
 $content = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $content);
 $published = isset($_POST['published']) ? (bool)$_POST['published'] : false;
 $template = sanitize_text($_POST['template'] ?? '');
-if ($template === '') {
-    $template = 'page.php';
-}
 $meta_title = sanitize_text($_POST['meta_title'] ?? '');
 $meta_description = sanitize_text($_POST['meta_description'] ?? '');
 $canonical_url = sanitize_url($_POST['canonical_url'] ?? '');
@@ -40,166 +25,33 @@ $og_description = sanitize_text($_POST['og_description'] ?? '');
 $og_image = sanitize_url($_POST['og_image'] ?? '');
 $access = sanitize_text($_POST['access'] ?? 'public');
 
-if ($title === '') {
-    http_response_code(400);
-    echo 'Missing fields';
-    exit;
-}
+$service = new PageService(
+    $pagesFile,
+    $historyFile,
+    function () use ($pagesFile) {
+        $sitemapPath = __DIR__ . '/../../../sitemap.xml';
+        return regenerate_sitemap($pagesFile, $sitemapPath, $_SERVER);
+    }
+);
 
-if ($id) {
-    // Update existing
-    $old = null;
-    foreach ($pages as &$p) {
-        if ($p['id'] == $id) {
-            $old = $p;
-            $p['title'] = $title;
-            $p['slug'] = $slug;
-            $p['content'] = $content;
-            $p['published'] = $published;
-            $p['template'] = $template;
-            $p['meta_title'] = $meta_title;
-            $p['meta_description'] = $meta_description;
-            $p['canonical_url'] = $canonical_url;
-            $p['og_title'] = $og_title;
-            $p['og_description'] = $og_description;
-            $p['og_image'] = $og_image;
-            $p['access'] = $access;
-            $p['last_modified'] = time();
-            $timestamp = $p['last_modified'];
-            break;
-        }
-    }
-    $changes = [];
-    $details = [];
-    if ($old) {
-        if ($old['title'] !== $title) {
-            $details[] = 'Title: "' . $old['title'] . '" → "' . $title . '"';
-        }
-        if ($old['slug'] !== $slug) {
-            $details[] = 'Slug: ' . $old['slug'] . ' → ' . $slug;
-        }
-        if ($old['template'] !== $template) {
-            $details[] = 'Template: ' . $old['template'] . ' → ' . $template;
-            $changes[] = 'Changed template';
-        }
-        if ($old['published'] != $published) {
-            $details[] = 'Visibility: ' . ($old['published'] ? 'Published' : 'Unpublished') . ' → ' . ($published ? 'Published' : 'Unpublished');
-            $changes[] = $published ? 'Published page' : 'Unpublished page';
-        }
-        if ($old['meta_title'] !== $meta_title) {
-            $details[] = 'Meta title updated';
-        }
-        if (($old['meta_description'] ?? '') !== $meta_description) {
-            $details[] = 'Meta description updated';
-        }
-        if (($old['canonical_url'] ?? '') !== $canonical_url) {
-            $details[] = 'Canonical URL: ' . (($old['canonical_url'] ?? '') !== '' ? ($old['canonical_url'] ?? '') : 'none') . ' → ' . ($canonical_url !== '' ? $canonical_url : 'none');
-        }
-        if ($old['og_title'] !== $og_title) {
-            $details[] = 'OG title: "' . $old['og_title'] . '" → "' . $og_title . '"';
-        }
-        if ($old['og_description'] !== $og_description) {
-            $details[] = 'OG description updated';
-        }
-        if ($old['og_image'] !== $og_image) {
-            $details[] = 'OG image: ' . ($old['og_image'] !== '' ? $old['og_image'] : 'none') . ' → ' . ($og_image !== '' ? $og_image : 'none');
-        }
-        if ($old['access'] !== $access) {
-            $details[] = 'Access: ' . $old['access'] . ' → ' . $access;
-        }
-    }
-    if (!$changes) {
-        $changes[] = 'Updated page settings';
-    }
-    if (!$details) {
-        $details[] = 'Saved without changing any settings.';
-    }
-    $action = implode('; ', $changes);
-    unset($p);
-} else {
-    $id = 1;
-    foreach ($pages as $p) {
-        if ($p['id'] >= $id) $id = $p['id'] + 1;
-    }
-    $pages[] = [
-        'id' => $id,
-        'title' => $title,
-        'slug' => $slug,
-        'content' => $content,
-        'published' => $published,
-        'template' => $template,
-        'meta_title' => $meta_title,
-        'meta_description' => $meta_description,
-        'canonical_url' => $canonical_url,
-        'og_title' => $og_title,
-        'og_description' => $og_description,
-        'og_image' => $og_image,
-        'access' => $access,
-        'views' => 0,
-        'last_modified' => time()
-    ];
-    $timestamp = $pages[array_key_last($pages)]['last_modified'];
-    $details = [
-        'Initial template: ' . $template,
-        'Visibility: ' . ($published ? 'Published' : 'Unpublished'),
-        'Access: ' . $access,
-    ];
-    $action = 'created page with template ' . $template;
-}
-
-$historyFile = __DIR__ . '/../../data/page_history.json';
-$historyData = read_json_file($historyFile);
-if (!isset($historyData[$id])) $historyData[$id] = [];
-$user = $_SESSION['user']['username'] ?? 'Unknown';
-$historyData[$id][] = [
-    'time' => $timestamp,
-    'user' => $user,
-    'action' => $action,
-    'details' => $details,
-    'context' => 'page',
-    'page_id' => $id,
+$payload = [
+    'id' => $id,
+    'title' => $title,
+    'slug' => $slug,
+    'content' => $content,
+    'published' => $published,
+    'template' => $template,
+    'meta_title' => $meta_title,
+    'meta_description' => $meta_description,
+    'canonical_url' => $canonical_url,
+    'og_title' => $og_title,
+    'og_description' => $og_description,
+    'og_image' => $og_image,
+    'access' => $access,
 ];
-$historyData[$id] = array_slice($historyData[$id], -20);
 
-if (!isset($historyData['__system__'])) {
-    $historyData['__system__'] = [];
-}
-$historyData['__system__'][] = [
-    'time' => time(),
-    'user' => '',
-    'action' => 'Regenerated sitemap',
-    'details' => [
-        'Automatic sitemap refresh after updating "' . $title . '" (' . $slug . ')',
-    ],
-    'context' => 'system',
-    'meta' => [
-        'trigger' => 'sitemap_regeneration',
-        'page_id' => $id,
-    ],
-    'page_title' => 'CMS Backend',
-];
-$historyData['__system__'] = array_slice($historyData['__system__'], -50);
-file_put_contents($historyFile, json_encode($historyData, JSON_PRETTY_PRINT));
+$response = $service->save($payload, $_SESSION['user']['username'] ?? 'Unknown');
 
-file_put_contents($pagesFile, json_encode($pages, JSON_PRETTY_PRINT));
-// Regenerate sitemap whenever pages are modified
-// Capture the output from the sitemap generator so we don't surface raw
-// JSON responses in the page editor.
-ob_start();
-require_once __DIR__ . '/../sitemap/generate.php';
-$sitemapOutput = ob_get_clean();
-
-// Reset the response headers to a plain text response for this endpoint
-// (generate.php sets JSON headers when run directly).
-header('Content-Type: text/plain; charset=UTF-8');
-
-if ($sitemapOutput !== '') {
-    $decoded = json_decode($sitemapOutput, true);
-    if (is_array($decoded) && isset($decoded['success']) && !$decoded['success']) {
-        http_response_code(500);
-        echo $decoded['message'] ?? 'Failed to regenerate sitemap.';
-        exit;
-    }
-}
-
-echo 'OK';
+http_response_code($response['status'] ?? 200);
+header('Content-Type: application/json; charset=UTF-8');
+echo json_encode($response);

--- a/CMS/modules/sitemap/SitemapService.php
+++ b/CMS/modules/sitemap/SitemapService.php
@@ -1,0 +1,121 @@
+<?php
+require_once __DIR__ . '/../../includes/data.php';
+
+/**
+ * Regenerate the sitemap using the stored pages dataset.
+ *
+ * @param string     $pagesFile   Path to the pages JSON dataset.
+ * @param string     $sitemapPath Path to the sitemap.xml output file.
+ * @param array|null $server      Optional server context (defaults to $_SERVER).
+ *
+ * @return array{success:bool,message:string,entryCount?:int,generatedAt?:int,generatedAtFormatted?:string,entries?:array,sitemapUrl?:string,generator?:string,error?:string}
+ */
+function regenerate_sitemap(string $pagesFile, string $sitemapPath, ?array $server = null): array
+{
+    $server = $server ?? $_SERVER;
+
+    try {
+        $pages = read_json_file($pagesFile);
+        if (!is_array($pages)) {
+            $pages = [];
+        }
+
+        $published = array_values(array_filter($pages, static function ($page) {
+            return !empty($page['published']);
+        }));
+
+        $scheme = 'http';
+        if (isset($server['HTTPS']) && $server['HTTPS'] === 'on') {
+            $scheme = 'https';
+        }
+
+        $host = $server['HTTP_HOST'] ?? 'localhost';
+        $scriptName = $server['SCRIPT_NAME'] ?? '/';
+        $scriptBase = rtrim(dirname($scriptName), '/');
+        if (substr($scriptBase, -4) === '/CMS') {
+            $scriptBase = substr($scriptBase, 0, -4);
+        }
+        $scriptBase = rtrim($scriptBase, '/');
+        $baseUrl = rtrim($scheme . '://' . $host . ($scriptBase !== '' ? '/' . ltrim($scriptBase, '/') : ''), '/');
+
+        $entries = [];
+        foreach ($published as $page) {
+            $slug = ltrim((string)($page['slug'] ?? ''), '/');
+            $lastModified = isset($page['last_modified']) ? (int)$page['last_modified'] : time();
+            $lastmodDate = date('Y-m-d', $lastModified);
+
+            $entries[] = [
+                'title' => (string)($page['title'] ?? ''),
+                'slug' => $slug,
+                'url' => $baseUrl . '/' . $slug,
+                'lastmodHuman' => date('F j, Y', $lastModified),
+                'lastmod' => $lastmodDate,
+            ];
+        }
+
+        $domAvailable = class_exists('DOMDocument');
+
+        if ($domAvailable) {
+            $dom = new DOMDocument('1.0', 'UTF-8');
+            $urlset = $dom->createElement('urlset');
+            $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+            foreach ($entries as $entry) {
+                $url = $dom->createElement('url');
+                $loc = $dom->createElement('loc', $entry['url']);
+                $lastmod = $dom->createElement('lastmod', $entry['lastmod']);
+
+                $url->appendChild($loc);
+                $url->appendChild($lastmod);
+                $urlset->appendChild($url);
+            }
+
+            $dom->appendChild($urlset);
+            $dom->formatOutput = true;
+
+            if ($dom->save($sitemapPath) === false) {
+                throw new RuntimeException('Unable to write sitemap file.');
+            }
+        } else {
+            $lines = [
+                '<?xml version="1.0" encoding="UTF-8"?>',
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            ];
+
+            foreach ($entries as $entry) {
+                $loc = htmlspecialchars($entry['url'], ENT_XML1);
+                $lastmod = htmlspecialchars($entry['lastmod'], ENT_XML1);
+                $lines[] = '  <url>';
+                $lines[] = '    <loc>' . $loc . '</loc>';
+                $lines[] = '    <lastmod>' . $lastmod . '</lastmod>';
+                $lines[] = '  </url>';
+            }
+
+            $lines[] = '</urlset>';
+            $xml = implode("\n", $lines);
+
+            if (file_put_contents($sitemapPath, $xml) === false) {
+                throw new RuntimeException('Unable to write sitemap file.');
+            }
+        }
+
+        $generatedAt = file_exists($sitemapPath) ? (filemtime($sitemapPath) ?: time()) : time();
+
+        return [
+            'success' => true,
+            'message' => 'Sitemap regenerated successfully.',
+            'entryCount' => count($entries),
+            'generatedAt' => $generatedAt,
+            'generatedAtFormatted' => date('F j, Y g:i a', $generatedAt),
+            'entries' => $entries,
+            'sitemapUrl' => $baseUrl . '/sitemap.xml',
+            'generator' => $domAvailable ? 'dom' : 'simple',
+        ];
+    } catch (Throwable $exception) {
+        return [
+            'success' => false,
+            'message' => 'Failed to regenerate sitemap.',
+            'error' => $exception->getMessage(),
+        ];
+    }
+}

--- a/CMS/modules/sitemap/generate.php
+++ b/CMS/modules/sitemap/generate.php
@@ -2,111 +2,18 @@
 // File: generate.php
 // Generate sitemap.xml listing all published pages
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/SitemapService.php';
 require_login();
 
-header('Content-Type: application/json');
+header('Content-Type: application/json; charset=UTF-8');
 
-try {
-    $pagesFile = __DIR__ . '/../../data/pages.json';
-    $pages = read_json_file($pagesFile);
-    if (!is_array($pages)) {
-        $pages = [];
-    }
+$pagesFile = __DIR__ . '/../../data/pages.json';
+$sitemapPath = __DIR__ . '/../../../sitemap.xml';
 
-    $published = array_values(array_filter($pages, function ($page) {
-        return !empty($page['published']);
-    }));
-
-    $scheme = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on') ? 'https' : 'http';
-    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-    $scriptBase = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
-    if (substr($scriptBase, -4) === '/CMS') {
-        $scriptBase = substr($scriptBase, 0, -4);
-    }
-    $scriptBase = rtrim($scriptBase, '/');
-    $baseUrl = $scheme . '://' . $host . $scriptBase;
-
-    $entries = [];
-    foreach ($published as $page) {
-        $slug = ltrim((string)($page['slug'] ?? ''), '/');
-        $lastModified = isset($page['last_modified']) ? (int)$page['last_modified'] : time();
-        $lastmodDate = date('Y-m-d', $lastModified);
-
-        $entries[] = [
-            'title' => (string)($page['title'] ?? ''),
-            'slug' => $slug,
-            'url' => $baseUrl . '/' . $slug,
-            'lastmodHuman' => date('F j, Y', $lastModified),
-            'lastmod' => $lastmodDate,
-        ];
-    }
-
-    $sitemapPath = __DIR__ . '/../../../sitemap.xml';
-    $domAvailable = class_exists('DOMDocument');
-
-    if ($domAvailable) {
-        $dom = new DOMDocument('1.0', 'UTF-8');
-        $urlset = $dom->createElement('urlset');
-        $urlset->setAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
-
-        foreach ($entries as $entry) {
-            $url = $dom->createElement('url');
-            $loc = $dom->createElement('loc', $entry['url']);
-            $lastmod = $dom->createElement('lastmod', $entry['lastmod']);
-
-            $url->appendChild($loc);
-            $url->appendChild($lastmod);
-            $urlset->appendChild($url);
-        }
-
-        $dom->appendChild($urlset);
-        $dom->formatOutput = true;
-
-        if ($dom->save($sitemapPath) === false) {
-            throw new RuntimeException('Unable to write sitemap file.');
-        }
-    } else {
-        $lines = [
-            '<?xml version="1.0" encoding="UTF-8"?>',
-            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
-        ];
-
-        foreach ($entries as $entry) {
-            $loc = htmlspecialchars($entry['url'], ENT_XML1);
-            $lastmod = htmlspecialchars($entry['lastmod'], ENT_XML1);
-            $lines[] = '  <url>';
-            $lines[] = '    <loc>' . $loc . '</loc>';
-            $lines[] = '    <lastmod>' . $lastmod . '</lastmod>';
-            $lines[] = '  </url>';
-        }
-
-        $lines[] = '</urlset>';
-        $xml = implode("\n", $lines);
-
-        if (file_put_contents($sitemapPath, $xml) === false) {
-            throw new RuntimeException('Unable to write sitemap file.');
-        }
-    }
-
-    $generatedAt = filemtime($sitemapPath) ?: time();
-
-    echo json_encode([
-        'success' => true,
-        'message' => 'Sitemap regenerated successfully.',
-        'entryCount' => count($entries),
-        'generatedAt' => $generatedAt,
-        'generatedAtFormatted' => date('F j, Y g:i a', $generatedAt),
-        'entries' => $entries,
-        'sitemapUrl' => $baseUrl . '/sitemap.xml',
-        'generator' => $domAvailable ? 'dom' : 'simple',
-    ]);
-} catch (Throwable $exception) {
+$result = regenerate_sitemap($pagesFile, $sitemapPath, $_SERVER);
+if (($result['success'] ?? false) !== true) {
     http_response_code(500);
-    echo json_encode([
-        'success' => false,
-        'message' => 'Failed to regenerate sitemap.',
-        'error' => $exception->getMessage(),
-    ]);
 }
+
+echo json_encode($result);
 ?>

--- a/tests/page_service_test.php
+++ b/tests/page_service_test.php
@@ -1,0 +1,158 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/pages/PageService.php';
+require_once __DIR__ . '/../CMS/modules/sitemap/SitemapService.php';
+
+function create_temp_json_file(array $data): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'sparkcms_');
+    if ($path === false) {
+        throw new RuntimeException('Unable to create temporary file.');
+    }
+    file_put_contents($path, json_encode($data));
+    return $path;
+}
+
+$pagesFile = create_temp_json_file([]);
+$historyFile = create_temp_json_file([]);
+$regenerationCalls = 0;
+
+$service = new PageService(
+    $pagesFile,
+    $historyFile,
+    function () use (&$regenerationCalls) {
+        $regenerationCalls++;
+        return [
+            'success' => true,
+            'message' => 'Sitemap regenerated successfully.',
+        ];
+    }
+);
+
+// Slug normalization on create
+$createResponse = $service->save([
+    'title' => 'Hello World!',
+    'slug' => '',
+    'content' => '<p>Sample</p>',
+    'published' => true,
+    'template' => '',
+    'meta_title' => '',
+    'meta_description' => '',
+    'canonical_url' => '',
+    'og_title' => '',
+    'og_description' => '',
+    'og_image' => '',
+    'access' => 'public',
+], 'tester');
+
+if (($createResponse['success'] ?? false) !== true) {
+    throw new RuntimeException('Creating a page should succeed.');
+}
+if ($createResponse['page']['slug'] !== 'hello-world') {
+    throw new RuntimeException('Slug should normalize to "hello-world".');
+}
+if ($createResponse['status'] !== 201) {
+    throw new RuntimeException('Creating a page should return HTTP 201 status.');
+}
+
+$pageId = $createResponse['page']['id'];
+
+// History diff generation on update
+$updateResponse = $service->save([
+    'id' => $pageId,
+    'title' => 'Updated World',
+    'slug' => 'Updated World Revisited',
+    'content' => '<p>Updated content</p>',
+    'published' => false,
+    'template' => 'landing.php',
+    'meta_title' => 'New Meta Title',
+    'meta_description' => 'New meta description',
+    'canonical_url' => 'https://example.com/new',
+    'og_title' => 'New OG',
+    'og_description' => 'New OG description',
+    'og_image' => 'https://example.com/image.png',
+    'access' => 'members',
+], 'editor');
+
+if (($updateResponse['success'] ?? false) !== true) {
+    throw new RuntimeException('Updating a page should succeed.');
+}
+
+$historyData = json_decode(file_get_contents($historyFile), true);
+$pageHistory = $historyData[$pageId] ?? [];
+if (empty($pageHistory)) {
+    throw new RuntimeException('Page history should include entries for the updated page.');
+}
+$latestHistory = $pageHistory[array_key_last($pageHistory)];
+$details = $latestHistory['details'] ?? [];
+$expectedSnippets = [
+    'Title: "Hello World!" → "Updated World"',
+    'Slug: hello-world → updated-world-revisited',
+    'Template: page.php → landing.php',
+    'Visibility: Published → Unpublished',
+    'Access: public → members',
+];
+foreach ($expectedSnippets as $snippet) {
+    $found = false;
+    foreach ($details as $detail) {
+        if (strpos($detail, $snippet) !== false) {
+            $found = true;
+            break;
+        }
+    }
+    if (!$found) {
+        throw new RuntimeException('Expected history detail missing: ' . $snippet);
+    }
+}
+
+// Sitemap regeneration error handling
+$pagesFileFailure = create_temp_json_file([]);
+$historyFileFailure = create_temp_json_file([]);
+$serviceWithFailure = new PageService(
+    $pagesFileFailure,
+    $historyFileFailure,
+    function () {
+        return [
+            'success' => false,
+            'message' => 'Simulated failure',
+        ];
+    }
+);
+
+$failureResponse = $serviceWithFailure->save([
+    'title' => 'Broken Sitemap',
+    'slug' => '',
+    'content' => 'Test',
+    'published' => false,
+    'template' => '',
+    'meta_title' => '',
+    'meta_description' => '',
+    'canonical_url' => '',
+    'og_title' => '',
+    'og_description' => '',
+    'og_image' => '',
+    'access' => 'public',
+], 'operator');
+
+if (($failureResponse['success'] ?? true) !== false) {
+    throw new RuntimeException('Failure response should indicate error.');
+}
+if (($failureResponse['status'] ?? 0) !== 500) {
+    throw new RuntimeException('Sitemap failure should map to HTTP 500.');
+}
+if (($failureResponse['sitemap']['message'] ?? '') !== 'Simulated failure') {
+    throw new RuntimeException('Sitemap error message should be returned.');
+}
+
+// Cleanup
+foreach ([
+    $pagesFile,
+    $historyFile,
+    $pagesFileFailure,
+    $historyFileFailure,
+] as $path) {
+    if (file_exists($path)) {
+        unlink($path);
+    }
+}
+
+echo "PageService tests passed\n";


### PR DESCRIPTION
## Summary
- introduce a reusable PageService that validates input, normalizes slugs, persists pages, and records history updates
- extract sitemap regeneration into a shared SitemapService utility and update the generator endpoint to consume it
- route save_page.php through the new service and cover slug, history, and sitemap failure scenarios with automated tests

## Testing
- php tests/page_service_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4e1f9760833181cd4c6c9ca7e51f