### PR TITLE
Refactor settings persistence with service and upload handler

### DIFF
--- a/CMS/includes/UploadHandler.php
+++ b/CMS/includes/UploadHandler.php
@@ -1,0 +1,164 @@
+<?php
+// File: CMS/includes/UploadHandler.php
+
+class UploadHandler
+{
+    /** @var string */
+    private $uploadsDir;
+
+    /** @var string */
+    private $uploadsRoot;
+
+    /** @var string */
+    private $baseDir;
+
+    /** @var string */
+    private $relativePrefix;
+
+    /** @var callable */
+    private $isUploadedFileCallback;
+
+    /** @var callable */
+    private $moveUploadedFileCallback;
+
+    public function __construct(
+        string $uploadsDir,
+        string $baseDir,
+        ?callable $isUploadedFileCallback = null,
+        ?callable $moveUploadedFileCallback = null
+    ) {
+        $this->uploadsDir = rtrim($uploadsDir, DIRECTORY_SEPARATOR);
+        $this->baseDir = rtrim($baseDir, DIRECTORY_SEPARATOR);
+
+        if ($this->uploadsDir === '' || $this->baseDir === '') {
+            throw new RuntimeException('Invalid upload configuration.');
+        }
+
+        if (!is_dir($this->uploadsDir) && !@mkdir($this->uploadsDir, 0777, true) && !is_dir($this->uploadsDir)) {
+            throw new RuntimeException('Unable to create uploads directory.');
+        }
+
+        $uploadsRoot = realpath($this->uploadsDir);
+        $baseReal = realpath($this->baseDir);
+        if ($uploadsRoot === false || $baseReal === false) {
+            throw new RuntimeException('Unable to resolve upload paths.');
+        }
+
+        $this->uploadsRoot = $uploadsRoot;
+        $this->baseDir = $baseReal;
+        $relative = str_replace($this->baseDir . DIRECTORY_SEPARATOR, '', $this->uploadsRoot . DIRECTORY_SEPARATOR);
+        $relative = trim(str_replace('\\', '/', $relative), '/');
+        $this->relativePrefix = $relative !== '' ? $relative : basename($this->uploadsRoot);
+        $this->isUploadedFileCallback = $isUploadedFileCallback ?: static function ($path) {
+            return is_uploaded_file($path);
+        };
+        $this->moveUploadedFileCallback = $moveUploadedFileCallback ?: static function ($from, $to) {
+            return move_uploaded_file($from, $to);
+        };
+    }
+
+    public function validateImageUpload(array $file, array $allowedTypes, int $maxSize, string $fieldLabel): void
+    {
+        $error = $file['error'] ?? UPLOAD_ERR_NO_FILE;
+        if ($error === UPLOAD_ERR_NO_FILE || empty($file['tmp_name'])) {
+            return;
+        }
+
+        if ($error !== UPLOAD_ERR_OK) {
+            throw new InvalidArgumentException(sprintf('%s upload failed. Please try again.', $fieldLabel));
+        }
+
+        if (!call_user_func($this->isUploadedFileCallback, $file['tmp_name'])) {
+            throw new InvalidArgumentException(sprintf('%s upload failed validation.', $fieldLabel));
+        }
+
+        if (isset($file['size']) && $file['size'] > $maxSize) {
+            throw new InvalidArgumentException(
+                sprintf('%s must be smaller than %d MB.', $fieldLabel, (int) ($maxSize / (1024 * 1024)))
+            );
+        }
+
+        $mime = null;
+        if (class_exists('finfo')) {
+            $finfo = new finfo(FILEINFO_MIME_TYPE);
+            $mime = $finfo->file($file['tmp_name']);
+        }
+
+        if (!$mime && function_exists('getimagesize')) {
+            $imageInfo = @getimagesize($file['tmp_name']);
+            if ($imageInfo && isset($imageInfo['mime'])) {
+                $mime = $imageInfo['mime'];
+            }
+        }
+
+        if (!$mime || !in_array($mime, $allowedTypes, true)) {
+            throw new InvalidArgumentException(sprintf('%s must be a valid image file.', $fieldLabel));
+        }
+    }
+
+    public function storeUploadedFile(array $file, string $prefix, array $allowedExtensions = [], ?string $fallbackExtension = null): ?string
+    {
+        $error = $file['error'] ?? UPLOAD_ERR_NO_FILE;
+        if ($error === UPLOAD_ERR_NO_FILE || empty($file['tmp_name'])) {
+            return null;
+        }
+
+        if ($error !== UPLOAD_ERR_OK) {
+            throw new RuntimeException(sprintf('Unable to save %s upload.', strtolower($prefix)));
+        }
+
+        if (!call_user_func($this->isUploadedFileCallback, $file['tmp_name'])) {
+            throw new RuntimeException(sprintf('%s upload failed integrity checks.', ucfirst($prefix)));
+        }
+
+        $name = (string) ($file['name'] ?? '');
+        $extension = strtolower(pathinfo($name, PATHINFO_EXTENSION));
+        if (!empty($allowedExtensions) && !in_array($extension, $allowedExtensions, true)) {
+            $extension = $fallbackExtension ?? $allowedExtensions[0];
+        }
+
+        $filename = $prefix . '_' . uniqid('', true);
+        if ($extension !== '') {
+            $filename .= '.' . $extension;
+        }
+
+        $destination = $this->uploadsRoot . DIRECTORY_SEPARATOR . $filename;
+        if (!call_user_func($this->moveUploadedFileCallback, $file['tmp_name'], $destination)) {
+            throw new RuntimeException(sprintf('Unable to move uploaded %s.', strtolower($prefix)));
+        }
+
+        return $this->relativePrefix . '/' . $filename;
+    }
+
+    public function deleteUploadFile($relativePath): void
+    {
+        if (!is_string($relativePath) || $relativePath === '') {
+            return;
+        }
+
+        $normalized = ltrim(str_replace('\\', '/', $relativePath), '/');
+        if ($normalized === '') {
+            return;
+        }
+
+        $prefix = $this->relativePrefix;
+        if ($prefix !== '' && strpos($normalized, $prefix . '/') !== 0 && $normalized !== $prefix) {
+            return;
+        }
+
+        $fullPath = $this->baseDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $normalized);
+        $realFullPath = realpath($fullPath);
+        if ($realFullPath === false) {
+            return;
+        }
+
+        if (strpos($realFullPath, $this->uploadsRoot) === 0 && is_file($realFullPath)) {
+            @unlink($realFullPath);
+        }
+    }
+
+    public function getUploadsRoot(): string
+    {
+        return $this->uploadsRoot;
+    }
+}

--- a/CMS/modules/settings/SettingsService.php
+++ b/CMS/modules/settings/SettingsService.php
@@ -1,0 +1,240 @@
+<?php
+// File: CMS/modules/settings/SettingsService.php
+
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/../../includes/settings.php';
+require_once __DIR__ . '/../../includes/UploadHandler.php';
+
+class SettingsService
+{
+    /** @var string */
+    private $settingsFile;
+
+    /** @var UploadHandler */
+    private $uploadHandler;
+
+    /** @var array<int, string> */
+    private $allowedImageTypes = [
+        'image/gif',
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+    ];
+
+    /** @var array<int, string> */
+    private $allowedFaviconTypes;
+
+    /** @var int */
+    private $maxUploadSize;
+
+    public function __construct(string $settingsFile, UploadHandler $uploadHandler, ?int $maxUploadSize = null)
+    {
+        $this->settingsFile = $settingsFile;
+        $this->uploadHandler = $uploadHandler;
+        $this->allowedFaviconTypes = array_merge(
+            $this->allowedImageTypes,
+            [
+                'image/x-icon',
+                'image/vnd.microsoft.icon',
+                'image/svg+xml',
+            ]
+        );
+        $this->maxUploadSize = $maxUploadSize ?? (5 * 1024 * 1024);
+    }
+
+    /**
+     * Persist settings based on the provided form payload and files.
+     *
+     * @param array<string, mixed> $form
+     * @param array<string, mixed> $files
+     *
+     * @return array<string, mixed>
+     */
+    public function save(array $form, array $files): array
+    {
+        $settings = read_json_file($this->settingsFile);
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+
+        $settings['site_name'] = sanitize_text($form['site_name'] ?? ($settings['site_name'] ?? ''));
+        $settings['tagline'] = sanitize_text($form['tagline'] ?? ($settings['tagline'] ?? ''));
+        $settings['admin_email'] = sanitize_text($form['admin_email'] ?? ($settings['admin_email'] ?? ''));
+        $settings['timezone'] = sanitize_text($form['timezone'] ?? ($settings['timezone'] ?? 'America/Denver'));
+        if ($settings['timezone'] === '') {
+            $settings['timezone'] = 'America/Denver';
+        }
+        $settings['googleAnalytics'] = sanitize_text($form['googleAnalytics'] ?? ($settings['googleAnalytics'] ?? ''));
+        $settings['googleSearchConsole'] = sanitize_text($form['googleSearchConsole'] ?? ($settings['googleSearchConsole'] ?? ''));
+        $settings['facebookPixel'] = sanitize_text($form['facebookPixel'] ?? ($settings['facebookPixel'] ?? ''));
+        $settings['generateSitemap'] = !empty($form['generateSitemap']);
+        $settings['allowIndexing'] = !empty($form['allowIndexing']);
+
+        $this->uploadHandler->validateImageUpload($files['logo'] ?? [], $this->allowedImageTypes, $this->maxUploadSize, 'Logo');
+        $this->uploadHandler->validateImageUpload($files['favicon'] ?? [], $this->allowedFaviconTypes, $this->maxUploadSize, 'Favicon');
+        $this->uploadHandler->validateImageUpload($files['ogImage'] ?? [], $this->allowedImageTypes, $this->maxUploadSize, 'Open graph image');
+
+        $settings = $this->syncSocialLinks($settings, $form);
+        $settings = $this->syncOpenGraph($settings, $form, $files);
+        $settings = $this->syncBrandAssets($settings, $form, $files);
+
+        $settings['last_updated'] = date('c');
+
+        if (!write_json_file($this->settingsFile, $settings)) {
+            throw new RuntimeException('Unable to write settings file.');
+        }
+
+        set_site_settings_cache($settings);
+
+        $openGraph = $settings['open_graph'] ?? [];
+
+        return [
+            'last_updated' => $settings['last_updated'],
+            'logo' => $settings['logo'] ?? null,
+            'favicon' => $settings['favicon'] ?? null,
+            'open_graph' => [
+                'image' => $openGraph['image'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $form
+     * @param array<string, mixed> $files
+     *
+     * @return array<string, mixed>
+     */
+    private function syncBrandAssets(array $settings, array $form, array $files): array
+    {
+        $logoResult = $this->processAsset(
+            $settings['logo'] ?? null,
+            $files['logo'] ?? [],
+            'logo',
+            !empty($form['clear_logo'])
+        );
+        if ($logoResult['path'] !== null) {
+            $settings['logo'] = $logoResult['path'];
+        } else {
+            unset($settings['logo']);
+        }
+
+        $faviconResult = $this->processAsset(
+            $settings['favicon'] ?? null,
+            $files['favicon'] ?? [],
+            'favicon',
+            !empty($form['clear_favicon']),
+            ['gif', 'jpg', 'jpeg', 'png', 'webp', 'ico', 'svg'],
+            'png'
+        );
+        if ($faviconResult['path'] !== null) {
+            $settings['favicon'] = $faviconResult['path'];
+        } else {
+            unset($settings['favicon']);
+        }
+
+        return $settings;
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $form
+     * @param array<string, mixed> $files
+     *
+     * @return array<string, mixed>
+     */
+    private function syncOpenGraph(array $settings, array $form, array $files): array
+    {
+        $openGraph = is_array($settings['open_graph'] ?? null) ? $settings['open_graph'] : [];
+        $openGraph['title'] = sanitize_text($form['ogTitle'] ?? ($openGraph['title'] ?? ''));
+        $openGraph['description'] = sanitize_text($form['ogDescription'] ?? ($openGraph['description'] ?? ''));
+
+        $ogResult = $this->processAsset(
+            $openGraph['image'] ?? null,
+            $files['ogImage'] ?? [],
+            'og',
+            !empty($form['clear_og_image'])
+        );
+        if ($ogResult['path'] !== null) {
+            $openGraph['image'] = $ogResult['path'];
+        } else {
+            unset($openGraph['image']);
+        }
+
+        $settings['open_graph'] = $openGraph;
+        return $settings;
+    }
+
+    /**
+     * @param array<string, mixed> $settings
+     * @param array<string, mixed> $form
+     *
+     * @return array<string, mixed>
+     */
+    private function syncSocialLinks(array $settings, array $form): array
+    {
+        $social = is_array($settings['social'] ?? null) ? $settings['social'] : [];
+        $fields = [
+            'facebook',
+            'twitter',
+            'instagram',
+            'linkedin',
+            'youtube',
+            'tiktok',
+            'pinterest',
+            'snapchat',
+            'reddit',
+            'threads',
+            'mastodon',
+            'github',
+            'dribbble',
+            'twitch',
+            'whatsapp',
+        ];
+
+        foreach ($fields as $field) {
+            $social[$field] = sanitize_url($form[$field] ?? ($social[$field] ?? ''));
+        }
+
+        $settings['social'] = $social;
+        return $settings;
+    }
+
+    /**
+     * @param string|null $previous
+     * @param array<string, mixed> $file
+     *
+     * @return array{path: string|null, uploaded: bool}
+     */
+    private function processAsset(
+        ?string $previous,
+        array $file,
+        string $prefix,
+        bool $cleared,
+        array $allowedExtensions = [],
+        ?string $fallbackExtension = null
+    ): array {
+        $path = $previous;
+        $uploaded = false;
+
+        $stored = $this->uploadHandler->storeUploadedFile($file, $prefix, $allowedExtensions, $fallbackExtension);
+        if ($stored !== null) {
+            if ($previous && $previous !== $stored) {
+                $this->uploadHandler->deleteUploadFile($previous);
+            }
+            $path = $stored;
+            $uploaded = true;
+        } elseif ($cleared) {
+            if ($previous) {
+                $this->uploadHandler->deleteUploadFile($previous);
+            }
+            $path = null;
+        }
+
+        return [
+            'path' => $path,
+            'uploaded' => $uploaded,
+        ];
+    }
+}

--- a/CMS/modules/settings/save_settings.php
+++ b/CMS/modules/settings/save_settings.php
@@ -4,283 +4,40 @@ require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
 require_once __DIR__ . '/../../includes/settings.php';
+require_once __DIR__ . '/SettingsService.php';
 require_login();
 
 header('Content-Type: application/json');
 
-$settingsFile = get_settings_file_path();
-$settings = read_json_file($settingsFile);
-if (!is_array($settings)) {
-    $settings = [];
-}
-
-$settings['site_name'] = sanitize_text($_POST['site_name'] ?? ($settings['site_name'] ?? ''));
-$settings['tagline'] = sanitize_text($_POST['tagline'] ?? ($settings['tagline'] ?? ''));
-$settings['admin_email'] = sanitize_text($_POST['admin_email'] ?? ($settings['admin_email'] ?? ''));
-$settings['timezone'] = sanitize_text($_POST['timezone'] ?? ($settings['timezone'] ?? 'America/Denver'));
-$settings['googleAnalytics'] = sanitize_text($_POST['googleAnalytics'] ?? ($settings['googleAnalytics'] ?? ''));
-$settings['googleSearchConsole'] = sanitize_text($_POST['googleSearchConsole'] ?? ($settings['googleSearchConsole'] ?? ''));
-$settings['facebookPixel'] = sanitize_text($_POST['facebookPixel'] ?? ($settings['facebookPixel'] ?? ''));
-$settings['generateSitemap'] = isset($_POST['generateSitemap']);
-$settings['allowIndexing'] = isset($_POST['allowIndexing']);
-
-function delete_upload_file($relativePath, $uploadsRoot, $baseDir)
-{
-    if (!is_string($relativePath) || $relativePath === '') {
-        return;
+try {
+    $settingsFile = get_settings_file_path();
+    $baseDir = realpath(__DIR__ . '/../../');
+    if ($baseDir === false) {
+        throw new RuntimeException('Unable to resolve application path.');
     }
 
-    $relativePath = ltrim($relativePath, '/');
-    if (strpos($relativePath, 'uploads/') !== 0) {
-        return;
-    }
+    $uploadHandler = new UploadHandler($baseDir . '/uploads', $baseDir);
+    $service = new SettingsService($settingsFile, $uploadHandler);
 
-    if (!$uploadsRoot || !$baseDir) {
-        return;
-    }
+    $result = $service->save($_POST, $_FILES);
 
-    $fullPath = $baseDir . DIRECTORY_SEPARATOR . $relativePath;
-    $realFullPath = realpath($fullPath);
-
-    if ($realFullPath === false) {
-        return;
-    }
-
-    if (strpos($realFullPath, $uploadsRoot) === 0 && is_file($realFullPath)) {
-        @unlink($realFullPath);
-    }
-}
-
-$uploadDir = __DIR__ . '/../../uploads';
-if (!is_dir($uploadDir)) {
-    mkdir($uploadDir, 0777, true);
-}
-$baseDir = realpath(__DIR__ . '/../../');
-$uploadsRoot = realpath($uploadDir);
-
-$previousLogo = $settings['logo'] ?? null;
-$previousFavicon = $settings['favicon'] ?? null;
-
-$logoCleared = !empty($_POST['clear_logo']);
-$faviconCleared = !empty($_POST['clear_favicon']);
-$newLogo = $previousLogo;
-$newFavicon = $previousFavicon;
-$logoUploaded = false;
-$faviconUploaded = false;
-
-$allowedImageTypes = [
-    'image/gif',
-    'image/jpeg',
-    'image/png',
-    'image/webp',
-];
-$allowedFaviconTypes = array_merge($allowedImageTypes, [
-    'image/x-icon',
-    'image/vnd.microsoft.icon',
-    'image/svg+xml',
-]);
-$maxUploadSize = 5 * 1024 * 1024; // 5 MB
-
-function validate_image_upload(array $file, array $allowedTypes, int $maxSize, string $fieldLabel)
-{
-    if (($file['error'] ?? UPLOAD_ERR_NO_FILE) === UPLOAD_ERR_NO_FILE || empty($file['tmp_name'])) {
-        return ['valid' => true];
-    }
-
-    if (($file['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
-        return [
-            'valid' => false,
-            'message' => sprintf('%s upload failed. Please try again.', $fieldLabel),
-        ];
-    }
-
-    if (!is_uploaded_file($file['tmp_name'])) {
-        return [
-            'valid' => false,
-            'message' => sprintf('%s upload failed validation.', $fieldLabel),
-        ];
-    }
-
-    if (isset($file['size']) && $file['size'] > $maxSize) {
-        return [
-            'valid' => false,
-            'message' => sprintf('%s must be smaller than %d MB.', $fieldLabel, (int) ($maxSize / (1024 * 1024))),
-        ];
-    }
-
-    $mime = null;
-    if (class_exists('finfo')) {
-        $finfo = new finfo(FILEINFO_MIME_TYPE);
-        $mime = $finfo->file($file['tmp_name']);
-    }
-
-    if (!$mime && function_exists('getimagesize')) {
-        $imageInfo = @getimagesize($file['tmp_name']);
-        if ($imageInfo && isset($imageInfo['mime'])) {
-            $mime = $imageInfo['mime'];
-        }
-    }
-
-    if (!$mime || !in_array($mime, $allowedTypes, true)) {
-        return [
-            'valid' => false,
-            'message' => sprintf('%s must be a valid image file.', $fieldLabel),
-        ];
-    }
-
-    return ['valid' => true];
-}
-
-$logoValidation = validate_image_upload($_FILES['logo'] ?? [], $allowedImageTypes, $maxUploadSize, 'Logo');
-if (!$logoValidation['valid']) {
+    echo json_encode([
+        'status' => 'ok',
+        'last_updated' => $result['last_updated'],
+        'logo' => $result['logo'],
+        'favicon' => $result['favicon'],
+        'open_graph' => $result['open_graph'],
+    ]);
+} catch (InvalidArgumentException $e) {
     http_response_code(400);
     echo json_encode([
         'status' => 'error',
-        'message' => $logoValidation['message'],
+        'message' => $e->getMessage(),
     ]);
-    exit;
-}
-
-$faviconValidation = validate_image_upload($_FILES['favicon'] ?? [], $allowedFaviconTypes, $maxUploadSize, 'Favicon');
-if (!$faviconValidation['valid']) {
-    http_response_code(400);
+} catch (RuntimeException $e) {
+    http_response_code(500);
     echo json_encode([
         'status' => 'error',
-        'message' => $faviconValidation['message'],
+        'message' => $e->getMessage(),
     ]);
-    exit;
 }
-
-$ogValidation = validate_image_upload($_FILES['ogImage'] ?? [], $allowedImageTypes, $maxUploadSize, 'Open graph image');
-if (!$ogValidation['valid']) {
-    http_response_code(400);
-    echo json_encode([
-        'status' => 'error',
-        'message' => $ogValidation['message'],
-    ]);
-    exit;
-}
-
-if (!empty($_FILES['logo']['name']) && is_uploaded_file($_FILES['logo']['tmp_name'])) {
-    $ext = strtolower(pathinfo($_FILES['logo']['name'], PATHINFO_EXTENSION));
-    $safe = 'logo_' . uniqid('', true) . '.' . $ext;
-    $dest = $uploadDir . '/' . $safe;
-    if (move_uploaded_file($_FILES['logo']['tmp_name'], $dest)) {
-        $newLogo = 'uploads/' . $safe;
-        $logoUploaded = true;
-    }
-}
-
-if (!empty($_FILES['favicon']['name']) && is_uploaded_file($_FILES['favicon']['tmp_name'])) {
-    $ext = strtolower(pathinfo($_FILES['favicon']['name'], PATHINFO_EXTENSION));
-    $allowedExtensions = ['gif', 'jpg', 'jpeg', 'png', 'webp', 'ico', 'svg'];
-    if (!in_array($ext, $allowedExtensions, true)) {
-        $ext = 'png';
-    }
-    $safe = 'favicon_' . uniqid('', true) . '.' . $ext;
-    $dest = $uploadDir . '/' . $safe;
-    if (move_uploaded_file($_FILES['favicon']['tmp_name'], $dest)) {
-        $newFavicon = 'uploads/' . $safe;
-        $faviconUploaded = true;
-    }
-}
-
-if ($logoCleared && !$logoUploaded) {
-    $newLogo = null;
-}
-
-if ($faviconCleared && !$faviconUploaded) {
-    $newFavicon = null;
-}
-
-if ($newLogo !== null) {
-    $settings['logo'] = $newLogo;
-} else {
-    unset($settings['logo']);
-}
-
-if ($newFavicon !== null) {
-    $settings['favicon'] = $newFavicon;
-} else {
-    unset($settings['favicon']);
-}
-
-if ($previousLogo && $previousLogo !== $newLogo) {
-    delete_upload_file($previousLogo, $uploadsRoot, $baseDir);
-}
-
-if ($previousFavicon && $previousFavicon !== $newFavicon) {
-    delete_upload_file($previousFavicon, $uploadsRoot, $baseDir);
-}
-
-$social = is_array($settings['social'] ?? null) ? $settings['social'] : [];
-$socialFields = [
-    'facebook',
-    'twitter',
-    'instagram',
-    'linkedin',
-    'youtube',
-    'tiktok',
-    'pinterest',
-    'snapchat',
-    'reddit',
-    'threads',
-    'mastodon',
-    'github',
-    'dribbble',
-    'twitch',
-    'whatsapp',
-];
-foreach ($socialFields as $field) {
-    $social[$field] = sanitize_url($_POST[$field] ?? ($social[$field] ?? ''));
-}
-$settings['social'] = $social;
-
-$openGraph = is_array($settings['open_graph'] ?? null) ? $settings['open_graph'] : [];
-$previousOgImage = $openGraph['image'] ?? null;
-$openGraph['title'] = sanitize_text($_POST['ogTitle'] ?? ($openGraph['title'] ?? ''));
-$openGraph['description'] = sanitize_text($_POST['ogDescription'] ?? ($openGraph['description'] ?? ''));
-
-$ogCleared = !empty($_POST['clear_og_image']);
-$newOgImage = $previousOgImage;
-$ogUploaded = false;
-
-if (!empty($_FILES['ogImage']['name']) && is_uploaded_file($_FILES['ogImage']['tmp_name'])) {
-    $ext = strtolower(pathinfo($_FILES['ogImage']['name'], PATHINFO_EXTENSION));
-    $safe = 'og_' . uniqid('', true) . '.' . $ext;
-    $dest = $uploadDir . '/' . $safe;
-    if (move_uploaded_file($_FILES['ogImage']['tmp_name'], $dest)) {
-        $newOgImage = 'uploads/' . $safe;
-        $ogUploaded = true;
-    }
-}
-
-if ($ogCleared && !$ogUploaded) {
-    $newOgImage = null;
-}
-
-if ($newOgImage !== null) {
-    $openGraph['image'] = $newOgImage;
-} else {
-    unset($openGraph['image']);
-}
-
-if ($previousOgImage && $previousOgImage !== $newOgImage) {
-    delete_upload_file($previousOgImage, $uploadsRoot, $baseDir);
-}
-
-$settings['open_graph'] = $openGraph;
-$settings['last_updated'] = date('c');
-
-write_json_file($settingsFile, $settings);
-set_site_settings_cache($settings);
-
-echo json_encode([
-    'status' => 'ok',
-    'last_updated' => $settings['last_updated'],
-    'logo' => $settings['logo'] ?? null,
-    'favicon' => $settings['favicon'] ?? null,
-    'open_graph' => [
-        'image' => $openGraph['image'] ?? null,
-    ],
-]);

--- a/tests/settings_service_test.php
+++ b/tests/settings_service_test.php
@@ -1,0 +1,134 @@
+<?php
+require_once __DIR__ . '/../CMS/includes/data.php';
+require_once __DIR__ . '/../CMS/includes/sanitize.php';
+require_once __DIR__ . '/../CMS/includes/settings.php';
+require_once __DIR__ . '/../CMS/includes/UploadHandler.php';
+require_once __DIR__ . '/../CMS/modules/settings/SettingsService.php';
+
+function create_settings_test_environment(array $initialSettings = []): array
+{
+    $baseDir = sys_get_temp_dir() . '/sparkcms_settings_' . uniqid('', true);
+    $uploadsDir = $baseDir . '/uploads';
+    if (!@mkdir($uploadsDir, 0777, true) && !is_dir($uploadsDir)) {
+        throw new RuntimeException('Unable to create uploads fixture directory.');
+    }
+
+    $settingsFile = $baseDir . '/settings.json';
+    file_put_contents($settingsFile, json_encode($initialSettings, JSON_PRETTY_PRINT));
+
+    $handler = new UploadHandler(
+        $uploadsDir,
+        $baseDir,
+        static function () {
+            return true;
+        },
+        static function ($from, $to) {
+            return rename($from, $to);
+        }
+    );
+
+    $service = new SettingsService($settingsFile, $handler);
+
+    return [
+        'baseDir' => $baseDir,
+        'uploadsDir' => $uploadsDir,
+        'settingsFile' => $settingsFile,
+        'handler' => $handler,
+        'service' => $service,
+    ];
+}
+
+function cleanup_settings_test_environment(string $baseDir): void
+{
+    if (!is_dir($baseDir)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($baseDir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($iterator as $file) {
+        if ($file->isDir()) {
+            @rmdir($file->getPathname());
+        } else {
+            @unlink($file->getPathname());
+        }
+    }
+
+    @rmdir($baseDir);
+}
+
+$environment = create_settings_test_environment();
+$invalidFile = tempnam($environment['baseDir'], 'upload');
+if ($invalidFile === false) {
+    throw new RuntimeException('Unable to create invalid upload fixture.');
+}
+file_put_contents($invalidFile, 'not an image');
+
+try {
+    $environment['handler']->validateImageUpload(
+        [
+            'tmp_name' => $invalidFile,
+            'error' => UPLOAD_ERR_OK,
+            'size' => filesize($invalidFile),
+            'name' => 'bad.txt',
+        ],
+        ['image/png'],
+        1024,
+        'Logo'
+    );
+    throw new RuntimeException('Invalid upload should fail validation.');
+} catch (InvalidArgumentException $e) {
+    if ($e->getMessage() !== 'Logo must be a valid image file.') {
+        throw new RuntimeException('Unexpected validation error message: ' . $e->getMessage());
+    }
+} finally {
+    @unlink($invalidFile);
+    cleanup_settings_test_environment($environment['baseDir']);
+}
+
+$originalLogo = 'uploads/original.png';
+$environment = create_settings_test_environment([
+    'site_name' => 'Existing',
+    'logo' => $originalLogo,
+]);
+file_put_contents($environment['uploadsDir'] . '/original.png', 'dummy');
+
+$environment['service']->save([
+    'clear_logo' => '1',
+], []);
+
+if (file_exists($environment['uploadsDir'] . '/original.png')) {
+    throw new RuntimeException('Clearing the logo should delete the previous asset.');
+}
+
+$updated = read_json_file($environment['settingsFile']);
+if (isset($updated['logo'])) {
+    throw new RuntimeException('Logo entry should be removed after clearing.');
+}
+
+cleanup_settings_test_environment($environment['baseDir']);
+
+$environment = create_settings_test_environment();
+$environment['service']->save([
+    'facebook' => ' https://example.com/page ',
+    'instagram' => '  ',
+], []);
+
+$updated = read_json_file($environment['settingsFile']);
+$facebook = $updated['social']['facebook'] ?? null;
+$instagram = $updated['social']['instagram'] ?? null;
+
+if ($facebook !== 'https://example.com/page') {
+    throw new RuntimeException('Facebook URL should be trimmed and sanitized.');
+}
+
+if ($instagram !== '') {
+    throw new RuntimeException('Empty social links should sanitize to an empty string.');
+}
+
+cleanup_settings_test_environment($environment['baseDir']);
+
+echo "SettingsService tests passed\n";


### PR DESCRIPTION
## Summary
- add a reusable UploadHandler for validating, storing, and deleting uploaded assets
- encapsulate settings merging and asset handling in a SettingsService consumed by save_settings.php
- cover validation, asset clearing, and social link sanitization with a dedicated settings service test

## Testing
- php tests/settings_service_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4e2c69c883318b615a5b55e4f62d