### PR TITLE
Refactor user module to use service and repository

### DIFF
--- a/CMS/modules/users/UserRepository.php
+++ b/CMS/modules/users/UserRepository.php
@@ -1,0 +1,60 @@
+<?php
+// File: UserRepository.php
+// Repository for managing persistence of user records.
+
+require_once __DIR__ . '/../../includes/data.php';
+
+class UserRepository
+{
+    /** @var string */
+    private $usersFile;
+
+    public function __construct($usersFile)
+    {
+        $this->usersFile = $usersFile;
+    }
+
+    /**
+     * Load all user records from storage.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function loadUsers()
+    {
+        $users = read_json_file($this->usersFile);
+        return is_array($users) ? array_values($users) : [];
+    }
+
+    /**
+     * Persist user records to storage.
+     *
+     * @param array<int,array<string,mixed>> $users
+     * @return void
+     */
+    public function saveUsers(array $users)
+    {
+        write_json_file($this->usersFile, array_values($users));
+    }
+
+    /**
+     * Generate the next sequential identifier.
+     *
+     * @param array<int,array<string,mixed>>|null $users
+     * @return int
+     */
+    public function getNextId(?array $users = null)
+    {
+        if ($users === null) {
+            $users = $this->loadUsers();
+        }
+
+        $maxId = 0;
+        foreach ($users as $user) {
+            if (isset($user['id']) && $user['id'] > $maxId) {
+                $maxId = (int) $user['id'];
+            }
+        }
+
+        return $maxId + 1;
+    }
+}

--- a/CMS/modules/users/UserService.php
+++ b/CMS/modules/users/UserService.php
@@ -1,0 +1,145 @@
+<?php
+// File: UserService.php
+// Provides business logic for managing users.
+
+require_once __DIR__ . '/UserRepository.php';
+
+class UserService
+{
+    /** @var UserRepository */
+    private $repository;
+
+    /** @var array<int,string> */
+    private $allowedRoles = ['admin', 'editor'];
+
+    /** @var array<int,string> */
+    private $allowedStatuses = ['active', 'inactive'];
+
+    public function __construct(UserRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * Retrieve all users with normalized defaults.
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    public function getUsers()
+    {
+        $users = $this->repository->loadUsers();
+        foreach ($users as &$user) {
+            $user['role'] = $this->normalizeRole($user['role'] ?? null);
+            $user['status'] = $this->normalizeStatus($user['status'] ?? null);
+            if (!isset($user['created_at'])) {
+                $user['created_at'] = 0;
+            }
+            if (!array_key_exists('last_login', $user)) {
+                $user['last_login'] = null;
+            }
+        }
+        unset($user);
+
+        return $users;
+    }
+
+    /**
+     * Save (create or update) a user record.
+     *
+     * @param int|null $id
+     * @param string $username
+     * @param string $password
+     * @param string $role
+     * @param string $status
+     * @return array<string,mixed> Saved user data
+     */
+    public function saveUser($id, $username, $password, $role, $status)
+    {
+        $username = trim((string) $username);
+        if ($username === '') {
+            throw new InvalidArgumentException('Missing username');
+        }
+
+        $role = $this->normalizeRole($role);
+        $status = $this->normalizeStatus($status);
+        $users = $this->repository->loadUsers();
+
+        $id = $id !== null && $id !== '' ? (int) $id : null;
+        $savedUser = null;
+
+        if ($id !== null) {
+            foreach ($users as &$user) {
+                if ((int) ($user['id'] ?? 0) === $id) {
+                    $user['username'] = $username;
+                    if ($password !== '') {
+                        $user['password'] = password_hash($password, PASSWORD_DEFAULT);
+                    }
+                    $user['role'] = $role;
+                    $user['status'] = $status;
+                    if (!isset($user['created_at'])) {
+                        $user['created_at'] = time();
+                    }
+                    if (!array_key_exists('last_login', $user)) {
+                        $user['last_login'] = null;
+                    }
+                    $savedUser = $user;
+                    break;
+                }
+            }
+            unset($user);
+
+            if ($savedUser === null) {
+                throw new InvalidArgumentException('User not found.');
+            }
+        } else {
+            $newUser = [
+                'id' => $this->repository->getNextId($users),
+                'username' => $username,
+                'password' => password_hash($password !== '' ? $password : 'password', PASSWORD_DEFAULT),
+                'role' => $role,
+                'status' => $status,
+                'created_at' => time(),
+                'last_login' => null,
+            ];
+            $users[] = $newUser;
+            $savedUser = $newUser;
+        }
+
+        $this->repository->saveUsers($users);
+        return $savedUser;
+    }
+
+    /**
+     * Delete a user record by its identifier.
+     *
+     * @param int $id
+     * @return void
+     */
+    public function deleteUser($id)
+    {
+        $id = (int) $id;
+        $users = $this->repository->loadUsers();
+        $filtered = array_filter($users, function ($user) use ($id) {
+            return (int) ($user['id'] ?? 0) !== $id;
+        });
+        $this->repository->saveUsers(array_values($filtered));
+    }
+
+    private function normalizeRole($role)
+    {
+        $role = is_string($role) ? trim($role) : '';
+        if (!in_array($role, $this->allowedRoles, true)) {
+            return 'editor';
+        }
+        return $role;
+    }
+
+    private function normalizeStatus($status)
+    {
+        $status = is_string($status) ? trim($status) : '';
+        if (!in_array($status, $this->allowedStatuses, true)) {
+            return 'active';
+        }
+        return $status;
+    }
+}

--- a/CMS/modules/users/delete_user.php
+++ b/CMS/modules/users/delete_user.php
@@ -3,12 +3,12 @@
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/UserService.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
-$users = read_json_file($usersFile);
 $id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT) ?: 0;
-$users = array_filter($users, function($u) use ($id) { return $u['id'] != $id; });
-file_put_contents($usersFile, json_encode(array_values($users), JSON_PRETTY_PRINT));
+$service = new UserService(new UserRepository($usersFile));
+$service->deleteUser($id);
 echo 'OK';
 ?>

--- a/CMS/modules/users/list_users.php
+++ b/CMS/modules/users/list_users.php
@@ -2,10 +2,12 @@
 // File: list_users.php
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/UserService.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
-$users = read_json_file($usersFile);
+$service = new UserService(new UserRepository($usersFile));
+$users = $service->getUsers();
 
 $clean = [];
 foreach ($users as $u) {

--- a/CMS/modules/users/save_user.php
+++ b/CMS/modules/users/save_user.php
@@ -3,60 +3,22 @@
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
 require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/UserService.php';
 require_login();
 
 $usersFile = __DIR__ . '/../../data/users.json';
-$users = read_json_file($usersFile);
+$service = new UserService(new UserRepository($usersFile));
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
 $username = sanitize_text($_POST['username'] ?? '');
 $password = trim($_POST['password'] ?? '');
 $role = sanitize_text($_POST['role'] ?? 'editor');
 $status = sanitize_text($_POST['status'] ?? 'active');
-$allowedRoles = ['admin', 'editor'];
-if (!in_array($role, $allowedRoles, true)) {
-    $role = 'editor';
-}
-$allowedStatus = ['active', 'inactive'];
-if (!in_array($status, $allowedStatus, true)) {
-    $status = 'active';
-}
-
-if ($username === '') {
+try {
+    $service->saveUser($id, $username, $password, $role, $status);
+    echo 'OK';
+} catch (InvalidArgumentException $e) {
     http_response_code(400);
-    echo 'Missing username';
-    exit;
+    echo $e->getMessage();
 }
-
-if ($id) {
-    foreach ($users as &$u) {
-        if ($u['id'] == $id) {
-            $u['username'] = $username;
-            if ($password !== '') {
-                $u['password'] = password_hash($password, PASSWORD_DEFAULT);
-            }
-            $u['role'] = $role;
-            $u['status'] = $status;
-            break;
-        }
-    }
-    unset($u);
-} else {
-    $id = 1;
-    foreach ($users as $u) {
-        if ($u['id'] >= $id) $id = $u['id'] + 1;
-    }
-    $users[] = [
-        'id' => $id,
-        'username' => $username,
-        'password' => password_hash($password !== '' ? $password : 'password', PASSWORD_DEFAULT),
-        'role' => $role,
-        'status' => $status,
-        'created_at' => time(),
-        'last_login' => null
-    ];
-}
-
-file_put_contents($usersFile, json_encode($users, JSON_PRETTY_PRINT));
-echo 'OK';
 ?>

--- a/tests/user_service_test.php
+++ b/tests/user_service_test.php
@@ -1,0 +1,80 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/users/UserService.php';
+
+$tempFile = tempnam(sys_get_temp_dir(), 'users');
+if ($tempFile === false) {
+    throw new RuntimeException('Unable to create temporary dataset.');
+}
+
+$repository = new UserRepository($tempFile);
+$service = new UserService($repository);
+
+$initialPasswordHash = password_hash('initial-secret', PASSWORD_DEFAULT);
+$repository->saveUsers([
+    [
+        'id' => 5,
+        'username' => 'alice',
+        'password' => $initialPasswordHash,
+        'role' => 'admin',
+        'status' => 'active',
+        'created_at' => 1700000000,
+    ],
+]);
+
+// Updating with an empty password should retain the existing hash while applying role/status clamps.
+$service->saveUser(5, 'alice', '', 'super-admin', 'disabled');
+$users = $repository->loadUsers();
+$alice = null;
+foreach ($users as $user) {
+    if ((int) $user['id'] === 5) {
+        $alice = $user;
+        break;
+    }
+}
+
+if ($alice === null) {
+    throw new RuntimeException('Updated user was not found.');
+}
+
+if ($alice['password'] !== $initialPasswordHash) {
+    throw new RuntimeException('Existing password hash should be retained when an empty password is provided.');
+}
+
+if ($alice['role'] !== 'editor') {
+    throw new RuntimeException('Roles should be clamped to allowed values.');
+}
+
+if ($alice['status'] !== 'active') {
+    throw new RuntimeException('Statuses should be clamped to allowed values.');
+}
+
+// Creating a new user should hash the provided password (or default) and apply defaults.
+$created = $service->saveUser(null, 'bob', '', 'manager', 'pending');
+if (!password_verify('password', $created['password'])) {
+    throw new RuntimeException('New users should receive the default password when none is provided.');
+}
+
+if ($created['role'] !== 'editor' || $created['status'] !== 'active') {
+    throw new RuntimeException('New users should receive normalized role and status values.');
+}
+
+$storedUsers = $repository->loadUsers();
+$bob = null;
+foreach ($storedUsers as $user) {
+    if ($user['username'] === 'bob') {
+        $bob = $user;
+        break;
+    }
+}
+
+if ($bob === null) {
+    throw new RuntimeException('Newly created user was not persisted.');
+}
+
+if (!password_verify('password', $bob['password'])) {
+    throw new RuntimeException('Persisted default password should remain hashed.');
+}
+
+unlink($tempFile);
+
+echo "UserService tests passed\n";


### PR DESCRIPTION
## Summary
- add a dedicated UserRepository to load and persist user data with sequential IDs
- introduce a UserService that centralizes normalization and password handling logic
- update user endpoints to rely on the new service and cover behaviors with tests

## Testing
- php tests/user_service_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4e4a09e483319d24627c0ee5f0dc