### PR TITLE
Add page service and restructure sitemap regeneration

### DIFF
--- a/CMS/modules/pages/PageService.php
+++ b/CMS/modules/pages/PageService.php
@@ -1,0 +1,474 @@
+<?php
+// File: PageService.php
+
+require_once __DIR__ . '/../../includes/data.php';
+require_once __DIR__ . '/../../includes/sanitize.php';
+require_once __DIR__ . '/../sitemap/SitemapRegenerator.php';
+
+class PageService
+{
+    private string $pagesFile;
+    private string $historyFile;
+    private string $sitemapPath;
+
+    /** @var callable */
+    private $timeProvider;
+
+    /** @var callable */
+    private $sitemapRegenerator;
+
+    public function __construct(
+        ?string $pagesFile = null,
+        ?string $historyFile = null,
+        ?string $sitemapPath = null,
+        ?callable $timeProvider = null,
+        ?callable $sitemapRegenerator = null
+    ) {
+        $this->pagesFile = $pagesFile ?? __DIR__ . '/../../data/pages.json';
+        $this->historyFile = $historyFile ?? __DIR__ . '/../../data/page_history.json';
+        $this->sitemapPath = $sitemapPath ?? __DIR__ . '/../../../sitemap.xml';
+        $this->timeProvider = $timeProvider ?? static function (): int {
+            return time();
+        };
+        $this->sitemapRegenerator = $sitemapRegenerator ?? function (array $pages): array {
+            return regenerate_sitemap($pages, $this->sitemapPath);
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     * @param array<string, mixed> $session
+     *
+     * @return array<string, mixed>
+     */
+    public function save(array $input, array $session = []): array
+    {
+        $title = sanitize_text((string)($input['title'] ?? ''));
+        if ($title === '') {
+            return [
+                'success' => false,
+                'status' => 400,
+                'message' => 'Title is required.',
+            ];
+        }
+
+        $id = isset($input['id']) && $input['id'] !== '' ? (int)$input['id'] : null;
+        $slugInput = sanitize_text((string)($input['slug'] ?? ''));
+        if ($slugInput === '') {
+            $slugInput = $title;
+        }
+        $slug = $this->slugify($slugInput);
+
+        $content = isset($input['content']) ? (string)$input['content'] : '';
+        $content = $this->sanitizeContent($content);
+
+        $published = isset($input['published']) ? (bool)$input['published'] : false;
+        $template = sanitize_text((string)($input['template'] ?? ''));
+        if ($template === '') {
+            $template = 'page.php';
+        }
+
+        $metaTitle = sanitize_text((string)($input['meta_title'] ?? ''));
+        $metaDescription = sanitize_text((string)($input['meta_description'] ?? ''));
+        $canonicalUrl = sanitize_url((string)($input['canonical_url'] ?? ''));
+        $ogTitle = sanitize_text((string)($input['og_title'] ?? ''));
+        $ogDescription = sanitize_text((string)($input['og_description'] ?? ''));
+        $ogImage = sanitize_url((string)($input['og_image'] ?? ''));
+        $access = sanitize_text((string)($input['access'] ?? 'public'));
+        if ($access === '') {
+            $access = 'public';
+        }
+
+        $pages = $this->loadPages();
+        $timestamp = $this->currentTime();
+
+        if ($id !== null) {
+            $updateResult = $this->updateExistingPage(
+                $pages,
+                $id,
+                [
+                    'title' => $title,
+                    'slug' => $slug,
+                    'content' => $content,
+                    'published' => $published,
+                    'template' => $template,
+                    'meta_title' => $metaTitle,
+                    'meta_description' => $metaDescription,
+                    'canonical_url' => $canonicalUrl,
+                    'og_title' => $ogTitle,
+                    'og_description' => $ogDescription,
+                    'og_image' => $ogImage,
+                    'access' => $access,
+                    'last_modified' => $timestamp,
+                ]
+            );
+
+            if ($updateResult === null) {
+                return [
+                    'success' => false,
+                    'status' => 404,
+                    'message' => 'Page not found.',
+                ];
+            }
+
+            [$pages, $savedPage, $historyAction, $historyDetails] = $updateResult;
+            $message = 'Page updated.';
+        } else {
+            $createResult = $this->createPage($pages, [
+                'title' => $title,
+                'slug' => $slug,
+                'content' => $content,
+                'published' => $published,
+                'template' => $template,
+                'meta_title' => $metaTitle,
+                'meta_description' => $metaDescription,
+                'canonical_url' => $canonicalUrl,
+                'og_title' => $ogTitle,
+                'og_description' => $ogDescription,
+                'og_image' => $ogImage,
+                'access' => $access,
+                'views' => 0,
+                'last_modified' => $timestamp,
+            ]);
+
+            [$pages, $savedPage, $historyAction, $historyDetails] = $createResult;
+            $id = (int)$savedPage['id'];
+            $message = 'Page created.';
+        }
+
+        if (!write_json_file($this->pagesFile, $pages)) {
+            return [
+                'success' => false,
+                'status' => 500,
+                'message' => 'Unable to save pages file.',
+            ];
+        }
+
+        try {
+            $historyEntry = $this->logHistory($id, $historyAction, $historyDetails, $session, $timestamp);
+        } catch (RuntimeException $exception) {
+            return [
+                'success' => false,
+                'status' => 500,
+                'message' => $exception->getMessage(),
+            ];
+        }
+
+        $sitemapResult = $this->callSitemapRegenerator($pages);
+        if ($sitemapResult['success'] !== true) {
+            return [
+                'success' => false,
+                'status' => 500,
+                'message' => 'Failed to regenerate sitemap.',
+                'page' => $savedPage,
+                'historyEntry' => $historyEntry,
+                'sitemap' => $sitemapResult,
+            ];
+        }
+
+        try {
+            $this->logSystemSitemapRegeneration($savedPage, $id);
+        } catch (RuntimeException $exception) {
+            return [
+                'success' => false,
+                'status' => 500,
+                'message' => $exception->getMessage(),
+                'page' => $savedPage,
+                'historyEntry' => $historyEntry,
+                'sitemap' => $sitemapResult,
+            ];
+        }
+
+        return [
+            'success' => true,
+            'status' => 200,
+            'message' => $message,
+            'page' => $savedPage,
+            'historyEntry' => $historyEntry,
+            'sitemap' => $sitemapResult,
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $pages
+     * @param int $id
+     * @param array<string, mixed> $updates
+     *
+     * @return array<int, mixed>|null
+     */
+    private function updateExistingPage(array $pages, int $id, array $updates): ?array
+    {
+        foreach ($pages as $index => $page) {
+            if (!is_array($page)) {
+                continue;
+            }
+            if ((int)($page['id'] ?? 0) === $id) {
+                $old = $page;
+                $updated = $page;
+                foreach ($updates as $key => $value) {
+                    $updated[$key] = $value;
+                }
+
+                $pages[$index] = $updated;
+
+                [$action, $details] = $this->buildUpdateHistory($old, $updated);
+
+                return [$pages, $updated, $action, $details];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $pages
+     * @param array<string, mixed> $data
+     *
+     * @return array<int, mixed>
+     */
+    private function createPage(array $pages, array $data): array
+    {
+        $nextId = 1;
+        foreach ($pages as $page) {
+            if (!is_array($page)) {
+                continue;
+            }
+            $pageId = isset($page['id']) ? (int)$page['id'] : 0;
+            if ($pageId >= $nextId) {
+                $nextId = $pageId + 1;
+            }
+        }
+
+        $data['id'] = $nextId;
+        $pages[] = $data;
+
+        [$action, $details] = $this->buildCreateHistory($data);
+
+        return [$pages, $data, $action, $details];
+    }
+
+    /**
+     * @param array<string, mixed> $page
+     * @return array{0:string,1:array<int,string>}
+     */
+    private function buildCreateHistory(array $page): array
+    {
+        $details = [
+            'Initial template: ' . ($page['template'] ?? ''),
+            'Visibility: ' . (!empty($page['published']) ? 'Published' : 'Unpublished'),
+            'Access: ' . ($page['access'] ?? 'public'),
+        ];
+
+        $action = 'created page with template ' . ($page['template'] ?? '');
+
+        return [$action, $details];
+    }
+
+    /**
+     * @param array<string, mixed> $old
+     * @param array<string, mixed> $new
+     * @return array{0:string,1:array<int,string>}
+     */
+    private function buildUpdateHistory(array $old, array $new): array
+    {
+        $changes = [];
+        $details = [];
+
+        if (($old['title'] ?? '') !== ($new['title'] ?? '')) {
+            $details[] = 'Title: "' . ($old['title'] ?? '') . '" → "' . ($new['title'] ?? '') . '"';
+        }
+        if (($old['slug'] ?? '') !== ($new['slug'] ?? '')) {
+            $details[] = 'Slug: ' . ($old['slug'] ?? '') . ' → ' . ($new['slug'] ?? '');
+        }
+        if (($old['template'] ?? '') !== ($new['template'] ?? '')) {
+            $details[] = 'Template: ' . ($old['template'] ?? '') . ' → ' . ($new['template'] ?? '');
+            $changes[] = 'Changed template';
+        }
+        if (!empty($old['published']) !== !empty($new['published'])) {
+            $details[] = 'Visibility: ' . (!empty($old['published']) ? 'Published' : 'Unpublished') . ' → ' . (!empty($new['published']) ? 'Published' : 'Unpublished');
+            $changes[] = !empty($new['published']) ? 'Published page' : 'Unpublished page';
+        }
+        if (($old['meta_title'] ?? '') !== ($new['meta_title'] ?? '')) {
+            $details[] = 'Meta title updated';
+        }
+        if (($old['meta_description'] ?? '') !== ($new['meta_description'] ?? '')) {
+            $details[] = 'Meta description updated';
+        }
+        if (($old['canonical_url'] ?? '') !== ($new['canonical_url'] ?? '')) {
+            $details[] = 'Canonical URL: ' . (($old['canonical_url'] ?? '') !== '' ? ($old['canonical_url'] ?? '') : 'none') . ' → ' . (($new['canonical_url'] ?? '') !== '' ? ($new['canonical_url'] ?? '') : 'none');
+        }
+        if (($old['og_title'] ?? '') !== ($new['og_title'] ?? '')) {
+            $details[] = 'OG title: "' . ($old['og_title'] ?? '') . '" → "' . ($new['og_title'] ?? '') . '"';
+        }
+        if (($old['og_description'] ?? '') !== ($new['og_description'] ?? '')) {
+            $details[] = 'OG description updated';
+        }
+        if (($old['og_image'] ?? '') !== ($new['og_image'] ?? '')) {
+            $details[] = 'OG image: ' . (($old['og_image'] ?? '') !== '' ? ($old['og_image'] ?? '') : 'none') . ' → ' . (($new['og_image'] ?? '') !== '' ? ($new['og_image'] ?? '') : 'none');
+        }
+        if (($old['access'] ?? '') !== ($new['access'] ?? '')) {
+            $details[] = 'Access: ' . ($old['access'] ?? '') . ' → ' . ($new['access'] ?? '');
+        }
+
+        if (!$changes) {
+            $changes[] = 'Updated page settings';
+        }
+        if (!$details) {
+            $details[] = 'Saved without changing any settings.';
+        }
+
+        $action = implode('; ', $changes);
+
+        return [$action, $details];
+    }
+
+    private function sanitizeContent(string $content): string
+    {
+        $content = trim($content);
+        return (string)preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $content);
+    }
+
+    private function slugify(string $text): string
+    {
+        $text = strtolower(trim($text));
+        $text = preg_replace('/[^a-z0-9]+/', '-', $text);
+        $text = trim((string)$text, '-');
+
+        return $text !== '' ? $text : 'page';
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadPages(): array
+    {
+        $pages = read_json_file($this->pagesFile);
+        return is_array($pages) ? $pages : [];
+    }
+
+    private function currentTime(): int
+    {
+        return (int)call_user_func($this->timeProvider);
+    }
+
+    /**
+     * @param int $pageId
+     * @param array<string, mixed> $page
+     * @param string $action
+     * @param array<int, string> $details
+     * @param array<string, mixed> $session
+     * @param int $timestamp
+     * @return array<string, mixed>
+     */
+    private function logHistory(int $pageId, string $action, array $details, array $session, int $timestamp): array
+    {
+        $historyData = read_json_file($this->historyFile);
+        if (!is_array($historyData)) {
+            $historyData = [];
+        }
+
+        if (!isset($historyData[$pageId]) || !is_array($historyData[$pageId])) {
+            $historyData[$pageId] = [];
+        }
+
+        $user = 'Unknown';
+        if (isset($session['user']) && is_array($session['user']) && isset($session['user']['username'])) {
+            $userValue = $session['user']['username'];
+            if (is_string($userValue) && $userValue !== '') {
+                $user = $userValue;
+            }
+        }
+
+        $entry = [
+            'time' => $timestamp,
+            'user' => $user,
+            'action' => $action,
+            'details' => $details,
+            'context' => 'page',
+            'page_id' => $pageId,
+        ];
+
+        $historyData[$pageId][] = $entry;
+        $historyData[$pageId] = array_slice($historyData[$pageId], -20);
+
+        if (!write_json_file($this->historyFile, $historyData)) {
+            throw new RuntimeException('Unable to save page history.');
+        }
+
+        return $entry;
+    }
+
+    /**
+     * @param array<string, mixed> $page
+     */
+    private function logSystemSitemapRegeneration(array $page, int $pageId): void
+    {
+        $historyData = read_json_file($this->historyFile);
+        if (!is_array($historyData)) {
+            $historyData = [];
+        }
+
+        if (!isset($historyData['__system__']) || !is_array($historyData['__system__'])) {
+            $historyData['__system__'] = [];
+        }
+
+        $historyData['__system__'][] = [
+            'time' => $this->currentTime(),
+            'user' => '',
+            'action' => 'Regenerated sitemap',
+            'details' => [
+                'Automatic sitemap refresh after updating "' . ($page['title'] ?? '') . '" (' . ($page['slug'] ?? '') . ')',
+            ],
+            'context' => 'system',
+            'meta' => [
+                'trigger' => 'sitemap_regeneration',
+                'page_id' => $pageId,
+            ],
+            'page_title' => 'CMS Backend',
+        ];
+        $historyData['__system__'] = array_slice($historyData['__system__'], -50);
+
+        if (!write_json_file($this->historyFile, $historyData)) {
+            throw new RuntimeException('Unable to save page history.');
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $pages
+     * @return array<string, mixed>
+     */
+    private function callSitemapRegenerator(array $pages): array
+    {
+        try {
+            $result = call_user_func($this->sitemapRegenerator, $pages);
+        } catch (Throwable $exception) {
+            $message = $exception->getMessage();
+            if (!is_string($message) || $message === '') {
+                $message = 'Failed to regenerate sitemap.';
+            }
+            return [
+                'success' => false,
+                'message' => $message,
+            ];
+        }
+
+        if (!is_array($result)) {
+            return [
+                'success' => false,
+                'message' => 'Sitemap regenerator returned an invalid result.',
+            ];
+        }
+
+        if (!isset($result['success'])) {
+            $result['success'] = false;
+        }
+
+        if ($result['success'] !== true) {
+            if (!isset($result['message']) || !is_string($result['message']) || $result['message'] === '') {
+                $result['message'] = 'Failed to regenerate sitemap.';
+            }
+        }
+
+        return $result;
+    }
+}

--- a/CMS/modules/pages/save_page.php
+++ b/CMS/modules/pages/save_page.php
@@ -1,204 +1,22 @@
 <?php
 // File: save_page.php
+
 require_once __DIR__ . '/../../includes/auth.php';
-require_once __DIR__ . '/../../includes/data.php';
-require_once __DIR__ . '/../../includes/sanitize.php';
-require_once __DIR__ . '/../sitemap/SitemapGenerator.php';
-$pagesFile = __DIR__ . '/../../data/pages.json';
-$pages = [];
-if (file_exists($pagesFile)) {
-    $pages = read_json_file($pagesFile);
+require_once __DIR__ . '/PageService.php';
+
+require_login();
+
+header('Content-Type: application/json; charset=UTF-8');
+
+$service = new PageService();
+$postData = $_POST;
+if (!is_array($postData)) {
+    $postData = [];
 }
+$session = isset($_SESSION) && is_array($_SESSION) ? $_SESSION : [];
 
-$id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
-$title = sanitize_text($_POST['title'] ?? '');
-$slug = sanitize_text($_POST['slug'] ?? '');
+$result = $service->save($postData, $session);
+$status = isset($result['status']) ? (int)$result['status'] : 200;
+http_response_code($status);
 
-function slugify($text){
-    $text = strtolower(trim($text));
-    $text = preg_replace('/[^a-z0-9]+/', '-', $text);
-    $text = trim($text, '-');
-    return $text ?: 'page';
-}
-
-if ($slug === '') {
-    $slug = $title;
-}
-$slug = slugify($slug);
-$content = trim($_POST['content'] ?? '');
-// strip script tags to avoid XSS in stored content
-$content = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $content);
-$published = isset($_POST['published']) ? (bool)$_POST['published'] : false;
-$template = sanitize_text($_POST['template'] ?? '');
-if ($template === '') {
-    $template = 'page.php';
-}
-$meta_title = sanitize_text($_POST['meta_title'] ?? '');
-$meta_description = sanitize_text($_POST['meta_description'] ?? '');
-$canonical_url = sanitize_url($_POST['canonical_url'] ?? '');
-$og_title = sanitize_text($_POST['og_title'] ?? '');
-$og_description = sanitize_text($_POST['og_description'] ?? '');
-$og_image = sanitize_url($_POST['og_image'] ?? '');
-$access = sanitize_text($_POST['access'] ?? 'public');
-
-if ($title === '') {
-    http_response_code(400);
-    echo 'Missing fields';
-    exit;
-}
-
-if ($id) {
-    // Update existing
-    $old = null;
-    foreach ($pages as &$p) {
-        if ($p['id'] == $id) {
-            $old = $p;
-            $p['title'] = $title;
-            $p['slug'] = $slug;
-            $p['content'] = $content;
-            $p['published'] = $published;
-            $p['template'] = $template;
-            $p['meta_title'] = $meta_title;
-            $p['meta_description'] = $meta_description;
-            $p['canonical_url'] = $canonical_url;
-            $p['og_title'] = $og_title;
-            $p['og_description'] = $og_description;
-            $p['og_image'] = $og_image;
-            $p['access'] = $access;
-            $p['last_modified'] = time();
-            $timestamp = $p['last_modified'];
-            break;
-        }
-    }
-    $changes = [];
-    $details = [];
-    if ($old) {
-        if ($old['title'] !== $title) {
-            $details[] = 'Title: "' . $old['title'] . '" → "' . $title . '"';
-        }
-        if ($old['slug'] !== $slug) {
-            $details[] = 'Slug: ' . $old['slug'] . ' → ' . $slug;
-        }
-        if ($old['template'] !== $template) {
-            $details[] = 'Template: ' . $old['template'] . ' → ' . $template;
-            $changes[] = 'Changed template';
-        }
-        if ($old['published'] != $published) {
-            $details[] = 'Visibility: ' . ($old['published'] ? 'Published' : 'Unpublished') . ' → ' . ($published ? 'Published' : 'Unpublished');
-            $changes[] = $published ? 'Published page' : 'Unpublished page';
-        }
-        if ($old['meta_title'] !== $meta_title) {
-            $details[] = 'Meta title updated';
-        }
-        if (($old['meta_description'] ?? '') !== $meta_description) {
-            $details[] = 'Meta description updated';
-        }
-        if (($old['canonical_url'] ?? '') !== $canonical_url) {
-            $details[] = 'Canonical URL: ' . (($old['canonical_url'] ?? '') !== '' ? ($old['canonical_url'] ?? '') : 'none') . ' → ' . ($canonical_url !== '' ? $canonical_url : 'none');
-        }
-        if ($old['og_title'] !== $og_title) {
-            $details[] = 'OG title: "' . $old['og_title'] . '" → "' . $og_title . '"';
-        }
-        if ($old['og_description'] !== $og_description) {
-            $details[] = 'OG description updated';
-        }
-        if ($old['og_image'] !== $og_image) {
-            $details[] = 'OG image: ' . ($old['og_image'] !== '' ? $old['og_image'] : 'none') . ' → ' . ($og_image !== '' ? $og_image : 'none');
-        }
-        if ($old['access'] !== $access) {
-            $details[] = 'Access: ' . $old['access'] . ' → ' . $access;
-        }
-    }
-    if (!$changes) {
-        $changes[] = 'Updated page settings';
-    }
-    if (!$details) {
-        $details[] = 'Saved without changing any settings.';
-    }
-    $action = implode('; ', $changes);
-    unset($p);
-} else {
-    $id = 1;
-    foreach ($pages as $p) {
-        if ($p['id'] >= $id) $id = $p['id'] + 1;
-    }
-    $pages[] = [
-        'id' => $id,
-        'title' => $title,
-        'slug' => $slug,
-        'content' => $content,
-        'published' => $published,
-        'template' => $template,
-        'meta_title' => $meta_title,
-        'meta_description' => $meta_description,
-        'canonical_url' => $canonical_url,
-        'og_title' => $og_title,
-        'og_description' => $og_description,
-        'og_image' => $og_image,
-        'access' => $access,
-        'views' => 0,
-        'last_modified' => time()
-    ];
-    $timestamp = $pages[array_key_last($pages)]['last_modified'];
-    $details = [
-        'Initial template: ' . $template,
-        'Visibility: ' . ($published ? 'Published' : 'Unpublished'),
-        'Access: ' . $access,
-    ];
-    $action = 'created page with template ' . $template;
-}
-
-$historyFile = __DIR__ . '/../../data/page_history.json';
-$historyData = read_json_file($historyFile);
-if (!isset($historyData[$id])) $historyData[$id] = [];
-$user = $_SESSION['user']['username'] ?? 'Unknown';
-$historyData[$id][] = [
-    'time' => $timestamp,
-    'user' => $user,
-    'action' => $action,
-    'details' => $details,
-    'context' => 'page',
-    'page_id' => $id,
-];
-$historyData[$id] = array_slice($historyData[$id], -20);
-
-if (!isset($historyData['__system__'])) {
-    $historyData['__system__'] = [];
-}
-$historyData['__system__'][] = [
-    'time' => time(),
-    'user' => '',
-    'action' => 'Regenerated sitemap',
-    'details' => [
-        'Automatic sitemap refresh after updating "' . $title . '" (' . $slug . ')',
-    ],
-    'context' => 'system',
-    'meta' => [
-        'trigger' => 'sitemap_regeneration',
-        'page_id' => $id,
-    ],
-    'page_title' => 'CMS Backend',
-];
-$historyData['__system__'] = array_slice($historyData['__system__'], -50);
-file_put_contents($historyFile, json_encode($historyData, JSON_PRETTY_PRINT));
-
-file_put_contents($pagesFile, json_encode($pages, JSON_PRETTY_PRINT));
-
-$generator = new SitemapGenerator(__DIR__ . '/../../../sitemap.xml');
-
-try {
-    $result = $generator->generate($pages);
-    if (isset($result['success']) && !$result['success']) {
-        throw new RuntimeException($result['message'] ?? 'Failed to regenerate sitemap.');
-    }
-} catch (Throwable $exception) {
-    header('Content-Type: text/plain; charset=UTF-8');
-    http_response_code(500);
-    $message = $exception->getMessage() !== '' ? $exception->getMessage() : 'Failed to regenerate sitemap.';
-    echo $message;
-    exit;
-}
-
-header('Content-Type: text/plain; charset=UTF-8');
-
-echo 'OK';
+echo json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/CMS/modules/sitemap/SitemapRegenerator.php
+++ b/CMS/modules/sitemap/SitemapRegenerator.php
@@ -1,0 +1,34 @@
+<?php
+// File: SitemapRegenerator.php
+
+require_once __DIR__ . '/SitemapGenerator.php';
+
+/**
+ * Regenerate the sitemap and return a structured result.
+ *
+ * @param array<int|string, array<string, mixed>> $pages
+ * @param string|null $sitemapPath
+ * @return array<string, mixed>
+ */
+function regenerate_sitemap(array $pages, ?string $sitemapPath = null): array
+{
+    try {
+        $generator = new SitemapGenerator($sitemapPath);
+        $result = $generator->generate($pages);
+        if (!isset($result['success'])) {
+            $result['success'] = true;
+        }
+
+        return $result;
+    } catch (Throwable $exception) {
+        $message = $exception->getMessage();
+        if (!is_string($message) || $message === '') {
+            $message = 'Failed to regenerate sitemap.';
+        }
+
+        return [
+            'success' => false,
+            'message' => $message,
+        ];
+    }
+}

--- a/CMS/modules/sitemap/generate.php
+++ b/CMS/modules/sitemap/generate.php
@@ -3,10 +3,10 @@
 // Generate sitemap.xml listing all published pages
 require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/../../includes/data.php';
-require_once __DIR__ . '/SitemapGenerator.php';
+require_once __DIR__ . '/SitemapRegenerator.php';
 require_login();
 
-header('Content-Type: application/json');
+header('Content-Type: application/json; charset=UTF-8');
 
 try {
     $pagesFile = __DIR__ . '/../../data/pages.json';
@@ -15,16 +15,21 @@ try {
         $pages = [];
     }
 
-    $generator = new SitemapGenerator(__DIR__ . '/../../../sitemap.xml');
-    $result = $generator->generate($pages);
+    $result = regenerate_sitemap($pages, __DIR__ . '/../../../sitemap.xml');
+    if (($result['success'] ?? false) !== true) {
+        http_response_code(500);
+    }
 
-    echo json_encode($result);
+    echo json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 } catch (Throwable $exception) {
     http_response_code(500);
+    $message = $exception->getMessage();
+    if (!is_string($message) || $message === '') {
+        $message = 'Failed to regenerate sitemap.';
+    }
     echo json_encode([
         'success' => false,
-        'message' => 'Failed to regenerate sitemap.',
-        'error' => $exception->getMessage(),
-    ]);
+        'message' => $message,
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 }
 ?>

--- a/tests/page_service_test.php
+++ b/tests/page_service_test.php
@@ -1,0 +1,149 @@
+<?php
+require_once __DIR__ . '/../CMS/modules/pages/PageService.php';
+
+function create_temp_file(array $initial = []): string {
+    $file = tempnam(sys_get_temp_dir(), 'page-service-');
+    if ($file === false) {
+        throw new RuntimeException('Unable to create temporary file.');
+    }
+    file_put_contents($file, json_encode($initial));
+    return $file;
+}
+
+function create_time_provider(array $timestamps): callable {
+    return function () use (&$timestamps): int {
+        if (count($timestamps) === 0) {
+            return time();
+        }
+        return (int)array_shift($timestamps);
+    };
+}
+
+$pagesFile = create_temp_file();
+$historyFile = create_temp_file();
+$sitemapFile = tempnam(sys_get_temp_dir(), 'sitemap-');
+if ($sitemapFile === false) {
+    throw new RuntimeException('Unable to create temporary sitemap file.');
+}
+
+$service = new PageService(
+    $pagesFile,
+    $historyFile,
+    $sitemapFile,
+    create_time_provider([1700000000]),
+    function (array $pages): array {
+        return [
+            'success' => true,
+            'message' => 'Sitemap regenerated successfully.',
+            'entryCount' => count($pages),
+        ];
+    }
+);
+
+$slugResult = $service->save([
+    'title' => 'Sample Page',
+    'slug' => '   Fancy TITLE!!  ',
+    'content' => '<p>Hello</p><script>alert(1);</script>',
+], [
+    'user' => ['username' => 'editor'],
+]);
+
+if ($slugResult['success'] !== true) {
+    throw new RuntimeException('Slug normalization test failed to save page.');
+}
+
+if (($slugResult['page']['slug'] ?? '') !== 'fancy-title') {
+    throw new RuntimeException('Slug should be normalized and lowercased with hyphens.');
+}
+
+$pagesData = json_decode(file_get_contents($pagesFile), true);
+if (!is_array($pagesData) || $pagesData[0]['slug'] !== 'fancy-title') {
+    throw new RuntimeException('Normalized slug should persist to the pages dataset.');
+}
+
+$createdId = (int)$slugResult['page']['id'];
+
+$serviceHistory = new PageService(
+    $pagesFile,
+    $historyFile,
+    $sitemapFile,
+    create_time_provider([1700000100]),
+    function (array $pages): array {
+        return [
+            'success' => true,
+            'message' => 'Sitemap regenerated successfully.',
+            'entryCount' => count($pages),
+        ];
+    }
+);
+
+$historyResult = $serviceHistory->save([
+    'id' => $createdId,
+    'title' => 'Updated Sample Page',
+    'slug' => 'updated-sample-page',
+    'content' => '<p>Updated</p>',
+    'published' => true,
+], [
+    'user' => ['username' => 'editor'],
+]);
+
+if ($historyResult['success'] !== true) {
+    throw new RuntimeException('History diff test failed to update page.');
+}
+
+$historyData = json_decode(file_get_contents($historyFile), true);
+if (!isset($historyData[$createdId]) || count($historyData[$createdId]) === 0) {
+    throw new RuntimeException('Page history should contain entries for the saved page.');
+}
+
+$latestHistory = end($historyData[$createdId]);
+if (!is_array($latestHistory)) {
+    throw new RuntimeException('Latest history entry should be an array.');
+}
+
+$detailSet = $latestHistory['details'] ?? [];
+if (!in_array('Title: "Sample Page" → "Updated Sample Page"', $detailSet, true)) {
+    throw new RuntimeException('History should record title changes.');
+}
+if (!in_array('Visibility: Unpublished → Published', $detailSet, true)) {
+    throw new RuntimeException('History should record changes to published status.');
+}
+
+$errorService = new PageService(
+    $pagesFile,
+    $historyFile,
+    $sitemapFile,
+    create_time_provider([1700000200]),
+    function (array $pages): array {
+        return [
+            'success' => false,
+            'message' => 'Intentional sitemap failure.',
+        ];
+    }
+);
+
+$errorResult = $errorService->save([
+    'title' => 'Another Page',
+    'slug' => 'Another Page',
+    'content' => '<p>Content</p>',
+], [
+    'user' => ['username' => 'editor'],
+]);
+
+if ($errorResult['success'] !== false) {
+    throw new RuntimeException('Sitemap error handling should return a failure result.');
+}
+
+if (($errorResult['status'] ?? 0) !== 500) {
+    throw new RuntimeException('Sitemap error handling should return a 500 status code.');
+}
+
+if (($errorResult['sitemap']['message'] ?? '') !== 'Intentional sitemap failure.') {
+    throw new RuntimeException('Sitemap error response should expose the underlying message.');
+}
+
+unlink($pagesFile);
+unlink($historyFile);
+unlink($sitemapFile);
+
+echo "PageService tests passed\n";


### PR DESCRIPTION
## Summary
- add a dedicated PageService to handle validation, slug generation, persistence, and history logging for pages
- extract sitemap regeneration into a reusable helper and update the page save and sitemap endpoints to use structured JSON responses
- introduce PageService unit tests covering slug normalization, history diffs, and sitemap error handling

## Testing
- php tests/page_service_test.php
- php tests/sitemap_generator_test.php

------
https://chatgpt.com/codex/tasks/task_e_68df4fb65c78833196bf71a256afb1b2