### PR TITLE
Restore calendar modals and category rendering

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -9334,6 +9334,45 @@
     gap: 18px;
 }
 
+.calendar-categories {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.calendar-category-empty {
+    padding: 14px 16px;
+    border-radius: 12px;
+    border: 1px dashed #cbd5f5;
+    background: #eef2ff;
+    color: #3730a3;
+    font-weight: 500;
+}
+
+.calendar-category-card-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 16px;
+    border-radius: 12px;
+    border: 1px solid #e2e8f0;
+    background: #f8fafc;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
+}
+
+.calendar-category-card-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: var(--calendar-category-color, #cbd5f5);
+    box-shadow: inset 0 0 0 1px rgba(30, 64, 175, 0.2);
+}
+
+.calendar-category-card-name {
+    font-weight: 600;
+    color: #1f2937;
+}
+
 .calendar-card-header {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure the calendar module can locate forms and modals even when rendered outside the dashboard container
- delegate click handling at the document level so add, edit, and delete buttons function again
- render categories in both the dashboard card and the management modal with refreshed styling

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68df54370c8c8331a2364c1b9c15aeb6