### PR TITLE
Add event block modal with cart functionality

### DIFF
--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -924,6 +924,74 @@ section.container-fluid {
     color: var(--gray-6);
 }
 
+.events-block__cart-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    border: 1px solid var(--primary-2);
+    background: rgba(79, 70, 229, 0.08);
+    color: var(--primary-7);
+    font-weight: var(--font-weight-semi-bold);
+    transition: background var(--transition-200, 0.2s ease), box-shadow var(--transition-200, 0.2s ease), transform var(--transition-200, 0.2s ease);
+}
+
+.events-block__cart-button:hover,
+.events-block__cart-button:focus-visible {
+    background: rgba(79, 70, 229, 0.12);
+    box-shadow: 0 12px 24px rgba(79, 70, 229, 0.18);
+    color: var(--primary-8);
+}
+
+.events-block__cart-button--active {
+    background: rgba(79, 70, 229, 0.18);
+    border-color: var(--primary-3);
+    color: var(--primary-8);
+}
+
+.events-block__cart-button:focus-visible {
+    outline: 3px solid rgba(79, 70, 229, 0.4);
+    outline-offset: 2px;
+}
+
+.events-block__cart-button:disabled,
+.events-block__cart-button[aria-disabled="true"] {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.events-block__cart-label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+}
+
+.events-block__cart-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.1rem;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    background: var(--primary);
+    color: var(--text-color-on-primary);
+    font-weight: var(--font-weight-bold);
+}
+
+.events-block__cart-total {
+    font-size: 0.9rem;
+    color: var(--gray-7);
+}
+
+.events-block__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
 .events-block__items {
     display: grid;
     gap: 1.5rem;
@@ -1057,6 +1125,8 @@ section.container-fluid {
     text-decoration: none;
     box-shadow: 0 12px 25px rgba(79, 70, 229, 0.25);
     transition: background var(--transition-200, 0.2s ease), transform var(--transition-200, 0.2s ease), box-shadow var(--transition-200, 0.2s ease);
+    border: none;
+    cursor: pointer;
 }
 
 .events-block__cta:hover,
@@ -1100,6 +1170,285 @@ section.container-fluid {
 
 .events-block--layout-compact .events-block__cta { align-self: center; }
 
+/* Events Modal */
+.events-modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    background: rgba(15, 23, 42, 0.55);
+    z-index: 1050;
+}
+
+.events-modal[hidden] {
+    display: none !important;
+}
+
+.events-modal__overlay {
+    position: absolute;
+    inset: 0;
+}
+
+.events-modal__dialog {
+    position: relative;
+    width: min(720px, 100%);
+    max-height: min(640px, 100%);
+    background: var(--white);
+    border-radius: 18px;
+    box-shadow: 0 30px 65px rgba(15, 23, 42, 0.3);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    padding: 2.25rem;
+    gap: 1.5rem;
+}
+
+.events-modal__dialog:focus {
+    outline: none;
+}
+
+.events-modal__close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    border: none;
+    background: transparent;
+    font-size: 1.75rem;
+    line-height: 1;
+    color: var(--gray-5);
+    cursor: pointer;
+    padding: 0.2rem;
+    border-radius: 999px;
+    transition: background var(--transition-200, 0.2s ease), color var(--transition-200, 0.2s ease);
+}
+
+.events-modal__close:hover,
+.events-modal__close:focus-visible {
+    background: rgba(79, 70, 229, 0.1);
+    color: var(--primary-7);
+}
+
+.events-modal__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    overflow-y: auto;
+}
+
+.events-modal__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.events-modal__title {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: var(--font-weight-bold);
+    letter-spacing: -0.01em;
+    color: var(--gray-9);
+}
+
+.events-modal__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+    color: var(--gray-6);
+    font-size: 0.95rem;
+}
+
+.events-modal__meta time {
+    font-weight: var(--font-weight-semi-bold);
+    color: var(--gray-8);
+}
+
+.events-modal__meta-badges {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.events-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    color: var(--gray-7);
+}
+
+.events-modal__description p {
+    margin-bottom: 0.75rem;
+    line-height: 1.6;
+}
+
+.events-modal__description ul,
+.events-modal__description ol {
+    padding-left: 1.25rem;
+}
+
+.events-modal__tickets {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.events-modal__ticket {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--gray-3);
+    border-radius: 12px;
+}
+
+.events-modal__ticket label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+    color: var(--gray-6);
+}
+
+.events-modal__ticket h4 {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: var(--font-weight-semi-bold);
+    color: var(--gray-9);
+}
+
+.events-modal__ticket-price {
+    font-weight: var(--font-weight-bold);
+    color: var(--primary-7);
+}
+
+.events-modal__ticket-availability {
+    font-size: 0.85rem;
+    color: var(--gray-5);
+}
+
+.events-modal__ticket input[type="number"] {
+    width: 80px;
+    padding: 0.35rem 0.5rem;
+    border-radius: 8px;
+    border: 1px solid var(--gray-3);
+}
+
+.events-modal__footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.events-modal__primary {
+    padding: 0.75rem 1.6rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, var(--primary), var(--primary-5));
+    color: var(--text-color-on-primary);
+    font-weight: var(--font-weight-semi-bold);
+    cursor: pointer;
+    box-shadow: 0 15px 30px rgba(79, 70, 229, 0.25);
+    transition: transform var(--transition-200, 0.2s ease), box-shadow var(--transition-200, 0.2s ease);
+}
+
+.events-modal__primary:hover,
+.events-modal__primary:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 40px rgba(79, 70, 229, 0.3);
+}
+
+.events-modal__secondary {
+    border: none;
+    background: transparent;
+    color: var(--gray-6);
+    font-weight: var(--font-weight-semi-bold);
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.events-modal__notice {
+    width: 100%;
+    border-radius: 10px;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+}
+
+.events-modal__notice--success {
+    background: rgba(34, 197, 94, 0.12);
+    color: var(--success);
+    border: 1px solid rgba(34, 197, 94, 0.4);
+}
+
+.events-modal__notice--error {
+    background: rgba(239, 68, 68, 0.12);
+    color: var(--danger);
+    border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.events-modal__cart-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.events-modal__cart-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.events-modal__cart-item {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    border: 1px solid var(--gray-3);
+    background: var(--gray-1);
+}
+
+.events-modal__cart-item h4 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: var(--font-weight-semi-bold);
+    color: var(--gray-9);
+}
+
+.events-modal__cart-item-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.9rem;
+    color: var(--gray-6);
+}
+
+.events-modal__cart-total {
+    font-size: 1.1rem;
+    font-weight: var(--font-weight-bold);
+    color: var(--gray-9);
+}
+
+.events-modal__cart-remove {
+    border: none;
+    background: transparent;
+    color: var(--danger);
+    cursor: pointer;
+    font-weight: var(--font-weight-semi-bold);
+}
+
+.events-modal__empty-cart {
+    text-align: center;
+    color: var(--gray-6);
+    padding: 2rem 1rem;
+    border-radius: 16px;
+    border: 1px dashed var(--gray-3);
+    background: var(--gray-1);
+}
+
 @media (max-width: 991px) {
     .events-block { padding: 3rem 0; }
     .events-block__items { gap: 1.25rem; }
@@ -1111,6 +1460,28 @@ section.container-fluid {
     .events-block__heading { font-size: 1.75rem; }
     .events-block__items { grid-template-columns: 1fr; }
     .events-block__item { padding: 1.5rem; }
+}
+
+@media (max-width: 767.98px) {
+    .events-block__cart-button {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .events-modal__dialog {
+        padding: 1.75rem;
+        max-height: calc(100% - 2rem);
+    }
+
+    .events-modal__ticket {
+        grid-template-columns: 1fr;
+        align-items: flex-start;
+    }
+
+    .events-modal__cart-item {
+        grid-template-columns: 1fr;
+        align-items: flex-start;
+    }
 }
 
 /* Utility & Form Styles */

--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -268,6 +268,10 @@
   var eventsPromise = null;
   var eventCategoriesPromise = null;
   var htmlParser = null;
+  var eventsDetailCache = Object.create(null);
+  var EVENTS_CART_STORAGE_KEY = 'sparkcms.events.cart';
+  var eventsCartState = loadEventsCartState();
+  var activeEventsModalState = null;
 
   function fetchEvents() {
     if (eventsPromise) {
@@ -555,9 +559,780 @@
     }
   }
 
+  function rememberEventDetail(event) {
+    if (!event || !event.raw) {
+      return;
+    }
+    var id = event.raw.id || event.raw.slug || '';
+    if (!id) {
+      return;
+    }
+    var detail = {
+      id: String(id),
+      title: event.raw.title || 'Untitled Event',
+      description: event.raw.description || '',
+      location: event.raw.location || '',
+      startDate: event.startDate instanceof Date && !Number.isNaN(event.startDate.getTime()) ? new Date(event.startDate.getTime()) : null,
+      endDate: event.endDate instanceof Date && !Number.isNaN(event.endDate.getTime()) ? new Date(event.endDate.getTime()) : null,
+      categoryNames: Array.isArray(event.categoryNames) ? event.categoryNames.slice() : [],
+      tickets: Array.isArray(event.raw.tickets)
+        ? event.raw.tickets.filter(function (ticket) {
+            return ticket && ticket.enabled !== false;
+          })
+        : [],
+      raw: event.raw
+    };
+    eventsDetailCache[detail.id] = detail;
+  }
+
+  function getEventDetailById(id) {
+    if (!id) {
+      return null;
+    }
+    return eventsDetailCache[id] || null;
+  }
+
+  function sanitizeEventHtml(html) {
+    if (!html) {
+      return '';
+    }
+    var wrapper = document.createElement('div');
+    wrapper.innerHTML = html;
+    var forbidden = wrapper.querySelectorAll('script, style, iframe, object, embed, link, meta');
+    forbidden.forEach(function (node) {
+      if (node && node.parentNode) {
+        node.parentNode.removeChild(node);
+      }
+    });
+    var allowed = {
+      P: true,
+      BR: true,
+      STRONG: true,
+      EM: true,
+      B: true,
+      I: true,
+      UL: true,
+      OL: true,
+      LI: true,
+      A: true,
+      H1: true,
+      H2: true,
+      H3: true,
+      H4: true,
+      H5: true,
+      H6: true,
+      BLOCKQUOTE: true,
+      SPAN: true,
+      DIV: true
+    };
+    var nodes = wrapper.querySelectorAll('*');
+    nodes.forEach(function (node) {
+      if (!allowed[node.tagName]) {
+        var parent = node.parentNode;
+        if (!parent) {
+          return;
+        }
+        while (node.firstChild) {
+          parent.insertBefore(node.firstChild, node);
+        }
+        parent.removeChild(node);
+        return;
+      }
+      Array.prototype.slice
+        .call(node.attributes || [])
+        .forEach(function (attr) {
+          var name = attr.name.toLowerCase();
+          if (node.tagName === 'A' && (name === 'href' || name === 'title')) {
+            if (name === 'href') {
+              var href = node.getAttribute('href') || '';
+              if (/^javascript:/i.test(href) || /^data:/i.test(href)) {
+                node.removeAttribute('href');
+              }
+            }
+            return;
+          }
+          if (name.indexOf('aria-') === 0) {
+            return;
+          }
+          node.removeAttribute(attr.name);
+        });
+    });
+    return wrapper.innerHTML;
+  }
+
+  function loadEventsCartState() {
+    var fallback = { items: [] };
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return fallback;
+    }
+    try {
+      var stored = window.localStorage.getItem(EVENTS_CART_STORAGE_KEY);
+      if (!stored) {
+        return fallback;
+      }
+      var parsed = JSON.parse(stored);
+      if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.items)) {
+        return fallback;
+      }
+      parsed.items = parsed.items.filter(function (item) {
+        if (!item || typeof item !== 'object') {
+          return false;
+        }
+        if (!item.eventId || !item.ticketId) {
+          return false;
+        }
+        var quantity = parseInt(item.quantity, 10);
+        if (!Number.isFinite(quantity) || quantity <= 0) {
+          return false;
+        }
+        var price = Number(item.price);
+        if (!Number.isFinite(price)) {
+          price = 0;
+        }
+        item.quantity = quantity;
+        item.price = price;
+        if (item.eventStart) {
+          var startDate = new Date(item.eventStart);
+          if (Number.isNaN(startDate.getTime())) {
+            item.eventStart = null;
+          }
+        }
+        if (item.eventEnd) {
+          var endDate = new Date(item.eventEnd);
+          if (Number.isNaN(endDate.getTime())) {
+            item.eventEnd = null;
+          }
+        }
+        return true;
+      });
+      return parsed;
+    } catch (error) {
+      console.warn('[SparkCMS] Unable to parse events cart from storage:', error);
+      return fallback;
+    }
+  }
+
+  function saveEventsCartState() {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+    try {
+      window.localStorage.setItem(EVENTS_CART_STORAGE_KEY, JSON.stringify(eventsCartState));
+    } catch (error) {
+      console.warn('[SparkCMS] Unable to persist events cart:', error);
+    }
+  }
+
+  function getCartItems() {
+    if (!eventsCartState || !Array.isArray(eventsCartState.items)) {
+      eventsCartState = { items: [] };
+    }
+    return eventsCartState.items;
+  }
+
+  function setCartItems(items) {
+    eventsCartState.items = items;
+    saveEventsCartState();
+    updateEventsCartIndicators();
+  }
+
+  function getCartItemCount() {
+    return getCartItems().reduce(function (total, item) {
+      var quantity = parseInt(item.quantity, 10);
+      if (!Number.isFinite(quantity) || quantity < 0) {
+        return total;
+      }
+      return total + quantity;
+    }, 0);
+  }
+
+  function getCartTotal() {
+    return getCartItems().reduce(function (total, item) {
+      var price = Number(item.price);
+      var quantity = parseInt(item.quantity, 10);
+      if (!Number.isFinite(price) || !Number.isFinite(quantity)) {
+        return total;
+      }
+      return total + price * quantity;
+    }, 0);
+  }
+
+  function updateEventsCartIndicators() {
+    var count = getCartItemCount();
+    var total = getCartTotal();
+    var totalLabel = formatCurrency(total);
+    if (!totalLabel) {
+      totalLabel = '$0.00';
+    }
+    document.querySelectorAll('[data-events-cart-count]').forEach(function (node) {
+      node.textContent = String(count);
+    });
+    document.querySelectorAll('[data-events-cart-total]').forEach(function (node) {
+      node.textContent = totalLabel;
+    });
+    document.querySelectorAll('[data-events-cart-open]').forEach(function (button) {
+      if (!(button instanceof HTMLElement)) {
+        return;
+      }
+      if (count > 0) {
+        button.classList.add('events-block__cart-button--active');
+      } else {
+        button.classList.remove('events-block__cart-button--active');
+      }
+    });
+  }
+
+  function updateCartButtonsExpanded(expanded) {
+    document.querySelectorAll('[data-events-cart-open]').forEach(function (button) {
+      if (button instanceof HTMLElement) {
+        button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+      }
+    });
+  }
+
+  function addTicketsToCart(detail, selections) {
+    if (!detail || !Array.isArray(selections) || !selections.length) {
+      return false;
+    }
+    var items = getCartItems().slice();
+    var didAdd = false;
+    selections.forEach(function (selection) {
+      if (!selection || !selection.ticket || !selection.ticketId) {
+        return;
+      }
+      var quantity = parseInt(selection.quantity, 10);
+      if (!Number.isFinite(quantity) || quantity <= 0) {
+        return;
+      }
+      var existing = items.find(function (item) {
+        return item.eventId === detail.id && item.ticketId === selection.ticketId;
+      });
+      var available = Number(selection.ticket.quantity);
+      if (existing) {
+        var targetQuantity = existing.quantity + quantity;
+        if (Number.isFinite(available) && available > 0) {
+          targetQuantity = Math.min(targetQuantity, available);
+        }
+        if (targetQuantity > existing.quantity) {
+          existing.quantity = targetQuantity;
+          didAdd = true;
+        }
+        return;
+      }
+      if (Number.isFinite(available) && available > 0) {
+        quantity = Math.min(quantity, available);
+      }
+      if (quantity <= 0) {
+        return;
+      }
+      items.push({
+        eventId: detail.id,
+        eventTitle: detail.title,
+        eventStart: detail.startDate instanceof Date ? detail.startDate.toISOString() : null,
+        eventEnd: detail.endDate instanceof Date ? detail.endDate.toISOString() : null,
+        ticketId: selection.ticketId,
+        ticketName: selection.ticket.name || 'General Admission',
+        price: Number(selection.ticket.price) || 0,
+        quantity: quantity
+      });
+      didAdd = true;
+    });
+    if (!didAdd) {
+      return false;
+    }
+    setCartItems(items);
+    return true;
+  }
+
+  function removeCartItem(eventId, ticketId) {
+    var items = getCartItems().filter(function (item) {
+      return !(item.eventId === eventId && item.ticketId === ticketId);
+    });
+    setCartItems(items);
+  }
+
+  function clearCart() {
+    setCartItems([]);
+  }
+
+  function getEventsModalState(container) {
+    if (!(container instanceof HTMLElement)) {
+      return null;
+    }
+    if (container._eventsModalState && container._eventsModalState.modal) {
+      return container._eventsModalState;
+    }
+    var modal = container.querySelector('[data-events-modal]');
+    if (!(modal instanceof HTMLElement)) {
+      return null;
+    }
+    var dialog = modal.querySelector('.events-modal__dialog');
+    var content = modal.querySelector('[data-events-modal-content]');
+    if (!(dialog instanceof HTMLElement) || !(content instanceof HTMLElement)) {
+      return null;
+    }
+    var state = {
+      container: container,
+      modal: modal,
+      dialog: dialog,
+      content: content,
+      titleId: content.dataset.eventsModalTitleId || dialog.getAttribute('aria-labelledby') || '',
+      lastTrigger: null,
+      currentMode: null,
+      notice: null
+    };
+    dialog.setAttribute('tabindex', '-1');
+    if (!modal.dataset.eventsModalBound) {
+      modal.dataset.eventsModalBound = 'true';
+      modal.addEventListener('click', function (event) {
+        var target = event.target;
+        if (!(target instanceof HTMLElement)) {
+          return;
+        }
+        if (target.dataset && target.dataset.eventsModalClose !== undefined) {
+          event.preventDefault();
+          closeEventsModal();
+        }
+      });
+    }
+    container._eventsModalState = state;
+    return state;
+  }
+
+  function trapModalFocus(dialog, event) {
+    var selectors = 'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    var focusable = Array.prototype.slice.call(dialog.querySelectorAll(selectors));
+    if (!focusable.length) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+    var active = document.activeElement;
+    if (event.shiftKey) {
+      if (active === first || !dialog.contains(active)) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function handleModalKeydown(event) {
+    if (!activeEventsModalState || !(activeEventsModalState.dialog instanceof HTMLElement)) {
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeEventsModal();
+      return;
+    }
+    if (event.key === 'Tab') {
+      trapModalFocus(activeEventsModalState.dialog, event);
+    }
+  }
+
+  function openEventsModal(state, trigger) {
+    if (!state || !(state.modal instanceof HTMLElement) || !(state.dialog instanceof HTMLElement)) {
+      return;
+    }
+    if (activeEventsModalState && activeEventsModalState !== state) {
+      closeEventsModal();
+    }
+    state.lastTrigger = trigger || null;
+    state.modal.hidden = false;
+    activeEventsModalState = state;
+    if (document && document.body) {
+      document.body.classList.add('events-modal-open');
+    }
+    requestAnimationFrame(function () {
+      try {
+        state.dialog.focus();
+      } catch (error) {}
+    });
+    document.addEventListener('keydown', handleModalKeydown);
+  }
+
+  function closeEventsModal() {
+    if (!activeEventsModalState) {
+      return;
+    }
+    var state = activeEventsModalState;
+    activeEventsModalState = null;
+    if (state.modal instanceof HTMLElement) {
+      state.modal.hidden = true;
+    }
+    if (document && document.body) {
+      document.body.classList.remove('events-modal-open');
+    }
+    document.removeEventListener('keydown', handleModalKeydown);
+    if (state.currentMode === 'cart') {
+      updateCartButtonsExpanded(false);
+    }
+    var trigger = state.lastTrigger;
+    state.lastTrigger = null;
+    if (trigger && typeof trigger.focus === 'function') {
+      try {
+        trigger.focus();
+      } catch (error) {}
+    }
+  }
+
+  function setEventsModalNotice(state, message, type) {
+    if (!state || !(state.notice instanceof HTMLElement)) {
+      return;
+    }
+    if (!message) {
+      state.notice.textContent = '';
+      state.notice.className = 'events-modal__notice';
+      state.notice.hidden = true;
+      return;
+    }
+    var className = 'events-modal__notice';
+    if (type === 'success') {
+      className += ' events-modal__notice--success';
+    } else if (type === 'error') {
+      className += ' events-modal__notice--error';
+    }
+    state.notice.className = className;
+    state.notice.textContent = message;
+    state.notice.hidden = false;
+  }
+
+  function renderEventDetailsModal(state, detail) {
+    if (!state || !detail || !(state.content instanceof HTMLElement)) {
+      return;
+    }
+    state.content.innerHTML = '';
+    var titleId = state.titleId || 'events-modal-title';
+    var header = document.createElement('header');
+    header.className = 'events-modal__header';
+    var title = document.createElement('h3');
+    title.className = 'events-modal__title';
+    title.id = titleId;
+    title.textContent = detail.title;
+    header.appendChild(title);
+
+    var meta = document.createElement('div');
+    meta.className = 'events-modal__meta';
+    var hasMeta = false;
+    if (detail.startDate instanceof Date) {
+      var metaTime = document.createElement('time');
+      metaTime.dateTime = detail.startDate.toISOString();
+      metaTime.textContent = formatEventRange(detail.startDate, detail.endDate);
+      meta.appendChild(metaTime);
+      hasMeta = true;
+    }
+    if (detail.location) {
+      var metaLocation = document.createElement('span');
+      metaLocation.textContent = 'Location: ' + detail.location;
+      meta.appendChild(metaLocation);
+      hasMeta = true;
+    }
+    if (detail.categoryNames && detail.categoryNames.length) {
+      var badgeWrap = document.createElement('span');
+      badgeWrap.className = 'events-modal__meta-badges';
+      detail.categoryNames.forEach(function (name) {
+        var badge = document.createElement('span');
+        badge.className = 'events-block__badge';
+        badge.textContent = name;
+        badgeWrap.appendChild(badge);
+      });
+      meta.appendChild(badgeWrap);
+      hasMeta = true;
+    }
+    if (hasMeta) {
+      header.appendChild(meta);
+    }
+    state.content.appendChild(header);
+
+    state.dialog.setAttribute('aria-labelledby', title.id);
+
+    var body = document.createElement('div');
+    body.className = 'events-modal__body';
+    if (detail.description) {
+      var description = document.createElement('div');
+      description.className = 'events-modal__description';
+      description.innerHTML = sanitizeEventHtml(detail.description);
+      body.appendChild(description);
+    }
+
+    var tickets = detail.tickets || [];
+    var ticketEntries = [];
+    if (tickets.length) {
+      var ticketsContainer = document.createElement('div');
+      ticketsContainer.className = 'events-modal__tickets';
+      tickets.forEach(function (ticket, index) {
+        if (!ticket) {
+          return;
+        }
+        var ticketNode = document.createElement('div');
+        ticketNode.className = 'events-modal__ticket';
+
+        var info = document.createElement('div');
+        var heading = document.createElement('h4');
+        heading.textContent = ticket.name || 'Ticket ' + (index + 1);
+        info.appendChild(heading);
+        var price = document.createElement('div');
+        price.className = 'events-modal__ticket-price';
+        var priceValue = Number(ticket.price);
+        price.textContent = Number.isFinite(priceValue) && priceValue > 0 ? formatCurrency(priceValue) : 'Free';
+        info.appendChild(price);
+        if (Number.isFinite(Number(ticket.quantity)) && Number(ticket.quantity) > 0) {
+          var availability = document.createElement('div');
+          availability.className = 'events-modal__ticket-availability';
+          availability.textContent = 'Available: ' + Number(ticket.quantity);
+          info.appendChild(availability);
+        }
+        ticketNode.appendChild(info);
+
+        var quantityWrapper = document.createElement('label');
+        var quantityId = titleId + '-qty-' + (ticket.id || index);
+        quantityWrapper.setAttribute('for', quantityId);
+        quantityWrapper.textContent = 'Quantity';
+        var quantityInput = document.createElement('input');
+        quantityInput.type = 'number';
+        quantityInput.min = '0';
+        quantityInput.step = '1';
+        quantityInput.id = quantityId;
+        quantityInput.value = '0';
+        if (Number.isFinite(Number(ticket.quantity)) && Number(ticket.quantity) > 0) {
+          quantityInput.max = String(Number(ticket.quantity));
+        }
+        quantityInput.setAttribute('aria-label', 'Quantity for ' + (ticket.name || 'ticket'));
+        quantityWrapper.appendChild(quantityInput);
+        ticketNode.appendChild(quantityWrapper);
+
+        ticketsContainer.appendChild(ticketNode);
+        ticketEntries.push({
+          input: quantityInput,
+          ticket: ticket,
+          ticketId: ticket.id || String(index)
+        });
+      });
+      body.appendChild(ticketsContainer);
+    } else {
+      var noTickets = document.createElement('p');
+      noTickets.className = 'events-modal__ticket-availability';
+      noTickets.textContent = 'Tickets are not currently available for this event.';
+      body.appendChild(noTickets);
+    }
+
+    state.content.appendChild(body);
+
+    var notice = document.createElement('div');
+    notice.className = 'events-modal__notice';
+    notice.hidden = true;
+    notice.setAttribute('role', 'status');
+    state.content.appendChild(notice);
+    state.notice = notice;
+
+    var footer = document.createElement('div');
+    footer.className = 'events-modal__footer';
+    if (tickets.length) {
+      var addButton = document.createElement('button');
+      addButton.type = 'button';
+      addButton.className = 'events-modal__primary';
+      addButton.textContent = 'Add to cart';
+      addButton.addEventListener('click', function () {
+        var selections = ticketEntries
+          .map(function (entry) {
+            var quantity = parseInt(entry.input.value, 10);
+            return {
+              ticket: entry.ticket,
+              ticketId: entry.ticketId,
+              quantity: quantity
+            };
+          })
+          .filter(function (entry) {
+            return Number.isFinite(entry.quantity) && entry.quantity > 0;
+          });
+        if (!selections.length) {
+          setEventsModalNotice(state, 'Please choose at least one ticket to add to your cart.', 'error');
+          return;
+        }
+        var added = addTicketsToCart(detail, selections);
+        if (!added) {
+          setEventsModalNotice(state, 'Unable to add tickets to your cart. Please try a smaller quantity.', 'error');
+          return;
+        }
+        ticketEntries.forEach(function (entry) {
+          entry.input.value = '0';
+        });
+        updateEventsCartIndicators();
+        setEventsModalNotice(state, 'Tickets added to your cart.', 'success');
+      });
+      footer.appendChild(addButton);
+    }
+
+    var closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'events-modal__secondary';
+    closeButton.textContent = 'Close';
+    closeButton.addEventListener('click', function () {
+      closeEventsModal();
+    });
+    footer.appendChild(closeButton);
+
+    state.content.appendChild(footer);
+    state.currentMode = 'details';
+  }
+
+  function openEventDetailsModal(container, eventId, trigger) {
+    var state = getEventsModalState(container);
+    if (!state) {
+      return;
+    }
+    var detail = getEventDetailById(eventId);
+    if (!detail) {
+      return;
+    }
+    renderEventDetailsModal(state, detail);
+    setEventsModalNotice(state, '', null);
+    openEventsModal(state, trigger || null);
+  }
+
+  function renderCartModal(state) {
+    if (!state || !(state.content instanceof HTMLElement)) {
+      return;
+    }
+    state.content.innerHTML = '';
+    var titleId = state.titleId || 'events-modal-title';
+    var header = document.createElement('header');
+    header.className = 'events-modal__header';
+    var title = document.createElement('h3');
+    title.className = 'events-modal__title';
+    title.id = titleId;
+    title.textContent = 'Your event cart';
+    header.appendChild(title);
+    state.content.appendChild(header);
+    state.dialog.setAttribute('aria-labelledby', title.id);
+
+    var body = document.createElement('div');
+    body.className = 'events-modal__body events-modal__cart-summary';
+    var items = getCartItems();
+    if (!items.length) {
+      var empty = document.createElement('div');
+      empty.className = 'events-modal__empty-cart';
+      empty.textContent = 'Your cart is empty. Add tickets from an event to get started.';
+      body.appendChild(empty);
+    } else {
+      var list = document.createElement('div');
+      list.className = 'events-modal__cart-list';
+      items.forEach(function (item) {
+        var entry = document.createElement('div');
+        entry.className = 'events-modal__cart-item';
+        var info = document.createElement('div');
+        var heading = document.createElement('h4');
+        heading.textContent = item.eventTitle || 'Event';
+        info.appendChild(heading);
+        var meta = document.createElement('div');
+        meta.className = 'events-modal__cart-item-meta';
+        if (item.eventStart) {
+          var startDate = new Date(item.eventStart);
+          var endDate = item.eventEnd ? new Date(item.eventEnd) : null;
+          if (!Number.isNaN(startDate.getTime())) {
+            var time = document.createElement('time');
+            time.dateTime = startDate.toISOString();
+            time.textContent = formatEventRange(startDate, endDate instanceof Date && !Number.isNaN(endDate.getTime()) ? endDate : null);
+            meta.appendChild(time);
+          }
+        }
+        var ticketLine = document.createElement('span');
+        ticketLine.textContent = (item.ticketName || 'Ticket') + ' × ' + item.quantity;
+        meta.appendChild(ticketLine);
+        var priceLine = document.createElement('span');
+        priceLine.textContent = formatCurrency(Number(item.price) * Number(item.quantity)) || '$0.00';
+        meta.appendChild(priceLine);
+        info.appendChild(meta);
+        entry.appendChild(info);
+
+        var removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.className = 'events-modal__cart-remove';
+        removeButton.textContent = 'Remove';
+        removeButton.addEventListener('click', function () {
+          removeCartItem(item.eventId, item.ticketId);
+          renderCartModal(state);
+        });
+        entry.appendChild(removeButton);
+        list.appendChild(entry);
+      });
+      body.appendChild(list);
+
+      var total = document.createElement('div');
+      total.className = 'events-modal__cart-total';
+      total.textContent = 'Total: ' + (formatCurrency(getCartTotal()) || '$0.00');
+      body.appendChild(total);
+    }
+
+    state.content.appendChild(body);
+
+    var notice = document.createElement('div');
+    notice.className = 'events-modal__notice';
+    notice.hidden = true;
+    notice.setAttribute('role', 'status');
+    state.content.appendChild(notice);
+    state.notice = notice;
+
+    var footer = document.createElement('div');
+    footer.className = 'events-modal__footer';
+    if (items.length) {
+      var clearButton = document.createElement('button');
+      clearButton.type = 'button';
+      clearButton.className = 'events-modal__secondary';
+      clearButton.textContent = 'Clear cart';
+      clearButton.addEventListener('click', function () {
+        clearCart();
+        renderCartModal(state);
+      });
+      footer.appendChild(clearButton);
+
+      var checkoutButton = document.createElement('button');
+      checkoutButton.type = 'button';
+      checkoutButton.className = 'events-modal__primary';
+      checkoutButton.textContent = 'Proceed to checkout';
+      checkoutButton.addEventListener('click', function () {
+        setEventsModalNotice(state, 'Checkout is not available in this demo experience. Please contact our team to complete your registration.', 'error');
+      });
+      footer.appendChild(checkoutButton);
+    } else {
+      var closeButton = document.createElement('button');
+      closeButton.type = 'button';
+      closeButton.className = 'events-modal__primary';
+      closeButton.textContent = 'Browse events';
+      closeButton.addEventListener('click', function () {
+        closeEventsModal();
+      });
+      footer.appendChild(closeButton);
+    }
+
+    state.content.appendChild(footer);
+    state.currentMode = 'cart';
+  }
+
+  function openEventsCartModal(container, trigger) {
+    var state = getEventsModalState(container);
+    if (!state) {
+      return;
+    }
+    renderCartModal(state);
+    setEventsModalNotice(state, '', null);
+    updateCartButtonsExpanded(true);
+    openEventsModal(state, trigger || null);
+  }
+
   function createEventsItem(event, options) {
     var item = document.createElement('article');
     item.className = 'events-block__item';
+    rememberEventDetail(event);
+    var eventId = event && event.raw && event.raw.id ? String(event.raw.id) : '';
+    if (eventId) {
+      item.setAttribute('data-events-id', eventId);
+    }
     if (event.id) {
       item.setAttribute('data-events-id', String(event.id));
     }
@@ -649,12 +1424,32 @@
       body.appendChild(description);
     }
 
+    var actions = document.createElement('div');
+    actions.className = 'events-block__actions';
+
+    if (eventId && options.container) {
+      var registerButton = document.createElement('button');
+      registerButton.type = 'button';
+      registerButton.className = 'events-block__cta events-block__cta--register';
+      registerButton.textContent = 'Details & Register';
+      registerButton.addEventListener('click', function (evt) {
+        evt.preventDefault();
+        evt.stopPropagation();
+        openEventDetailsModal(options.container, eventId, registerButton);
+      });
+      actions.appendChild(registerButton);
+    }
+
     if (options.showButton && linkUrl) {
       var cta = document.createElement('a');
       cta.className = 'events-block__cta';
       cta.href = linkUrl;
       cta.textContent = options.buttonLabel || 'View event';
-      body.appendChild(cta);
+      actions.appendChild(cta);
+    }
+
+    if (actions.childNodes.length) {
+      body.appendChild(actions);
     }
 
     item.appendChild(body);
@@ -668,6 +1463,19 @@
     var itemsHost = container.querySelector('[data-events-items]');
     if (!itemsHost) {
       return;
+    }
+
+    updateEventsCartIndicators();
+
+    if (!container.dataset.eventsControlsBound) {
+      container.dataset.eventsControlsBound = 'true';
+      var cartButton = container.querySelector('[data-events-cart-open]');
+      if (cartButton) {
+        cartButton.addEventListener('click', function (event) {
+          event.preventDefault();
+          openEventsCartModal(container, cartButton);
+        });
+      }
     }
 
     itemsHost.innerHTML = '';
@@ -700,7 +1508,8 @@
       showDescription: parseBooleanOption(container.dataset.eventsShowDescription, true),
       showLocation: parseBooleanOption(container.dataset.eventsShowLocation, true),
       showCategories: parseBooleanOption(container.dataset.eventsShowCategories, true),
-      showPrice: parseBooleanOption(container.dataset.eventsShowPrice, true)
+      showPrice: parseBooleanOption(container.dataset.eventsShowPrice, true),
+      container: container
     };
 
     Promise.all([fetchEvents(), fetchEventCategories()])
@@ -775,6 +1584,7 @@
           var node = createEventsItem(event, options);
           itemsHost.appendChild(node);
         });
+        updateEventsCartIndicators();
       })
       .catch(function () {
         itemsHost.innerHTML = '';
@@ -787,6 +1597,7 @@
     blocks.forEach(function (block) {
       renderEventsBlock(block);
     });
+    updateEventsCartIndicators();
   }
 
   var calendarEventsPromise = null;
@@ -1268,6 +2079,7 @@
   ready(function () {
     initBlogLists();
     initEventsBlocks();
+    updateEventsCartIndicators();
     initCalendarBlocks();
     observe();
   });
@@ -1284,7 +2096,6 @@
     refresh: initCalendarBlocks
   };
 })();
-
 /* File: script.js */
 // File: script.js
 (function () {

--- a/theme/templates/blocks/interactive.events.php
+++ b/theme/templates/blocks/interactive.events.php
@@ -106,10 +106,17 @@
 </templateSetting>
 <section id="<?= $blockId ?>" class="events-block events-block--layout-{custom_layout}" data-tpl-tooltip="Events" data-events-block data-events-layout="{custom_layout}" data-events-limit="{custom_limit}" data-events-category="{custom_category}" data-events-detail-base="{custom_detail_base}" data-events-button-label="{custom_button_label}" data-events-show-button="{custom_show_button}" data-events-show-description="{custom_show_description}" data-events-description-length="{custom_description_length}" data-events-show-location="{custom_show_location}" data-events-show-categories="{custom_show_categories}" data-events-show-price="{custom_show_price}" data-events-empty="{custom_empty}">
     <div class="container">
-        <div class="row justify-content-center">
-            <div class="col-lg-8 text-center mb-4">
+        <div class="row align-items-center justify-content-between mb-4 g-3">
+            <div class="col-lg-8 text-center text-lg-start">
                 <h2 class="events-block__heading" data-editable>{custom_title}</h2>
                 <p class="events-block__intro text-muted" data-editable>{custom_intro}</p>
+            </div>
+            <div class="col-lg-auto text-center">
+                <button type="button" class="events-block__cart-button" data-events-cart-open aria-haspopup="dialog" aria-expanded="false">
+                    <span class="events-block__cart-label">View cart</span>
+                    <span class="events-block__cart-pill" aria-live="polite"><span data-events-cart-count>0</span></span>
+                    <span class="events-block__cart-total" data-events-cart-total>$0.00</span>
+                </button>
             </div>
         </div>
         <div class="events-block__items" data-events-items>
@@ -121,5 +128,15 @@
             </article>
         </div>
         <div class="events-block__empty text-center text-muted d-none" data-events-empty>{custom_empty}</div>
+    </div>
+    <div class="events-modal" data-events-modal hidden>
+        <div class="events-modal__overlay" data-events-modal-close></div>
+        <div class="events-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="<?= $blockId ?>-modal-title">
+            <button type="button" class="events-modal__close" data-events-modal-close>
+                <span aria-hidden="true">&times;</span>
+                <span class="sr-only">Close</span>
+            </button>
+            <div class="events-modal__content" data-events-modal-content data-events-modal-title-id="<?= $blockId ?>-modal-title"></div>
+        </div>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- add a cart control and reusable modal container to the events block template
- style the events cart button and modal experience, including responsive tweaks
- implement cart state, modal rendering, and registration flows in the events scripts (and update the combined bundle)

## Testing
- none


------
https://chatgpt.com/codex/tasks/task_e_68df5d7fe37083319bcfd3e54a31b399