### PR TITLE
Remove calendar categories card from calendar view

### DIFF
--- a/CMS/modules/calendar/view.php
+++ b/CMS/modules/calendar/view.php
@@ -166,16 +166,6 @@ $initialPayload = [
             </div>
         </section>
 
-        <section class="a11y-detail-card calendar-categories-card">
-            <header>
-                <h3>Categories</h3>
-                <p>Tag events with unique colors to make schedules easier to scan.</p>
-            </header>
-            <div class="calendar-categories" data-calendar-categories>
-                <div class="calendar-category-empty">No categories available. Add one to get started.</div>
-            </div>
-        </section>
-
         <template id="calendarData" type="application/json"><?php echo htmlspecialchars(json_encode($initialPayload), ENT_QUOTES, 'UTF-8'); ?></template>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove the calendar categories card from the calendar module view template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd9ff5c908331aa8101da4cbe08de