### PR TITLE
Remove unused speed report download action

### DIFF
--- a/CMS/modules/speed/view.php
+++ b/CMS/modules/speed/view.php
@@ -375,14 +375,6 @@ function speed_render_delta(?array $delta, string $statLabel, string $unitSingul
                 </button>
             </div>
         </div>
-        <div class="a11y-action-bar">
-            <div class="a11y-bulk-actions">
-                <button type="button" class="a11y-btn a11y-btn--secondary" id="speedDownloadReport">
-                    <i class="fas fa-download" aria-hidden="true"></i>
-                    <span>Download Speed Report</span>
-                </button>
-            </div>
-        </div>
         <div class="a11y-pages-grid" id="speedPagesGrid" role="list"></div>
         <div class="a11y-table-view" id="speedTableView" hidden>
             <div class="a11y-table-header">


### PR DESCRIPTION
## Summary
- remove the download speed report bulk action button from the speed module view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfda99dbd08331ad2d7c02842c4030