### PR TITLE
Align analytics detail styling with shared design system

### DIFF
--- a/CMS/modules/analytics/analytics.css
+++ b/CMS/modules/analytics/analytics.css
@@ -10,7 +10,7 @@
     justify-content: space-between;
     gap: 0.5rem;
     font: inherit;
-    font-size: 13px;
+    font-size: var(--font-size-sm);
     letter-spacing: 0.08em;
     padding: 0;
     text-transform: uppercase;
@@ -20,17 +20,17 @@
 
 .analytics-table__sort:hover,
 .analytics-table__sort:focus-visible {
-    color: #0f172a;
+    color: var(--color-text-primary);
 }
 
 .analytics-table__sort:focus-visible {
-    outline: 2px solid #2563eb;
+    outline: 2px solid var(--color-primary);
     outline-offset: 2px;
     border-radius: 6px;
 }
 
 .analytics-table__sort.is-active {
-    color: #0f172a;
+    color: var(--color-text-primary);
     font-weight: 600;
 }
 
@@ -93,11 +93,11 @@
 
 .analytics-page-card:hover,
 .analytics-page-card:focus-visible {
-    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+    box-shadow: var(--shadow-card-strong);
 }
 
 .analytics-page-card:focus-visible {
-    outline: 3px solid #2563eb;
+    outline: 3px solid var(--color-primary);
     outline-offset: 2px;
 }
 
@@ -111,14 +111,14 @@
 }
 
 .analytics-table__row:hover {
-    background-color: #f8fafc;
+    background-color: var(--color-surface-subtle);
 }
 
 .analytics-table__row:focus-visible {
-    outline: 2px solid #2563eb;
+    outline: 2px solid var(--color-primary);
     outline-offset: -2px;
-    background-color: #f1f5f9;
-    box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.25);
+    background-color: var(--color-surface-muted);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 25%, transparent);
 }
 
 .analytics-detail__content {
@@ -129,26 +129,7 @@
 }
 
 .analytics-detail__close {
-    color: #1f2937;
-    background: #ffffff;
-    border: 1px solid #e2e8f0;
-    border-radius: 999px;
-    font-size: 14px;
-    font-weight: 600;
-    padding: 6px 14px;
-    width: auto;
-    height: auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-}
-
-.analytics-detail__close:hover,
-.analytics-detail__close:focus-visible {
-    color: #0f172a;
-    background: #f1f5f9;
-    border-color: #cbd5f5;
+    align-self: flex-end;
 }
 
 .analytics-detail__close-text {
@@ -173,21 +154,21 @@
 
 .analytics-detail__slug {
     margin: 0;
-    font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    font-size: 13px;
-    color: #64748b;
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
 }
 
 .analytics-detail__title {
     margin: 0;
-    font-size: 24px;
-    color: #0f172a;
+    font-size: var(--font-size-xl);
+    color: var(--color-text-primary);
 }
 
 .analytics-detail__summary {
     margin: 0;
-    font-size: 15px;
-    color: #475569;
+    font-size: var(--font-size-md);
+    color: var(--color-text-secondary);
 }
 
 .analytics-detail__headline {
@@ -199,79 +180,40 @@
 }
 
 .analytics-detail__views-number {
-    font-size: 34px;
+    font-size: var(--font-size-3xl);
     font-weight: 700;
-    color: #2563eb;
+    color: var(--color-primary);
 }
 
 .analytics-detail__views-caption {
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #64748b;
+    color: var(--color-text-muted);
 }
 
 .analytics-detail__delta {
-    font-size: 14px;
+    font-size: var(--font-size-base);
     font-weight: 600;
-    color: #475569;
+    color: var(--color-text-secondary);
 }
 
 .analytics-detail__delta--positive {
-    color: #047857;
+    color: var(--color-success-strong);
 }
 
 .analytics-detail__delta--negative {
-    color: #b91c1c;
+    color: var(--color-danger-strong);
 }
 
 .analytics-detail__delta--neutral {
-    color: #475569;
+    color: var(--color-text-secondary);
 }
 
 .analytics-detail__badges {
     display: flex;
     flex-wrap: wrap;
     gap: 12px;
-}
-
-.analytics-detail__badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 14px;
-    border-radius: 999px;
-    font-weight: 600;
-    font-size: 13px;
-    background: #f1f5f9;
-    color: #475569;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-}
-
-.analytics-detail__badge--success {
-    background: #dcfce7;
-    color: #15803d;
-}
-
-.analytics-detail__badge--warning {
-    background: #fef3c7;
-    color: #b45309;
-}
-
-.analytics-detail__badge--neutral {
-    background: #e2e8f0;
-    color: #475569;
-}
-
-.analytics-detail__badge--positive {
-    background: #e0f2fe;
-    color: #0369a1;
-}
-
-.analytics-detail__badge--negative {
-    background: #fee2e2;
-    color: #b91c1c;
 }
 
 .analytics-detail__body {
@@ -294,19 +236,19 @@
     gap: 16px;
     padding: 12px 16px;
     border-radius: 12px;
-    background: #f8fafc;
+    background: var(--color-surface-subtle);
 }
 
 .analytics-detail__metric-label {
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    color: #64748b;
+    color: var(--color-text-muted);
 }
 
 .analytics-detail__metric-value {
     font-weight: 600;
-    color: #0f172a;
+    color: var(--color-text-primary);
     text-align: right;
 }
 
@@ -318,8 +260,8 @@
 
 .analytics-detail__insights-title {
     margin: 0;
-    font-size: 16px;
-    color: #0f172a;
+    font-size: var(--font-size-md);
+    color: var(--color-text-primary);
 }
 
 .analytics-detail__insights ul {
@@ -327,7 +269,7 @@
     padding-left: 20px;
     display: grid;
     gap: 8px;
-    color: #475569;
+    color: var(--color-text-secondary);
 }
 
 .analytics-detail__insights li {
@@ -338,29 +280,6 @@
 .analytics-detail__footer {
     display: flex;
     justify-content: flex-end;
-}
-
-.analytics-detail__link {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 18px;
-    border-radius: 999px;
-    background: #2563eb;
-    color: #fff;
-    font-weight: 600;
-    text-decoration: none;
-    transition: background-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.analytics-detail__link:hover {
-    background: #1d4ed8;
-}
-
-.analytics-detail__link:focus-visible {
-    outline: 2px solid #1d4ed8;
-    outline-offset: 2px;
-    box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.2);
 }
 
 @media (max-width: 720px) {

--- a/CMS/modules/analytics/analytics.js
+++ b/CMS/modules/analytics/analytics.js
@@ -726,28 +726,31 @@ $(function(){
 
     function getTrendBadgeClass(entry){
         if (!entry) {
-            return 'analytics-detail__badge--neutral';
+            return '';
         }
-        if (entry.trend === 'up' || entry.trend === 'new') {
-            return 'analytics-detail__badge--positive';
+        if (entry.trend === 'new') {
+            return 'status-draft';
+        }
+        if (entry.trend === 'up') {
+            return 'status-good';
         }
         if (entry.trend === 'down') {
-            return 'analytics-detail__badge--negative';
+            return 'status-critical';
         }
-        return 'analytics-detail__badge--neutral';
+        return '';
     }
 
     function getStatusBadgeClass(entry){
         if (!entry) {
-            return 'analytics-detail__badge--neutral';
+            return '';
         }
         if (entry.status === 'top') {
-            return 'analytics-detail__badge--success';
+            return 'status-good';
         }
         if (entry.status === 'no-views') {
-            return 'analytics-detail__badge--warning';
+            return 'status-warning';
         }
-        return 'analytics-detail__badge--neutral';
+        return '';
     }
 
     function getInsightSuggestions(entry){
@@ -817,13 +820,15 @@ $(function(){
                 .text(buildDeltaText(entry));
         }
         if ($detailBadge.length) {
+            const statusClass = getStatusBadgeClass(entry);
             $detailBadge
-                .attr('class', 'analytics-detail__badge ' + getStatusBadgeClass(entry))
+                .attr('class', 'analytics-detail__badge status-badge' + (statusClass ? ' ' + statusClass : ''))
                 .text(entry.badge || 'Page insight');
         }
         if ($detailTrend.length) {
+            const trendClass = getTrendBadgeClass(entry);
             $detailTrend
-                .attr('class', 'analytics-detail__badge ' + getTrendBadgeClass(entry))
+                .attr('class', 'analytics-detail__badge status-badge' + (trendClass ? ' ' + trendClass : ''))
                 .text(getTrendLabel(entry));
         }
 

--- a/CMS/modules/analytics/view.php
+++ b/CMS/modules/analytics/view.php
@@ -211,7 +211,7 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
     </div>
     <div class="a11y-page-detail analytics-detail" id="analyticsDetail" hidden role="dialog" aria-modal="true" aria-labelledby="analyticsDetailTitle">
         <div class="a11y-detail-content analytics-detail__content" role="document">
-            <button type="button" class="a11y-detail-close analytics-detail__close" id="analyticsDetailClose" aria-label="Close page analytics">
+            <button type="button" class="a11y-detail-close analytics-detail__close btn btn-secondary btn-sm" id="analyticsDetailClose" aria-label="Close page analytics">
                 <span class="analytics-detail__close-text">Close</span>
             </button>
             <header class="analytics-detail__header">
@@ -227,8 +227,8 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
                 </div>
             </header>
             <div class="analytics-detail__badges">
-                <span id="analyticsDetailBadge" class="analytics-detail__badge analytics-detail__badge--neutral">Page insight</span>
-                <span id="analyticsDetailTrend" class="analytics-detail__badge analytics-detail__badge--neutral">Traffic holding steady</span>
+                <span id="analyticsDetailBadge" class="analytics-detail__badge status-badge">Page insight</span>
+                <span id="analyticsDetailTrend" class="analytics-detail__badge status-badge">Traffic holding steady</span>
             </div>
             <div class="analytics-detail__body">
                 <ul id="analyticsDetailMetrics" class="analytics-detail__metrics"></ul>
@@ -238,7 +238,7 @@ $lastUpdatedDisplay = $lastUpdatedTimestamp > 0
                 </section>
             </div>
             <footer class="analytics-detail__footer">
-                <a id="analyticsDetailVisit" class="analytics-detail__link" href="/" target="_blank" rel="noopener">
+                <a id="analyticsDetailVisit" class="analytics-detail__link btn btn-primary" href="/" target="_blank" rel="noopener">
                     <span>Open live page</span>
                 </a>
             </footer>


### PR DESCRIPTION
## Summary
- replace hard-coded analytics detail colors and type sizes with design tokens
- swap bespoke badge and button styles for shared status badge and button classes
- update analytics view markup and scripting to use the new shared classes

## Testing
- php -l CMS/modules/analytics/view.php

------
https://chatgpt.com/codex/tasks/task_e_68dfdc79ac208331a2cc2c31d61b2640