### PR TITLE
Remove unused helper methods across CMS modules

### DIFF
--- a/CMS/includes/UploadHandler.php
+++ b/CMS/includes/UploadHandler.php
@@ -157,8 +157,4 @@ class UploadHandler
         }
     }
 
-    public function getUploadsRoot(): string
-    {
-        return $this->uploadsRoot;
-    }
 }

--- a/CMS/includes/search_helpers.php
+++ b/CMS/includes/search_helpers.php
@@ -712,16 +712,4 @@ function get_search_history($limit = 10)
     return $history;
 }
 
-/**
- * Return the raw search history terms only.
- *
- * @param int $limit
- * @return array
- */
-function get_search_history_terms($limit = 10)
-{
-    return array_map(function ($item) {
-        return $item['term'];
-    }, get_search_history($limit));
-}
 ?>

--- a/CMS/modules/accessibility/AccessibilityReport.php
+++ b/CMS/modules/accessibility/AccessibilityReport.php
@@ -71,11 +71,6 @@ class AccessibilityReport
         return array_values(array_filter($pages, 'is_array'));
     }
 
-    public function getLastScan(): string
-    {
-        return $this->lastScan;
-    }
-
     /**
      * Generate the accessibility report for all pages.
      *

--- a/CMS/modules/events/EventsService.php
+++ b/CMS/modules/events/EventsService.php
@@ -28,11 +28,6 @@ class EventsService
         return $this->repository->getOrders();
     }
 
-    public function getCategoriesData(): array
-    {
-        return $this->repository->getCategories();
-    }
-
     public function formatCurrency(float $value): string
     {
         return '$' . number_format($value, 2);

--- a/CMS/modules/import_export/ImportExportManager.php
+++ b/CMS/modules/import_export/ImportExportManager.php
@@ -40,11 +40,6 @@ class ImportExportManager
         return $this->datasetMetadata;
     }
 
-    public function getDatasetFilename(string $key): ?string
-    {
-        return $this->datasetMap[$key] ?? null;
-    }
-
     public function getAvailableDatasets(bool $includeDrafts = true): array
     {
         $datasets = array_keys($this->datasetMap);

--- a/CMS/modules/menus/MenuBuilder.php
+++ b/CMS/modules/menus/MenuBuilder.php
@@ -16,19 +16,6 @@ class MenuBuilder
         return $this->normalizeLevel($rawItems, $pageIndex);
     }
 
-    /**
-     * Prepare stored items for UI editing, keeping parity with normalizeItems.
-     *
-     * @param array $storedItems
-     * @param array $pages
-     * @return array
-     */
-    public function denormalizeItems(array $storedItems, array $pages): array
-    {
-        $pageIndex = $this->indexPages($pages);
-        return $this->denormalizeLevel($storedItems, $pageIndex);
-    }
-
     private function normalizeLevel($rawItems, array $pageIndex): array
     {
         if (!is_array($rawItems)) {
@@ -88,45 +75,6 @@ class MenuBuilder
         }
 
         return $items;
-    }
-
-    private function denormalizeLevel(array $storedItems, array $pageIndex): array
-    {
-        $result = [];
-        foreach ($storedItems as $storedItem) {
-            if (!is_array($storedItem)) {
-                continue;
-            }
-
-            $type = isset($storedItem['type']) ? (string)$storedItem['type'] : 'custom';
-            $denormalized = [
-                'label' => isset($storedItem['label']) ? (string)$storedItem['label'] : '',
-                'type' => $type,
-                'new_tab' => !empty($storedItem['new_tab']),
-            ];
-
-            if ($type === 'page') {
-                $pageId = isset($storedItem['page']) ? (int)$storedItem['page'] : 0;
-                $denormalized['page'] = $pageId;
-                if ($pageId && isset($pageIndex[$pageId]['slug'])) {
-                    $denormalized['link'] = '/' . ltrim((string)$pageIndex[$pageId]['slug'], '/');
-                } elseif (isset($storedItem['link'])) {
-                    $denormalized['link'] = (string)$storedItem['link'];
-                } else {
-                    $denormalized['link'] = '';
-                }
-            } else {
-                $denormalized['link'] = isset($storedItem['link']) ? (string)$storedItem['link'] : '';
-            }
-
-            if (!empty($storedItem['children']) && is_array($storedItem['children'])) {
-                $denormalized['children'] = $this->denormalizeLevel($storedItem['children'], $pageIndex);
-            }
-
-            $result[] = $denormalized;
-        }
-
-        return $result;
     }
 
     private function indexPages(array $pages): array

--- a/CMS/modules/seo/SeoReport.php
+++ b/CMS/modules/seo/SeoReport.php
@@ -74,11 +74,6 @@ class SeoReport
         return array_values(array_filter($pages, 'is_array'));
     }
 
-    public function getLastScan(): string
-    {
-        return $this->lastScan;
-    }
-
     /**
      * Generate the SEO report for all pages.
      *


### PR DESCRIPTION
## Summary
- remove unused accessors from upload handling, reporting, events, and import/export services
- drop unused search history helper and menu denormalization logic
- rely on direct dataset maps and repositories where consumers already access the data

## Testing
- for test in tests/*_test.php; do echo "Running $test"; php "$test" || break; done

------
https://chatgpt.com/codex/tasks/task_e_68dfde619598833188d98c40c1db2eec