### PR TITLE
Move page header content below hero section

### DIFF
--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -123,15 +123,17 @@ function renderFooterMenu($items){
                 <div class="container">
                     <div class="hero-content">
                         <p class="eyebrow"><?php echo htmlspecialchars($tagline); ?></p>
-                        <h1 class="page-title"><?php echo htmlspecialchars($page['title'] ?? $siteName); ?></h1>
-                        <?php if (!empty($page['summary'])): ?>
-                            <p class="page-subtitle"><?php echo htmlspecialchars($page['summary']); ?></p>
-                        <?php endif; ?>
                     </div>
                 </div>
             </section>
             <div class="content-wrapper">
                 <div class="container">
+                    <header class="page-header">
+                        <h1 class="page-title"><?php echo htmlspecialchars($page['title'] ?? $siteName); ?></h1>
+                        <?php if (!empty($page['summary'])): ?>
+                            <p class="page-subtitle"><?php echo htmlspecialchars($page['summary']); ?></p>
+                        <?php endif; ?>
+                    </header>
                     <div class="drop-area"></div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- stop rendering the page title and summary inside the hero section of page.php
- add a dedicated page-header block inside the main content wrapper for the title and subtitle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe3d042148331bc31c4d1bad6d6c4