### PR TITLE
Align media module buttons with a11y styles

### DIFF
--- a/CMS/modules/media/media.js
+++ b/CMS/modules/media/media.js
@@ -26,7 +26,7 @@ $(function(){
         const container = $(containerSelector);
         let btn = container.find('button.retry-button');
         if(!btn.length){
-            btn = $('<button type="button" class="btn btn-secondary retry-button"><i class="fa-solid fa-rotate-right btn-icon" aria-hidden="true"></i><span class="btn-label">Retry</span></button>');
+            btn = $('<button type="button" class="a11y-btn a11y-btn--secondary retry-button"><i class="fa-solid fa-rotate-right btn-icon" aria-hidden="true"></i><span class="btn-label">Retry</span></button>');
             container.append(btn);
         }
         btn.off('click').on('click', function(e){

--- a/CMS/modules/media/view.php
+++ b/CMS/modules/media/view.php
@@ -1,6 +1,6 @@
 <!-- File: view.php -->
                 <div class="content-section" id="media">
-                    <div class="media-dashboard">
+                    <div class="media-dashboard a11y-dashboard">
                         <header class="a11y-hero media-hero">
                             <div class="a11y-hero-content media-hero-content">
                                 <div>
@@ -9,10 +9,10 @@
                                     <p class="a11y-hero-subtitle media-hero-subtitle">Keep your images, documents, and videos organised with a modern, visual workspace that mirrors the accessibility dashboard experience.</p>
                                 </div>
                                 <div class="a11y-hero-actions media-hero-actions">
-                                    <button type="button" class="media-btn media-btn--ghost" id="createFolderBtn">
+                                    <button type="button" class="a11y-btn a11y-btn--ghost" id="createFolderBtn">
                                         <span>New Folder</span>
                                     </button>
-                                    <button type="button" class="media-btn media-btn--primary is-disabled" id="uploadBtn" disabled aria-disabled="true">
+                                    <button type="button" class="a11y-btn a11y-btn--primary is-disabled" id="uploadBtn" disabled aria-disabled="true">
                                         <span>Upload Media</span>
                                     </button>
                                 </div>
@@ -67,8 +67,8 @@
                                         <div class="folder-stats" id="folderStats"></div>
                                     </div>
                                     <div class="gallery-actions">
-                                        <button class="btn btn-secondary" id="renameFolderBtn"><i class="fa-solid fa-pen-to-square btn-icon" aria-hidden="true"></i><span class="btn-label">Rename</span></button>
-                                        <button class="btn btn-danger" id="deleteFolderBtn"><i class="fa-solid fa-trash btn-icon" aria-hidden="true"></i><span class="btn-label">Delete</span></button>
+                                        <button class="a11y-btn a11y-btn--secondary" id="renameFolderBtn"><i class="fa-solid fa-pen-to-square btn-icon" aria-hidden="true"></i><span class="btn-label">Rename</span></button>
+                                        <button class="a11y-btn a11y-btn--danger" id="deleteFolderBtn"><i class="fa-solid fa-trash btn-icon" aria-hidden="true"></i><span class="btn-label">Delete</span></button>
                                     </div>
                                 </div>
                                 <div class="gallery-content" id="galleryContent">
@@ -139,8 +139,8 @@
                                 <input type="text" id="newFolderName" placeholder="Folder name">
                             </div>
                             <div class="modal-footer">
-                                <button class="btn btn-secondary" id="cancelBtn"><i class="fa-solid fa-circle-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Cancel</span></button>
-                                <button class="btn btn-primary" id="confirmCreateBtn"><i class="fa-solid fa-folder-plus btn-icon" aria-hidden="true"></i><span class="btn-label">Create</span></button>
+                                <button class="a11y-btn a11y-btn--secondary" id="cancelBtn"><i class="fa-solid fa-circle-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Cancel</span></button>
+                                <button class="a11y-btn a11y-btn--primary" id="confirmCreateBtn"><i class="fa-solid fa-folder-plus btn-icon" aria-hidden="true"></i><span class="btn-label">Create</span></button>
                             </div>
                         </div>
                     </div>
@@ -157,8 +157,8 @@
                                 </div>
                             </div>
                             <div class="modal-footer">
-                                <button class="btn btn-secondary" id="cancelRenameFolderBtn"><i class="fa-solid fa-circle-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Cancel</span></button>
-                                <button class="btn btn-primary" id="confirmRenameFolderBtn"><i class="fa-solid fa-pen-to-square btn-icon" aria-hidden="true"></i><span class="btn-label">Rename</span></button>
+                                <button class="a11y-btn a11y-btn--secondary" id="cancelRenameFolderBtn"><i class="fa-solid fa-circle-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Cancel</span></button>
+                                <button class="a11y-btn a11y-btn--primary" id="confirmRenameFolderBtn"><i class="fa-solid fa-pen-to-square btn-icon" aria-hidden="true"></i><span class="btn-label">Rename</span></button>
                             </div>
                         </div>
                     </div>
@@ -194,8 +194,8 @@
                                         </div>
                                     </div>
                                     <div class="form-actions" id="infoActions">
-                                        <button class="btn btn-danger" id="deleteBtn"><i class="fa-solid fa-trash btn-icon" aria-hidden="true"></i><span class="btn-label">Delete</span></button>
-                                        <button class="btn btn-primary" id="saveEditBtn"><i class="fa-solid fa-floppy-disk btn-icon" aria-hidden="true"></i><span class="btn-label">Save</span></button>
+                                        <button class="a11y-btn a11y-btn--danger" id="deleteBtn"><i class="fa-solid fa-trash btn-icon" aria-hidden="true"></i><span class="btn-label">Delete</span></button>
+                                        <button class="a11y-btn a11y-btn--primary" id="saveEditBtn"><i class="fa-solid fa-floppy-disk btn-icon" aria-hidden="true"></i><span class="btn-label">Save</span></button>
                                     </div>
                                 </div>
                             </div>
@@ -212,10 +212,10 @@
                                 </div>
                                 <div class="crop-sidebar">
                                     <div class="form-group">
-                                        <button class="btn btn-secondary" id="flipHorizontal"><i class="fa-solid fa-arrows-left-right btn-icon" aria-hidden="true"></i><span class="btn-label">Flip Horizontal</span></button>
+                                        <button class="a11y-btn a11y-btn--secondary" id="flipHorizontal"><i class="fa-solid fa-arrows-left-right btn-icon" aria-hidden="true"></i><span class="btn-label">Flip Horizontal</span></button>
                                     </div>
                                     <div class="form-group">
-                                        <button class="btn btn-secondary" id="flipVertical"><i class="fa-solid fa-arrows-up-down btn-icon" aria-hidden="true"></i><span class="btn-label">Flip Vertical</span></button>
+                                        <button class="a11y-btn a11y-btn--secondary" id="flipVertical"><i class="fa-solid fa-arrows-up-down btn-icon" aria-hidden="true"></i><span class="btn-label">Flip Vertical</span></button>
                                     </div>
                                     <div class="form-group">
                                         <label class="form-label" for="scaleSlider">Scale</label>
@@ -245,8 +245,8 @@
                                 </div>
                             </div>
                             <div class="modal-footer">
-                                <button class="btn btn-secondary" id="imageEditCancel"><i class="fa-solid fa-circle-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Cancel</span></button>
-                                <button class="btn btn-primary" id="imageEditSave"><i class="fa-solid fa-floppy-disk btn-icon" aria-hidden="true"></i><span class="btn-label">Save</span></button>
+                                <button class="a11y-btn a11y-btn--secondary" id="imageEditCancel"><i class="fa-solid fa-circle-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Cancel</span></button>
+                                <button class="a11y-btn a11y-btn--primary" id="imageEditSave"><i class="fa-solid fa-floppy-disk btn-icon" aria-hidden="true"></i><span class="btn-label">Save</span></button>
                             </div>
                         </div>
                     </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -8013,7 +8013,7 @@
     flex-wrap: wrap;
 }
 
-.media-btn {
+.media-hero-actions .a11y-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -8022,35 +8022,35 @@
     border: none;
     font-weight: 600;
     font-size: var(--font-size-base);
-    cursor: pointer;
-    transition: all 0.2s ease;
     text-decoration: none;
 }
 
-.media-btn--ghost {
+.media-hero-actions .a11y-btn--ghost {
     background: rgba(255,255,255,0.18);
     border: 1px solid rgba(255,255,255,0.35);
     color: var(--color-text-inverse);
+    box-shadow: none;
 }
 
-.media-btn--ghost:hover {
+.media-hero-actions .a11y-btn--ghost:hover {
     transform: translateY(-1px);
     background: rgba(255,255,255,0.25);
 }
 
-.media-btn--primary {
+.media-hero-actions .a11y-btn--primary {
     background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
     color: var(--color-text-inverse);
     box-shadow: 0 14px 30px rgba(79, 70, 229, 0.35);
+    border: none;
 }
 
-.media-btn--primary:hover {
+.media-hero-actions .a11y-btn--primary:hover {
     transform: translateY(-1px);
     box-shadow: 0 18px 36px rgba(79, 70, 229, 0.45);
 }
 
-.media-btn.is-disabled,
-.media-btn[disabled] {
+.media-hero-actions .a11y-btn.is-disabled,
+.media-hero-actions .a11y-btn[disabled] {
     opacity: 0.55;
     cursor: not-allowed;
     box-shadow: none;
@@ -8267,7 +8267,7 @@
     flex-wrap: wrap;
 }
 
-.gallery-actions .btn {
+.gallery-actions .a11y-btn {
     border-radius: 999px;
     display: inline-flex;
     align-items: center;
@@ -8278,23 +8278,23 @@
     box-shadow: none;
 }
 
-.gallery-actions .btn-secondary {
+.gallery-actions .a11y-btn--secondary {
     background: #e0f2fe;
     color: #0369a1;
     border: 1px solid #bae6fd;
 }
 
-.gallery-actions .btn-secondary:hover {
+.gallery-actions .a11y-btn--secondary:hover {
     background: #bae6fd;
 }
 
-.gallery-actions .btn-danger {
+.gallery-actions .a11y-btn--danger {
     background: #fee2e2;
     color: #b91c1c;
     border: 1px solid #fecaca;
 }
 
-.gallery-actions .btn-danger:hover {
+.gallery-actions .a11y-btn--danger:hover {
     background: #fecaca;
 }
 
@@ -8820,7 +8820,7 @@
     font-size: 14px;
 }
 
-.crop-sidebar .btn { width: 100%; }
+.crop-sidebar .a11y-btn { width: 100%; }
 .crop-sidebar input[type=range] { width: 100%; }
 
 .size-estimate {


### PR DESCRIPTION
## Summary
- add the `a11y-dashboard` wrapper class and migrate media module hero, gallery, and modal buttons to `a11y-btn` variants
- update retry button creation and scoped CSS selectors so dynamic controls use the new accessibility-focused styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe431ad788331bd9e5d0eb5f614e9