### PR TITLE
Add accessibility dashboard class to import/export module

### DIFF
--- a/CMS/modules/import_export/view.php
+++ b/CMS/modules/import_export/view.php
@@ -1,6 +1,6 @@
 <!-- File: view.php -->
                 <div class="content-section" id="import">
-                    <div class="import-dashboard">
+                    <div class="import-dashboard a11y-dashboard">
                         <header class="a11y-hero import-hero">
                             <div class="a11y-hero-content import-hero-content">
                                 <div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -966,7 +966,7 @@
         }
 
         /* Import/Export module */
-        #import .import-dashboard {
+        #import .import-dashboard.a11y-dashboard {
             display: flex;
             flex-direction: column;
             gap: 24px;


### PR DESCRIPTION
## Summary
- add the shared `a11y-dashboard` class to the import/export module wrapper for consistent styling
- scope the import/export dashboard layout rule to the combined class to reflect the updated markup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfe43257a48331936a0c00f25b1884