### PR TITLE
Adopt a11y button styles in menus dashboard

### DIFF
--- a/CMS/modules/menus/menus.js
+++ b/CMS/modules/menus/menus.js
@@ -238,13 +238,13 @@ $(function () {
 
             const $actionsCell = $('<div class="menu-table-cell menu-table-actions"></div>');
             const $editBtn = $(
-                '<button type="button" class="menu-btn menu-btn--ghost menu-btn--sm editMenu">' +
+                '<button type="button" class="a11y-btn a11y-btn--ghost a11y-btn--sm editMenu">' +
                     '<i class="fa-solid fa-pen-to-square" aria-hidden="true"></i>' +
                     '<span>Edit</span>' +
                 '</button>'
             );
             const $deleteBtn = $(
-                '<button type="button" class="menu-btn menu-btn--danger menu-btn--sm deleteMenu">' +
+                '<button type="button" class="a11y-btn a11y-btn--danger a11y-btn--sm deleteMenu">' +
                     '<i class="fa-solid fa-trash" aria-hidden="true"></i>' +
                     '<span>Delete</span>' +
                 '</button>'

--- a/CMS/modules/menus/view.php
+++ b/CMS/modules/menus/view.php
@@ -88,7 +88,7 @@ $filterCounts = [
     'single' => $singleLevelMenus,
 ];
 ?>
-<div class="content-section" id="menus">
+<div class="content-section a11y-dashboard" id="menus">
     <div class="menu-dashboard" data-last-updated="<?php echo htmlspecialchars($lastUpdatedIso, ENT_QUOTES); ?>">
         <header class="a11y-hero menu-hero">
             <div class="a11y-hero-content menu-hero-content">
@@ -98,11 +98,11 @@ $filterCounts = [
                     <p class="a11y-hero-subtitle menu-hero-subtitle">Craft intuitive navigation experiences and keep every menu in sync with your site's structure.</p>
                 </div>
                 <div class="a11y-hero-actions menu-hero-actions">
-                    <button type="button" class="menu-btn menu-btn--primary" id="newMenuBtn">
+                    <button type="button" class="a11y-btn a11y-btn--primary" id="newMenuBtn">
                         <i class="fas fa-plus" aria-hidden="true"></i>
                         <span>New Menu</span>
                     </button>
-                    <button type="button" class="menu-btn menu-btn--icon" id="refreshMenusBtn" aria-label="Refresh menus">
+                    <button type="button" class="a11y-btn a11y-btn--icon" id="refreshMenusBtn" aria-label="Refresh menus">
                         <i class="fas fa-rotate" aria-hidden="true"></i>
                     </button>
                     <span class="a11y-hero-meta menu-hero-meta">
@@ -163,7 +163,7 @@ $filterCounts = [
             <i class="fas fa-sitemap" aria-hidden="true"></i>
             <h3>No menus yet</h3>
             <p>Create your first navigation menu to help visitors find key pages.</p>
-            <button type="button" class="menu-btn menu-btn--primary" id="emptyStateCreateMenu">
+            <button type="button" class="a11y-btn a11y-btn--primary" id="emptyStateCreateMenu">
                 <i class="fas fa-plus" aria-hidden="true"></i>
                 <span>Create Menu</span>
             </button>
@@ -176,7 +176,7 @@ $filterCounts = [
                 <h3 id="menuFormTitle">Add Menu</h3>
                 <p class="menu-editor-subtitle">Drag and drop to arrange links and nest submenus.</p>
             </div>
-            <button type="button" class="menu-editor-close" id="closeMenuEditor" aria-label="Close menu editor">
+            <button type="button" class="a11y-btn a11y-btn--ghost menu-editor-close" id="closeMenuEditor" aria-label="Close menu editor">
                 <i class="fas fa-times" aria-hidden="true"></i>
             </button>
         </header>
@@ -190,14 +190,14 @@ $filterCounts = [
                 <label class="form-label">Menu Items</label>
                 <p class="menu-editor-hint">Choose a page or custom URL, then drag handles to reorder or nest items.</p>
                 <ul id="menuItems" class="menu-list"></ul>
-                <button type="button" class="menu-btn menu-btn--secondary menu-btn--sm" id="addMenuItem">
+                <button type="button" class="a11y-btn a11y-btn--secondary a11y-btn--sm" id="addMenuItem">
                     <i class="fas fa-plus" aria-hidden="true"></i>
                     <span>Add Item</span>
                 </button>
             </div>
             <div class="menu-form-actions">
-                <button type="submit" class="menu-btn menu-btn--primary">Save Menu</button>
-                <button type="button" class="menu-btn menu-btn--ghost" id="cancelMenuEdit">Cancel</button>
+                <button type="submit" class="a11y-btn a11y-btn--primary">Save Menu</button>
+                <button type="button" class="a11y-btn a11y-btn--ghost" id="cancelMenuEdit">Cancel</button>
             </div>
         </form>
     </div>

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -3515,6 +3515,11 @@
             box-shadow: none;
         }
 
+        .a11y-btn--sm {
+            padding: 8px 16px;
+            font-size: var(--font-size-sm);
+        }
+
         .a11y-btn.is-loading {
             opacity: 0.65;
             cursor: wait;
@@ -6027,90 +6032,21 @@
             font-size: 13px;
         }
 
-        .menu-btn {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            gap: 8px;
-            padding: 10px 18px;
-            border-radius: 999px;
-            border: 1px solid transparent;
-            font-weight: 600;
-            font-size: 14px;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            text-decoration: none;
-            background: #f1f5f9;
-            color: #1f2937;
-        }
-
-        .menu-btn i {
-            font-size: 14px;
-        }
-
-        .menu-btn:focus-visible {
-            outline: none;
-            box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
-        }
-
-        .menu-btn--primary {
-            background: linear-gradient(135deg, #2563eb, #0ea5e9);
-            color: #fff;
-            box-shadow: 0 14px 28px rgba(37, 99, 235, 0.25);
-        }
-
-        .menu-btn--primary:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 18px 32px rgba(37, 99, 235, 0.35);
-        }
-
-        .menu-btn--secondary {
-            background: #e0f2fe;
-            color: #1d4ed8;
-        }
-
-        .menu-btn--secondary:hover {
-            background: #bae6fd;
-        }
-
-        .menu-btn--ghost {
-            background: transparent;
-            color: #1e293b;
-            border-color: #cbd5f5;
-        }
-
-        .menu-btn--ghost:hover {
-            background: #e2e8f0;
-        }
-
-        .menu-btn--danger {
-            background: #fee2e2;
-            color: #b91c1c;
-        }
-
-        .menu-btn--danger:hover {
-            background: #fecaca;
-        }
-
-        .menu-btn--icon {
-            padding: 8px 14px;
-            border-radius: 12px;
+        .menu-hero-actions .a11y-btn--icon {
             background: rgba(255, 255, 255, 0.18);
             color: #fff;
+            border-color: transparent;
+            box-shadow: none;
         }
 
-        .menu-btn--icon:hover {
-            transform: translateY(-1px);
+        .menu-hero-actions .a11y-btn--icon:hover,
+        .menu-hero-actions .a11y-btn--icon:focus-visible {
+            background: rgba(255, 255, 255, 0.28);
+            color: #fff;
         }
 
-        .menu-btn--sm {
-            padding: 8px 16px;
-            font-size: 13px;
-        }
-
-        .menu-btn.is-loading {
-            opacity: 0.65;
-            cursor: wait;
+        .menu-hero-actions .a11y-btn.is-loading {
+            opacity: 0.75;
         }
 
         .menu-overview-grid {
@@ -6371,21 +6307,21 @@
         }
 
         .menu-editor-close {
-            background: #f1f5f9;
-            border: none;
-            width: 36px;
-            height: 36px;
+            width: 38px;
+            height: 38px;
+            padding: 0;
             border-radius: 50%;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
+            border: none;
+            background: #f1f5f9;
             color: #475569;
-            cursor: pointer;
-            transition: background 0.2s ease;
+            box-shadow: none;
         }
 
-        .menu-editor-close:hover {
+        .menu-editor-close:hover,
+        .menu-editor-close:focus-visible {
             background: #e2e8f0;
+            color: #1f2937;
+            box-shadow: none;
         }
 
         .menu-editor-hint {


### PR DESCRIPTION
## Summary
- add the shared `a11y-dashboard` container and convert dashboard controls to `a11y-btn` variants
- update menu editor actions and JavaScript-generated buttons to use the new accessibility button styles
- replace menu-specific button styling with overrides that extend the global `a11y-btn` system, including a reusable small size modifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe4307f3c8331b7486eb9986efffa