### PR TITLE
Use a11y button styling for form field remove control

### DIFF
--- a/CMS/modules/forms/forms.js
+++ b/CMS/modules/forms/forms.js
@@ -721,7 +721,7 @@ $(function(){
         const $bar = $('<div class="field-bar"></div>');
         $bar.append('<span class="drag-handle action-icon-button has-tooltip" role="button" tabindex="0" aria-label="Move field" data-tooltip="Drag to reorder"><i class="fa-solid fa-up-down-left-right action-icon" aria-hidden="true"></i></span>');
         $bar.append('<span class="field-type">'+escapeHtml(typeLabel)+'</span>');
-        $bar.append('<button type="button" class="btn btn-danger btn-sm removeField" aria-label="Remove '+escapeHtml(typeLabel)+'"><i class="fa-solid fa-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Remove</span></button>');
+        $bar.append('<button type="button" class="a11y-btn a11y-btn--danger removeField" aria-label="Remove '+escapeHtml(typeLabel)+'"><i class="fa-solid fa-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Remove</span></button>');
         const preview = $('<div class="field-preview"></div>');
         const body = $('<div class="field-body"></div>');
 

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -3456,6 +3456,10 @@
             box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.3);
         }
 
+        .a11y-btn .btn-label {
+            line-height: 1;
+        }
+
         .a11y-btn--primary {
             background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
             color: var(--color-text-inverse);
@@ -10762,6 +10766,17 @@ body.calendar-modal-open {
 #fieldSettings p {
     margin: 0;
     color: #64748b;
+}
+
+.field-bar .a11y-btn {
+    padding: 6px 14px;
+    font-size: 13px;
+    gap: 8px;
+    box-shadow: none;
+}
+
+.field-bar .a11y-btn i {
+    font-size: 0.9rem;
 }
 
 #formsTable tbody tr.selected {


### PR DESCRIPTION
## Summary
- swap the form builder remove control to use the shared a11y button classes instead of legacy bootstrap styles
- adjust shared button and form builder styles so the remove control keeps its compact layout with the new classes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe4345c44833188cdf35158602891