### PR TITLE
Remove post excerpt from blog table cards

### DIFF
--- a/CMS/modules/blogs/blogs.js
+++ b/CMS/modules/blogs/blogs.js
@@ -713,7 +713,6 @@ $(document).ready(function(){
                             ${thumbnail}
                             <div>
                                 <div class="post-title">${post.title}</div>
-                                <div class="post-excerpt">${post.excerpt}</div>
                             </div>
                         </div>
                         ${post.image ? '' : '<span class="sr-only">No featured image</span>'}

--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -7264,11 +7264,6 @@
     font-size: 15px;
 }
 
-.blog-table .post-excerpt {
-    margin-top: 4px;
-    font-size: 13px;
-}
-
 .blog-post-cell {
     display: flex;
     align-items: flex-start;
@@ -7308,11 +7303,6 @@
 
 .post-title {
     font-weight: 600;
-}
-
-.post-excerpt {
-    color: #64748b;
-    font-size: 14px;
 }
 
 .author-info {


### PR DESCRIPTION
## Summary
- remove the post excerpt from the blog table card rendering in the blogs module
- delete the unused CSS rules that styled the removed post excerpt element

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe4a073f4833184e63c724ffb6b24