### PR TITLE
Adjust menu search styling

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -6108,7 +6108,7 @@
             align-items: center;
             background: #fff;
             border: 1px solid #e2e8f0;
-            border-radius: 12px;
+            border-radius: 25px;
             padding: 10px 14px;
             gap: 10px;
             color: #64748b;


### PR DESCRIPTION
## Summary
- increase the menu search input's border radius to 25px for a more rounded appearance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfe7fc4d3c833198f9cd3380e3fa46