### PR TITLE
Prevent inactive users from authenticating

### DIFF
--- a/CMS/login.php
+++ b/CMS/login.php
@@ -9,10 +9,14 @@ $settings = get_site_settings();
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-$username = sanitize_text($_POST['username'] ?? '');
-$password = $_POST['password'] ?? '';
-$user = find_user($username);
-    if ($user && password_verify($password, $user['password'])) {
+    $username = sanitize_text($_POST['username'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $user = find_user($username);
+    if (
+        $user &&
+        ($user['status'] ?? null) === 'active' &&
+        password_verify($password, $user['password'])
+    ) {
         $_SESSION['user'] = $user;
         header('Location: admin.php');
         exit;

--- a/tests/login_handler_test.php
+++ b/tests/login_handler_test.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__ . '/../CMS/includes/auth.php';
+
+// Ensure a clean session state for the test run.
+$_SESSION = [];
+
+// Provide a controlled dataset so the login handler inspects an inactive account.
+global $users;
+$users = [
+    [
+        'id' => 99,
+        'username' => 'inactive-user',
+        'password' => password_hash('secret-pass', PASSWORD_DEFAULT),
+        'role' => 'admin',
+        'status' => 'inactive',
+        'created_at' => time(),
+        'last_login' => null,
+    ],
+];
+
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$_POST = [
+    'username' => 'inactive-user',
+    'password' => 'secret-pass',
+];
+
+ob_start();
+require __DIR__ . '/../CMS/login.php';
+$output = ob_get_clean();
+
+if (isset($_SESSION['user'])) {
+    throw new RuntimeException('Inactive users should not receive an authenticated session.');
+}
+
+if (strpos($output, 'Invalid credentials') === false) {
+    throw new RuntimeException('Inactive accounts should receive the generic invalid credentials response.');
+}
+
+session_unset();
+session_destroy();
+
+$_SERVER['REQUEST_METHOD'] = 'GET';
+$_POST = [];
+
+// The regression passed if no exception was thrown.
+echo "Login handler inactive user regression test passed\n";


### PR DESCRIPTION
## Summary
- ensure the login handler confirms a user is active before creating a session
- add a regression test covering inactive accounts to confirm the generic error is returned

## Testing
- php tests/login_handler_test.php

------
https://chatgpt.com/codex/tasks/task_e_68dfe907f3148331af9d1d3226c2a876