### PR TITLE
Regenerate session on login

### DIFF
--- a/CMS/login.php
+++ b/CMS/login.php
@@ -17,6 +17,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         ($user['status'] ?? null) === 'active' &&
         password_verify($password, $user['password'])
     ) {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_regenerate_id(true);
+        }
+        $_SESSION = [];
         $_SESSION['user'] = $user;
         header('Location: admin.php');
         exit;

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Theme files are stored under the `theme` directory. To modify the site appearanc
 
 After editing templates or CSS, refresh your browser to see the changes.
 
+## Manual QA
+
+- **Verify session cookie rotation after login:**
+  1. Start the development server with `php -S localhost:8000 router.php` and open the site in a private browser window.
+  2. Before logging in, note the value of the `PHPSESSID` cookie in your browser's developer tools.
+  3. Log in with a valid account and confirm the `PHPSESSID` cookie value changes, indicating the session ID was regenerated for the authenticated session.
+
 ## Developing Modules
 
 Modules are self contained directories inside `CMS/modules`. A module typically contains PHP endpoints and optional JavaScript. To create a custom module:


### PR DESCRIPTION
## Summary
- regenerate the session identifier when a user successfully authenticates and reset the session payload before saving the account data
- add a manual QA step describing how to confirm the PHP session cookie changes after login

## Testing
- php -l CMS/login.php

------
https://chatgpt.com/codex/tasks/task_e_68dfea90dbd08331aa194a4025464b19