### PR TITLE
Add calendar layout option to calendar block

### DIFF
--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -888,6 +888,131 @@ section.container-fluid {
 .calendar-block--layout-compact .calendar-block__meta,
 .calendar-block--layout-compact .calendar-block__description { font-size: 0.9rem; }
 
+.calendar-block--layout-calendar .calendar-block__items {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.calendar-block__calendar {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.calendar-block__calendar-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.calendar-block__calendar-month {
+    font-size: 1.35rem;
+    font-weight: var(--font-weight-bold);
+    color: var(--gray-9);
+}
+
+.calendar-block__calendar-range {
+    font-size: 0.95rem;
+    color: var(--gray-6);
+}
+
+.calendar-block__calendar-weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    color: var(--gray-6);
+}
+
+.calendar-block__calendar-weekdays > div {
+    text-align: center;
+    font-weight: var(--font-weight-semi-bold);
+    padding: 0.25rem 0;
+}
+
+.calendar-block__calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 0.5rem;
+}
+
+.calendar-block__calendar-day {
+    min-height: 120px;
+    padding: 0.75rem;
+    border-radius: var(--border-radius-md, 8px);
+    border: 1px solid var(--gray-3);
+    background: var(--gray-1);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    position: relative;
+    transition: border-color var(--transition-200, 0.2s ease), box-shadow var(--transition-200, 0.2s ease);
+}
+
+.calendar-block__calendar-day:hover,
+.calendar-block__calendar-day:focus-within {
+    border-color: var(--primary-3);
+    box-shadow: 0 12px 25px rgba(15, 23, 42, 0.12);
+}
+
+.calendar-block__calendar-day--outside {
+    opacity: 0.5;
+}
+
+.calendar-block__calendar-date {
+    font-weight: var(--font-weight-semi-bold);
+    color: var(--gray-8);
+}
+
+.calendar-block__calendar-events {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    flex: 1;
+}
+
+.calendar-block__calendar-event {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    font-size: 0.9rem;
+}
+
+.calendar-block__calendar-event-time {
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--gray-6);
+}
+
+.calendar-block__calendar-event-title {
+    font-weight: var(--font-weight-medium);
+    color: var(--gray-9);
+}
+
+.calendar-block__calendar-event-description {
+    font-size: 0.8rem;
+    color: var(--gray-6);
+}
+
+.calendar-block__calendar-event-category {
+    font-size: 0.75rem;
+    text-transform: capitalize;
+    color: var(--primary-5);
+}
+
+.calendar-block__calendar-more {
+    margin-top: auto;
+    font-size: 0.85rem;
+    color: var(--gray-6);
+}
+
 @media (max-width: 768px) {
     .calendar-block { padding: 1.25rem; }
     .calendar-block__item { flex-direction: column; }
@@ -907,6 +1032,15 @@ section.container-fluid {
     .calendar-block__date-day {
         font-size: 1.5rem;
         color: var(--primary-5);
+    }
+
+    .calendar-block__calendar-grid {
+        gap: 0.35rem;
+    }
+
+    .calendar-block__calendar-day {
+        min-height: 100px;
+        padding: 0.65rem;
     }
 }
 

--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -1855,9 +1855,181 @@
     return startLabel + ' ' + startTime + ' – ' + endLabel + ' ' + endTime;
   }
 
+  function formatMonthYearLabel(date) {
+    if (!(date instanceof Date)) {
+      return '';
+    }
+    try {
+      return date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+    } catch (err) {
+      return (MONTH_NAMES[date.getMonth()] || '') + ' ' + date.getFullYear();
+    }
+  }
+
+  function formatCalendarRangeLabel(start, end) {
+    if (!(start instanceof Date) || !(end instanceof Date)) {
+      return '';
+    }
+    try {
+      var formatter = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+      return formatter.format(start) + ' – ' + formatter.format(end);
+    } catch (err) {
+      var startLabel = (MONTH_NAMES[start.getMonth()] || '') + ' ' + start.getDate();
+      var endLabel = (MONTH_NAMES[end.getMonth()] || '') + ' ' + end.getDate();
+      return startLabel + ' – ' + endLabel;
+    }
+  }
+
+  function computeCalendarWindow(reference) {
+    var base = reference instanceof Date ? reference : new Date();
+    var monthStart = new Date(base.getFullYear(), base.getMonth(), 1);
+    var monthEnd = new Date(base.getFullYear(), base.getMonth() + 1, 0);
+    var gridStart = new Date(monthStart.getFullYear(), monthStart.getMonth(), monthStart.getDate());
+    gridStart.setDate(gridStart.getDate() - gridStart.getDay());
+    gridStart.setHours(0, 0, 0, 0);
+    var gridEnd = new Date(monthEnd.getFullYear(), monthEnd.getMonth(), monthEnd.getDate());
+    gridEnd.setDate(gridEnd.getDate() + (6 - gridEnd.getDay()));
+    gridEnd.setHours(23, 59, 59, 999);
+    var totalDays = Math.round((gridEnd.getTime() - gridStart.getTime()) / 86400000) + 1;
+    return {
+      displayMonth: monthStart,
+      monthStart: monthStart,
+      monthEnd: monthEnd,
+      gridStart: gridStart,
+      gridEnd: gridEnd,
+      totalDays: totalDays
+    };
+  }
+
+  function formatDateKey(date) {
+    if (!(date instanceof Date)) {
+      return '';
+    }
+    var year = date.getFullYear();
+    var month = date.getMonth() + 1;
+    var day = date.getDate();
+    var monthLabel = month < 10 ? '0' + month : String(month);
+    var dayLabel = day < 10 ? '0' + day : String(day);
+    return year + '-' + monthLabel + '-' + dayLabel;
+  }
+
+  function renderCalendarMonth(container, host, occurrences, settings) {
+    var calendar = document.createElement('div');
+    calendar.className = 'calendar-block__calendar';
+    var windowInfo = settings.window || computeCalendarWindow(new Date());
+
+    var header = document.createElement('div');
+    header.className = 'calendar-block__calendar-header';
+    var monthEl = document.createElement('div');
+    monthEl.className = 'calendar-block__calendar-month';
+    monthEl.textContent = formatMonthYearLabel(windowInfo.displayMonth);
+    header.appendChild(monthEl);
+    var rangeEl = document.createElement('div');
+    rangeEl.className = 'calendar-block__calendar-range';
+    rangeEl.textContent = formatCalendarRangeLabel(windowInfo.monthStart, windowInfo.monthEnd);
+    header.appendChild(rangeEl);
+    calendar.appendChild(header);
+
+    var weekdaysRow = document.createElement('div');
+    weekdaysRow.className = 'calendar-block__calendar-weekdays';
+    for (var i = 0; i < 7; i += 1) {
+      var weekdayCell = document.createElement('div');
+      weekdayCell.textContent = WEEKDAY_NAMES[i];
+      weekdaysRow.appendChild(weekdayCell);
+    }
+    calendar.appendChild(weekdaysRow);
+
+    var grid = document.createElement('div');
+    grid.className = 'calendar-block__calendar-grid';
+    var eventsByDay = {};
+    occurrences.forEach(function (occurrence) {
+      var key = formatDateKey(occurrence.start);
+      if (!key) {
+        return;
+      }
+      if (!eventsByDay[key]) {
+        eventsByDay[key] = [];
+      }
+      eventsByDay[key].push(occurrence);
+    });
+
+    Object.keys(eventsByDay).forEach(function (key) {
+      eventsByDay[key].sort(function (a, b) {
+        return a.start.getTime() - b.start.getTime();
+      });
+    });
+
+    var cursor = new Date(windowInfo.gridStart.getTime());
+    var dayEventLimit = Number.isFinite(settings.dayEventLimit) ? settings.dayEventLimit : 3;
+    for (var dayIndex = 0; dayIndex < windowInfo.totalDays; dayIndex += 1) {
+      var cell = document.createElement('div');
+      cell.className = 'calendar-block__calendar-day';
+      if (cursor.getMonth() !== windowInfo.monthStart.getMonth()) {
+        cell.classList.add('calendar-block__calendar-day--outside');
+      }
+
+      var dateLabel = document.createElement('span');
+      dateLabel.className = 'calendar-block__calendar-date';
+      dateLabel.textContent = String(cursor.getDate());
+      cell.appendChild(dateLabel);
+
+      var eventsList = document.createElement('ul');
+      eventsList.className = 'calendar-block__calendar-events';
+      var dayKey = formatDateKey(cursor);
+      var dayEvents = eventsByDay[dayKey] || [];
+      dayEvents.slice(0, dayEventLimit).forEach(function (occurrence) {
+        var eventItem = document.createElement('li');
+        eventItem.className = 'calendar-block__calendar-event';
+
+        var timeLabel = formatTimeRangeDisplay(occurrence.start, occurrence.end);
+        if (timeLabel) {
+          var timeEl = document.createElement('span');
+          timeEl.className = 'calendar-block__calendar-event-time';
+          timeEl.textContent = timeLabel;
+          eventItem.appendChild(timeEl);
+        }
+
+        var titleEl = document.createElement('span');
+        titleEl.className = 'calendar-block__calendar-event-title';
+        titleEl.textContent = occurrence.title || 'Untitled Event';
+        eventItem.appendChild(titleEl);
+
+        if (settings.showCategory && occurrence.category) {
+          var categoryEl = document.createElement('span');
+          categoryEl.className = 'calendar-block__calendar-event-category';
+          categoryEl.textContent = occurrence.category;
+          eventItem.appendChild(categoryEl);
+        }
+
+        if (settings.showDescription && occurrence.description) {
+          var descriptionEl = document.createElement('span');
+          descriptionEl.className = 'calendar-block__calendar-event-description';
+          descriptionEl.textContent = occurrence.description;
+          eventItem.appendChild(descriptionEl);
+        }
+
+        eventsList.appendChild(eventItem);
+      });
+
+      if (dayEvents.length > dayEventLimit) {
+        var moreItem = document.createElement('li');
+        moreItem.className = 'calendar-block__calendar-more';
+        moreItem.textContent = '+' + (dayEvents.length - dayEventLimit) + ' more';
+        eventsList.appendChild(moreItem);
+      }
+
+      cell.appendChild(eventsList);
+      grid.appendChild(cell);
+      cursor = new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate() + 1);
+    }
+
+    calendar.appendChild(grid);
+    host.appendChild(calendar);
+  }
+
   function normalizeCalendarLayout(value) {
     var layout = (value || '').toString().toLowerCase();
-    if (layout !== 'cards' && layout !== 'compact') {
+    if (layout !== 'cards' && layout !== 'compact' && layout !== 'calendar') {
       layout = 'list';
     }
     return layout;
@@ -1976,7 +2148,12 @@
 
     var layout = normalizeCalendarLayout(container.dataset.calendarLayout);
     container.dataset.calendarLayout = layout;
-    container.classList.remove('calendar-block--layout-list', 'calendar-block--layout-cards', 'calendar-block--layout-compact');
+    container.classList.remove(
+      'calendar-block--layout-list',
+      'calendar-block--layout-cards',
+      'calendar-block--layout-compact',
+      'calendar-block--layout-calendar'
+    );
     container.classList.add('calendar-block--layout-' + layout);
 
     var limit = parsePositiveInt(container.dataset.calendarLimit, 6);
@@ -1990,14 +2167,30 @@
     fetchCalendarEvents()
       .then(function (records) {
         var now = new Date();
+        var calendarWindow = null;
+        var windowStart = now;
+        var windowEnd = null;
+        var fetchLimit = limit;
+        var perEventLimit = Math.max(limit * 3, 18);
+        var maxIterations = Math.max(limit * 6, 120);
+        var perDayDisplay = 3;
+        if (layout === 'calendar') {
+          calendarWindow = computeCalendarWindow(now);
+          windowStart = calendarWindow.gridStart;
+          windowEnd = calendarWindow.gridEnd;
+          fetchLimit = 0;
+          perEventLimit = 180;
+          maxIterations = 360;
+          perDayDisplay = limit > 0 ? Math.min(limit, 10) : 3;
+        }
         var occurrences = buildCalendarOccurrences(records, {
           now: now,
-          windowStart: now,
-          windowEnd: null,
-          limit: limit,
+          windowStart: windowStart,
+          windowEnd: windowEnd,
+          limit: fetchLimit,
           category: category,
-          perEventLimit: Math.max(limit * 3, 18),
-          maxIterations: Math.max(limit * 6, 120)
+          perEventLimit: perEventLimit,
+          maxIterations: maxIterations
         });
         itemsHost.innerHTML = '';
         if (!occurrences.length) {
@@ -2005,13 +2198,22 @@
           return;
         }
         hideCalendarEmpty(container);
-        occurrences.forEach(function (occurrence) {
-          var node = createCalendarItem(occurrence, {
+        if (layout === 'calendar') {
+          renderCalendarMonth(container, itemsHost, occurrences, {
+            window: calendarWindow,
             showDescription: showDescriptionFlag,
-            showCategory: showCategoryFlag
+            showCategory: showCategoryFlag,
+            dayEventLimit: perDayDisplay
           });
-          itemsHost.appendChild(node);
-        });
+        } else {
+          occurrences.forEach(function (occurrence) {
+            var node = createCalendarItem(occurrence, {
+              showDescription: showDescriptionFlag,
+              showCategory: showCategoryFlag
+            });
+            itemsHost.appendChild(node);
+          });
+        }
       })
       .catch(function () {
         itemsHost.innerHTML = '';

--- a/theme/templates/blocks/interactive.calendar.php
+++ b/theme/templates/blocks/interactive.calendar.php
@@ -6,6 +6,7 @@
         <dd>
             <select name="custom_layout">
                 <option value="list" selected>Event list</option>
+                <option value="calendar">Calendar view</option>
                 <option value="cards">Event cards</option>
                 <option value="compact">Compact list</option>
             </select>


### PR DESCRIPTION
## Summary
- add a calendar display option to the calendar block template
- implement client-side rendering logic for the month grid layout and supporting styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfeb209460833183f01becc08a6475