### PR TITLE
Enable multi-category filtering for blog post list block

### DIFF
--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -70,13 +70,18 @@
     if (value == null) {
       return [];
     }
+    var seen = Object.create(null);
     return String(value)
       .split(',')
       .map(function (entry) {
         return entry.toLowerCase().trim();
       })
       .filter(function (entry) {
-        return entry.length > 0;
+        if (entry.length === 0 || seen[entry]) {
+          return false;
+        }
+        seen[entry] = true;
+        return true;
       });
   }
 
@@ -165,16 +170,20 @@
     }
     var settings = container.dataset || {};
     var limit = parseLimit(settings.limit);
-    var category = normalizeCategory(settings.category);
+    var categories = parseCategoriesList(settings.category);
     var showExcerpt = String(settings.showExcerpt || '').toLowerCase();
     var showMeta = String(settings.showMeta || '').toLowerCase();
     var emptyMessage = settings.empty || 'No posts available.';
     fetchBlogPosts()
       .then(function (posts) {
         var filtered = posts.slice();
-        if (category) {
+        if (categories.length) {
           filtered = filtered.filter(function (post) {
-            return normalizeCategory(post.category) === category;
+            var postCategory = normalizeCategory(post.category);
+            if (!postCategory) {
+              return false;
+            }
+            return categories.indexOf(postCategory) !== -1;
           });
         }
         filtered.sort(function (a, b) {

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -68,13 +68,18 @@
     if (value == null) {
       return [];
     }
+    var seen = Object.create(null);
     return String(value)
       .split(',')
       .map(function (entry) {
         return entry.toLowerCase().trim();
       })
       .filter(function (entry) {
-        return entry.length > 0;
+        if (entry.length === 0 || seen[entry]) {
+          return false;
+        }
+        seen[entry] = true;
+        return true;
       });
   }
 
@@ -163,16 +168,20 @@
     }
     var settings = container.dataset || {};
     var limit = parseLimit(settings.limit);
-    var category = normalizeCategory(settings.category);
+    var categories = parseCategoriesList(settings.category);
     var showExcerpt = String(settings.showExcerpt || '').toLowerCase();
     var showMeta = String(settings.showMeta || '').toLowerCase();
     var emptyMessage = settings.empty || 'No posts available.';
     fetchBlogPosts()
       .then(function (posts) {
         var filtered = posts.slice();
-        if (category) {
+        if (categories.length) {
           filtered = filtered.filter(function (post) {
-            return normalizeCategory(post.category) === category;
+            var postCategory = normalizeCategory(post.category);
+            if (!postCategory) {
+              return false;
+            }
+            return categories.indexOf(postCategory) !== -1;
           });
         }
         filtered.sort(function (a, b) {

--- a/theme/templates/blocks/blog.post-list.php
+++ b/theme/templates/blocks/blog.post-list.php
@@ -27,10 +27,12 @@
         </dd>
     </dl>
     <dl class="sparkDialog _tpl-box mb-3">
-        <dt>Filter by Category</dt>
+        <dt>Filter by Categories</dt>
         <dd>
-            <input type="text" class="form-control" name="custom_category" placeholder="All categories">
-            <small class="form-text text-muted">Leave blank to include every published category.</small>
+            <select name="custom_category" class="form-select" multiple data-blog-category-select data-placeholder="All categories">
+                <option value="">All categories</option>
+            </select>
+            <small class="form-text text-muted">Select one or more categories to limit the list. Choose “All categories” or leave everything unselected to show all published posts.</small>
         </dd>
     </dl>
     <dl class="sparkDialog _tpl-box mb-3">


### PR DESCRIPTION
## Summary
- replace the post list block category text input with a multi-select that is auto-populated from blog categories
- update the builder settings module to fetch categories, handle multi-select values, and persist them in block settings
- allow both the front-end renderer and server-side hydrator to filter posts by multiple categories while treating an empty selection as all posts

## Testing
- php -l CMS/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dfec75ce9883319998eefe591be91b