### PR TITLE
Add blog post detail block with client-side rendering

### DIFF
--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -731,6 +731,156 @@ section.container-fluid {
     display: none;
 }
 
+/* Blog Post Detail Block */
+.blog-post-detail {
+    padding-top: 4rem;
+    padding-bottom: 4rem;
+}
+
+.blog-post-detail .blog-detail-loading,
+.blog-post-detail .blog-detail-empty {
+    text-align: center;
+    color: var(--gray-6);
+    margin: 2rem auto;
+    max-width: 40rem;
+    font-size: 1rem;
+}
+
+.blog-post-detail .blog-detail-body {
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.blog-post-detail .blog-detail-back-link {
+    display: inline-flex;
+    align-items: center;
+    font-weight: var(--font-weight-semi-bold, 600);
+    color: var(--primary);
+    text-decoration: none;
+    transition: color var(--transition-200, 0.2s ease);
+}
+
+.blog-post-detail .blog-detail-back-link::before {
+    content: "←";
+    margin-right: 0.5rem;
+    transition: transform var(--transition-200, 0.2s ease);
+}
+
+.blog-post-detail .blog-detail-back-link:hover,
+.blog-post-detail .blog-detail-back-link:focus-visible {
+    color: var(--primary-dark, var(--primary));
+    text-decoration: underline;
+}
+
+.blog-post-detail .blog-detail-back-link:hover::before,
+.blog-post-detail .blog-detail-back-link:focus-visible::before {
+    transform: translateX(-4px);
+}
+
+.blog-post-detail .blog-detail-header {
+    margin-bottom: 2.5rem;
+    text-align: left;
+}
+
+.blog-post-detail .blog-detail-category {
+    display: inline-block;
+    margin-bottom: 1rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background-color: var(--gray-2);
+    color: var(--gray-8);
+    font-size: 0.85rem;
+    font-weight: var(--font-weight-semi-bold, 600);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.blog-post-detail .blog-detail-title {
+    margin: 0 0 1.25rem;
+    font-size: clamp(2rem, 5vw, 2.75rem);
+    line-height: 1.2;
+}
+
+.blog-post-detail .blog-detail-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+    color: var(--gray-6);
+}
+
+.blog-post-detail .blog-detail-meta span:empty {
+    display: none;
+}
+
+.blog-post-detail .blog-detail-meta span:not(:empty) + span:not(:empty)::before {
+    content: "•";
+    margin-right: 0.75rem;
+    color: var(--gray-4);
+}
+
+.blog-post-detail .blog-detail-image-wrapper {
+    margin: 0 0 2.5rem;
+    border-radius: var(--border-radius-lg, 16px);
+    overflow: hidden;
+    background: var(--gray-2);
+}
+
+.blog-post-detail .blog-detail-image {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.blog-post-detail .blog-detail-content {
+    color: var(--gray-8);
+    font-size: 1.05rem;
+    line-height: 1.8;
+}
+
+.blog-post-detail .blog-detail-content > * + * {
+    margin-top: 1.25rem;
+}
+
+.blog-post-detail .blog-detail-tags {
+    margin-top: 3rem;
+}
+
+.blog-post-detail .blog-detail-tags-title {
+    font-size: 1.15rem;
+    margin-bottom: 1rem;
+}
+
+.blog-post-detail .blog-detail-tag-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.blog-post-detail .blog-detail-tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background-color: var(--gray-2);
+    color: var(--gray-8);
+    font-size: 0.85rem;
+}
+
+@media (max-width: 767.98px) {
+    .blog-post-detail {
+        padding-top: 3rem;
+        padding-bottom: 3rem;
+    }
+
+    .blog-post-detail .blog-detail-title {
+        font-size: clamp(1.75rem, 7vw, 2.25rem);
+    }
+}
+
 @media (min-width: 768px) {
     .blog-post-list .blog-posts {
         grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -105,6 +105,74 @@
     return start.replace(/\/+$/, '') + '/' + path;
   }
 
+  function parseBooleanOption(value, fallback) {
+    if (value == null || value === '') {
+      return fallback;
+    }
+    var normalized = String(value).toLowerCase().trim();
+    if (['false', 'no', '0', 'off', 'hide'].indexOf(normalized) !== -1) {
+      return false;
+    }
+    if (['true', 'yes', '1', 'on', 'show'].indexOf(normalized) !== -1) {
+      return true;
+    }
+    return fallback;
+  }
+
+  function getSlugFromQuery(param) {
+    if (!param) {
+      return '';
+    }
+    try {
+      var search = typeof window.location === 'object' ? window.location.search || '' : '';
+      var params = new URLSearchParams(search);
+      var value = params.get(param);
+      return value ? value.trim() : '';
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function extractSlugFromLocation(basePath) {
+    if (typeof window.location !== 'object') {
+      return '';
+    }
+    var path = window.location.pathname || '';
+    var base = normalizeBasePath();
+    if (base && path.indexOf(base) === 0) {
+      path = path.slice(base.length);
+    }
+    path = path.replace(/[#?].*$/, '');
+    path = path.replace(/^\/+/, '').replace(/\/+$/, '');
+    if (basePath) {
+      var normalized = String(basePath).trim().replace(/^\/+/, '').replace(/\/+$/, '');
+      if (normalized) {
+        var lowerPath = path.toLowerCase();
+        var lowerBase = normalized.toLowerCase();
+        if (lowerPath === lowerBase) {
+          path = '';
+        } else if (lowerPath.indexOf(lowerBase + '/') === 0) {
+          path = path.slice(normalized.length + 1);
+        }
+      }
+    }
+    if (!path) {
+      return '';
+    }
+    var segments = path.split('/').filter(function (segment) {
+      return segment;
+    });
+    if (!segments.length) {
+      return '';
+    }
+    var last = segments[segments.length - 1];
+    try {
+      return decodeURIComponent(last);
+    } catch (err) {
+      return last;
+    }
+  }
+
   function formatDate(value) {
     if (!value) {
       return '';
@@ -265,6 +333,214 @@
       });
   }
 
+  function showBlogDetailLoading(container) {
+    var loading = container.querySelector('[data-blog-loading]');
+    var body = container.querySelector('[data-blog-body]');
+    var emptyState = container.querySelector('[data-blog-empty]');
+    if (loading) {
+      loading.style.display = '';
+    }
+    if (body) {
+      body.style.display = 'none';
+    }
+    if (emptyState) {
+      emptyState.style.display = 'none';
+    }
+  }
+
+  function showBlogDetailEmpty(container, message) {
+    var loading = container.querySelector('[data-blog-loading]');
+    var body = container.querySelector('[data-blog-body]');
+    var emptyState = container.querySelector('[data-blog-empty]');
+    if (loading) {
+      loading.style.display = 'none';
+    }
+    if (body) {
+      body.style.display = 'none';
+    }
+    if (emptyState) {
+      emptyState.textContent = message || 'This blog post could not be found.';
+      emptyState.style.display = '';
+    }
+  }
+
+  function populateBlogDetail(container, post, options) {
+    options = options || {};
+    var loading = container.querySelector('[data-blog-loading]');
+    var emptyState = container.querySelector('[data-blog-empty]');
+    var body = container.querySelector('[data-blog-body]');
+    if (loading) {
+      loading.style.display = 'none';
+    }
+    if (emptyState) {
+      emptyState.style.display = 'none';
+    }
+    if (body) {
+      body.style.display = '';
+    }
+
+    var titleEl = container.querySelector('[data-blog-title]');
+    if (titleEl) {
+      titleEl.textContent = post.title || 'Untitled Post';
+    }
+
+    var categoryEl = container.querySelector('[data-blog-category]');
+    if (categoryEl) {
+      if (options.showCategory && post.category) {
+        categoryEl.textContent = post.category;
+        categoryEl.style.display = '';
+      } else {
+        categoryEl.textContent = '';
+        categoryEl.style.display = 'none';
+      }
+    }
+
+    var metaEl = container.querySelector('[data-blog-meta]');
+    var authorEl = container.querySelector('[data-blog-author]');
+    var dateEl = container.querySelector('[data-blog-date]');
+    var metaVisible = false;
+    if (options.showMeta) {
+      if (authorEl) {
+        authorEl.textContent = post.author || '';
+        if (post.author) {
+          authorEl.style.display = '';
+          metaVisible = true;
+        } else {
+          authorEl.style.display = 'none';
+        }
+      }
+      if (dateEl) {
+        var formattedDate = formatDate(post.publishDate || post.createdAt);
+        dateEl.textContent = formattedDate || '';
+        if (formattedDate) {
+          dateEl.style.display = '';
+          metaVisible = true;
+        } else {
+          dateEl.style.display = 'none';
+        }
+      }
+    } else {
+      if (authorEl) {
+        authorEl.textContent = '';
+        authorEl.style.display = 'none';
+      }
+      if (dateEl) {
+        dateEl.textContent = '';
+        dateEl.style.display = 'none';
+      }
+    }
+    if (metaEl) {
+      if (options.showMeta && metaVisible) {
+        metaEl.style.display = '';
+      } else {
+        metaEl.style.display = 'none';
+      }
+    }
+
+    var imageWrapper = container.querySelector('[data-blog-image-wrapper]');
+    var imageEl = container.querySelector('[data-blog-image]');
+    if (imageWrapper) {
+      if (options.showImage && post.image && imageEl) {
+        imageEl.src = post.image;
+        imageEl.alt = post.imageAlt || ('Featured image for ' + (post.title || 'blog post'));
+        imageWrapper.style.display = '';
+      } else {
+        if (imageEl) {
+          imageEl.removeAttribute('src');
+          imageEl.alt = '';
+        }
+        imageWrapper.style.display = 'none';
+      }
+    }
+
+    var contentEl = container.querySelector('[data-blog-content]');
+    if (contentEl) {
+      contentEl.innerHTML = post.content || '<p>This post does not have any content yet.</p>';
+    }
+
+    var tagsContainer = container.querySelector('[data-blog-tags]');
+    var tagsList = container.querySelector('[data-blog-tag-list]');
+    if (tagsContainer) {
+      if (options.showTags && post.tags && tagsList) {
+        var tags = String(post.tags)
+          .split(',')
+          .map(function (tag) {
+            return tag.trim();
+          })
+          .filter(function (tag) {
+            return tag.length > 0;
+          });
+        if (tags.length) {
+          tagsList.innerHTML = '';
+          tags.forEach(function (tag) {
+            var item = document.createElement('li');
+            item.className = 'blog-detail-tag';
+            item.textContent = tag;
+            tagsList.appendChild(item);
+          });
+          tagsContainer.style.display = '';
+        } else {
+          tagsList.innerHTML = '';
+          tagsContainer.style.display = 'none';
+        }
+      } else if (tagsList) {
+        tagsList.innerHTML = '';
+        tagsContainer.style.display = 'none';
+      }
+    }
+  }
+
+  function renderBlogDetail(container) {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+    showBlogDetailLoading(container);
+    var dataset = container.dataset || {};
+    var emptyMessage = dataset.empty || 'This blog post could not be found.';
+    var slug = dataset.slug || '';
+    var autoSlug = String(dataset.autoSlug || 'yes').toLowerCase();
+    if (autoSlug !== 'no' && autoSlug !== 'false') {
+      var fromQuery = getSlugFromQuery(dataset.queryParam);
+      if (fromQuery) {
+        slug = fromQuery;
+      } else {
+        var derived = extractSlugFromLocation(dataset.base);
+        if (derived) {
+          slug = derived;
+        }
+      }
+    }
+    slug = (slug || '').trim();
+    if (!slug) {
+      showBlogDetailEmpty(container, emptyMessage);
+      return;
+    }
+    container.dataset.blogSlug = slug;
+    fetchBlogPosts()
+      .then(function (posts) {
+        var normalized = slug.toLowerCase();
+        var match = posts.find(function (post) {
+          if (!post) {
+            return false;
+          }
+          return String(post.slug || '').toLowerCase() === normalized;
+        });
+        if (!match) {
+          showBlogDetailEmpty(container, emptyMessage);
+          return;
+        }
+        populateBlogDetail(container, match, {
+          showImage: parseBooleanOption(dataset.showImage, true),
+          showMeta: parseBooleanOption(dataset.showMeta, true),
+          showCategory: parseBooleanOption(dataset.showCategory, true),
+          showTags: parseBooleanOption(dataset.showTags, true)
+        });
+      })
+      .catch(function () {
+        showBlogDetailEmpty(container, emptyMessage);
+      });
+  }
+
   var eventsPromise = null;
   var eventCategoriesPromise = null;
   var htmlParser = null;
@@ -348,20 +624,6 @@
         return {};
       });
     return eventCategoriesPromise;
-  }
-
-  function parseBooleanOption(value, defaultValue) {
-    if (value == null) {
-      return defaultValue;
-    }
-    var normalized = String(value).toLowerCase().trim();
-    if (['no', 'false', '0', 'off', 'hide'].indexOf(normalized) !== -1) {
-      return false;
-    }
-    if (['yes', 'true', '1', 'show', 'on'].indexOf(normalized) !== -1) {
-      return true;
-    }
-    return defaultValue;
   }
 
   function normalizeEventsLayout(value) {
@@ -2033,12 +2295,20 @@
     });
   }
 
+  function initBlogDetails() {
+    var details = document.querySelectorAll('[data-blog-detail]');
+    details.forEach(function (container) {
+      renderBlogDetail(container);
+    });
+  }
+
   function observe() {
     if (typeof MutationObserver === 'undefined') {
       return;
     }
     var observer = new MutationObserver(function (mutations) {
       var shouldRefreshBlogs = false;
+      var shouldRefreshBlogDetails = false;
       var shouldRefreshCalendars = false;
       var shouldRefreshEvents = false;
       mutations.forEach(function (mutation) {
@@ -2052,6 +2322,9 @@
           if (node.matches('[data-blog-list]') || node.querySelector('[data-blog-list]')) {
             shouldRefreshBlogs = true;
           }
+          if (node.matches('[data-blog-detail]') || node.querySelector('[data-blog-detail]')) {
+            shouldRefreshBlogDetails = true;
+          }
           if (node.matches('[data-calendar-block]') || node.querySelector('[data-calendar-block]')) {
             shouldRefreshCalendars = true;
           }
@@ -2060,6 +2333,9 @@
           }
         });
       });
+      if (shouldRefreshBlogDetails) {
+        initBlogDetails();
+      }
       if (shouldRefreshBlogs) {
         initBlogLists();
       }
@@ -2077,6 +2353,7 @@
   }
 
   ready(function () {
+    initBlogDetails();
     initBlogLists();
     initEventsBlocks();
     updateEventsCartIndicators();
@@ -2086,6 +2363,10 @@
 
   window.SparkCMSBlogLists = {
     refresh: initBlogLists
+  };
+
+  window.SparkCMSBlogDetails = {
+    refresh: initBlogDetails
   };
 
   window.SparkCMSEvents = {

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -103,6 +103,74 @@
     return start.replace(/\/+$/, '') + '/' + path;
   }
 
+  function parseBooleanOption(value, fallback) {
+    if (value == null || value === '') {
+      return fallback;
+    }
+    var normalized = String(value).toLowerCase().trim();
+    if (['false', 'no', '0', 'off', 'hide'].indexOf(normalized) !== -1) {
+      return false;
+    }
+    if (['true', 'yes', '1', 'on', 'show'].indexOf(normalized) !== -1) {
+      return true;
+    }
+    return fallback;
+  }
+
+  function getSlugFromQuery(param) {
+    if (!param) {
+      return '';
+    }
+    try {
+      var search = typeof window.location === 'object' ? window.location.search || '' : '';
+      var params = new URLSearchParams(search);
+      var value = params.get(param);
+      return value ? value.trim() : '';
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function extractSlugFromLocation(basePath) {
+    if (typeof window.location !== 'object') {
+      return '';
+    }
+    var path = window.location.pathname || '';
+    var base = normalizeBasePath();
+    if (base && path.indexOf(base) === 0) {
+      path = path.slice(base.length);
+    }
+    path = path.replace(/[#?].*$/, '');
+    path = path.replace(/^\/+/, '').replace(/\/+$/, '');
+    if (basePath) {
+      var normalized = String(basePath).trim().replace(/^\/+/, '').replace(/\/+$/, '');
+      if (normalized) {
+        var lowerPath = path.toLowerCase();
+        var lowerBase = normalized.toLowerCase();
+        if (lowerPath === lowerBase) {
+          path = '';
+        } else if (lowerPath.indexOf(lowerBase + '/') === 0) {
+          path = path.slice(normalized.length + 1);
+        }
+      }
+    }
+    if (!path) {
+      return '';
+    }
+    var segments = path.split('/').filter(function (segment) {
+      return segment;
+    });
+    if (!segments.length) {
+      return '';
+    }
+    var last = segments[segments.length - 1];
+    try {
+      return decodeURIComponent(last);
+    } catch (err) {
+      return last;
+    }
+  }
+
   function formatDate(value) {
     if (!value) {
       return '';
@@ -263,6 +331,214 @@
       });
   }
 
+  function showBlogDetailLoading(container) {
+    var loading = container.querySelector('[data-blog-loading]');
+    var body = container.querySelector('[data-blog-body]');
+    var emptyState = container.querySelector('[data-blog-empty]');
+    if (loading) {
+      loading.style.display = '';
+    }
+    if (body) {
+      body.style.display = 'none';
+    }
+    if (emptyState) {
+      emptyState.style.display = 'none';
+    }
+  }
+
+  function showBlogDetailEmpty(container, message) {
+    var loading = container.querySelector('[data-blog-loading]');
+    var body = container.querySelector('[data-blog-body]');
+    var emptyState = container.querySelector('[data-blog-empty]');
+    if (loading) {
+      loading.style.display = 'none';
+    }
+    if (body) {
+      body.style.display = 'none';
+    }
+    if (emptyState) {
+      emptyState.textContent = message || 'This blog post could not be found.';
+      emptyState.style.display = '';
+    }
+  }
+
+  function populateBlogDetail(container, post, options) {
+    options = options || {};
+    var loading = container.querySelector('[data-blog-loading]');
+    var emptyState = container.querySelector('[data-blog-empty]');
+    var body = container.querySelector('[data-blog-body]');
+    if (loading) {
+      loading.style.display = 'none';
+    }
+    if (emptyState) {
+      emptyState.style.display = 'none';
+    }
+    if (body) {
+      body.style.display = '';
+    }
+
+    var titleEl = container.querySelector('[data-blog-title]');
+    if (titleEl) {
+      titleEl.textContent = post.title || 'Untitled Post';
+    }
+
+    var categoryEl = container.querySelector('[data-blog-category]');
+    if (categoryEl) {
+      if (options.showCategory && post.category) {
+        categoryEl.textContent = post.category;
+        categoryEl.style.display = '';
+      } else {
+        categoryEl.textContent = '';
+        categoryEl.style.display = 'none';
+      }
+    }
+
+    var metaEl = container.querySelector('[data-blog-meta]');
+    var authorEl = container.querySelector('[data-blog-author]');
+    var dateEl = container.querySelector('[data-blog-date]');
+    var metaVisible = false;
+    if (options.showMeta) {
+      if (authorEl) {
+        authorEl.textContent = post.author || '';
+        if (post.author) {
+          authorEl.style.display = '';
+          metaVisible = true;
+        } else {
+          authorEl.style.display = 'none';
+        }
+      }
+      if (dateEl) {
+        var formattedDate = formatDate(post.publishDate || post.createdAt);
+        dateEl.textContent = formattedDate || '';
+        if (formattedDate) {
+          dateEl.style.display = '';
+          metaVisible = true;
+        } else {
+          dateEl.style.display = 'none';
+        }
+      }
+    } else {
+      if (authorEl) {
+        authorEl.textContent = '';
+        authorEl.style.display = 'none';
+      }
+      if (dateEl) {
+        dateEl.textContent = '';
+        dateEl.style.display = 'none';
+      }
+    }
+    if (metaEl) {
+      if (options.showMeta && metaVisible) {
+        metaEl.style.display = '';
+      } else {
+        metaEl.style.display = 'none';
+      }
+    }
+
+    var imageWrapper = container.querySelector('[data-blog-image-wrapper]');
+    var imageEl = container.querySelector('[data-blog-image]');
+    if (imageWrapper) {
+      if (options.showImage && post.image && imageEl) {
+        imageEl.src = post.image;
+        imageEl.alt = post.imageAlt || ('Featured image for ' + (post.title || 'blog post'));
+        imageWrapper.style.display = '';
+      } else {
+        if (imageEl) {
+          imageEl.removeAttribute('src');
+          imageEl.alt = '';
+        }
+        imageWrapper.style.display = 'none';
+      }
+    }
+
+    var contentEl = container.querySelector('[data-blog-content]');
+    if (contentEl) {
+      contentEl.innerHTML = post.content || '<p>This post does not have any content yet.</p>';
+    }
+
+    var tagsContainer = container.querySelector('[data-blog-tags]');
+    var tagsList = container.querySelector('[data-blog-tag-list]');
+    if (tagsContainer) {
+      if (options.showTags && post.tags && tagsList) {
+        var tags = String(post.tags)
+          .split(',')
+          .map(function (tag) {
+            return tag.trim();
+          })
+          .filter(function (tag) {
+            return tag.length > 0;
+          });
+        if (tags.length) {
+          tagsList.innerHTML = '';
+          tags.forEach(function (tag) {
+            var item = document.createElement('li');
+            item.className = 'blog-detail-tag';
+            item.textContent = tag;
+            tagsList.appendChild(item);
+          });
+          tagsContainer.style.display = '';
+        } else {
+          tagsList.innerHTML = '';
+          tagsContainer.style.display = 'none';
+        }
+      } else if (tagsList) {
+        tagsList.innerHTML = '';
+        tagsContainer.style.display = 'none';
+      }
+    }
+  }
+
+  function renderBlogDetail(container) {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+    showBlogDetailLoading(container);
+    var dataset = container.dataset || {};
+    var emptyMessage = dataset.empty || 'This blog post could not be found.';
+    var slug = dataset.slug || '';
+    var autoSlug = String(dataset.autoSlug || 'yes').toLowerCase();
+    if (autoSlug !== 'no' && autoSlug !== 'false') {
+      var fromQuery = getSlugFromQuery(dataset.queryParam);
+      if (fromQuery) {
+        slug = fromQuery;
+      } else {
+        var derived = extractSlugFromLocation(dataset.base);
+        if (derived) {
+          slug = derived;
+        }
+      }
+    }
+    slug = (slug || '').trim();
+    if (!slug) {
+      showBlogDetailEmpty(container, emptyMessage);
+      return;
+    }
+    container.dataset.blogSlug = slug;
+    fetchBlogPosts()
+      .then(function (posts) {
+        var normalized = slug.toLowerCase();
+        var match = posts.find(function (post) {
+          if (!post) {
+            return false;
+          }
+          return String(post.slug || '').toLowerCase() === normalized;
+        });
+        if (!match) {
+          showBlogDetailEmpty(container, emptyMessage);
+          return;
+        }
+        populateBlogDetail(container, match, {
+          showImage: parseBooleanOption(dataset.showImage, true),
+          showMeta: parseBooleanOption(dataset.showMeta, true),
+          showCategory: parseBooleanOption(dataset.showCategory, true),
+          showTags: parseBooleanOption(dataset.showTags, true)
+        });
+      })
+      .catch(function () {
+        showBlogDetailEmpty(container, emptyMessage);
+      });
+  }
+
   var eventsPromise = null;
   var eventCategoriesPromise = null;
   var htmlParser = null;
@@ -346,20 +622,6 @@
         return {};
       });
     return eventCategoriesPromise;
-  }
-
-  function parseBooleanOption(value, defaultValue) {
-    if (value == null) {
-      return defaultValue;
-    }
-    var normalized = String(value).toLowerCase().trim();
-    if (['no', 'false', '0', 'off', 'hide'].indexOf(normalized) !== -1) {
-      return false;
-    }
-    if (['yes', 'true', '1', 'show', 'on'].indexOf(normalized) !== -1) {
-      return true;
-    }
-    return defaultValue;
   }
 
   function normalizeEventsLayout(value) {
@@ -2031,12 +2293,20 @@
     });
   }
 
+  function initBlogDetails() {
+    var details = document.querySelectorAll('[data-blog-detail]');
+    details.forEach(function (container) {
+      renderBlogDetail(container);
+    });
+  }
+
   function observe() {
     if (typeof MutationObserver === 'undefined') {
       return;
     }
     var observer = new MutationObserver(function (mutations) {
       var shouldRefreshBlogs = false;
+      var shouldRefreshBlogDetails = false;
       var shouldRefreshCalendars = false;
       var shouldRefreshEvents = false;
       mutations.forEach(function (mutation) {
@@ -2050,6 +2320,9 @@
           if (node.matches('[data-blog-list]') || node.querySelector('[data-blog-list]')) {
             shouldRefreshBlogs = true;
           }
+          if (node.matches('[data-blog-detail]') || node.querySelector('[data-blog-detail]')) {
+            shouldRefreshBlogDetails = true;
+          }
           if (node.matches('[data-calendar-block]') || node.querySelector('[data-calendar-block]')) {
             shouldRefreshCalendars = true;
           }
@@ -2058,6 +2331,9 @@
           }
         });
       });
+      if (shouldRefreshBlogDetails) {
+        initBlogDetails();
+      }
       if (shouldRefreshBlogs) {
         initBlogLists();
       }
@@ -2075,6 +2351,7 @@
   }
 
   ready(function () {
+    initBlogDetails();
     initBlogLists();
     initEventsBlocks();
     updateEventsCartIndicators();
@@ -2084,6 +2361,10 @@
 
   window.SparkCMSBlogLists = {
     refresh: initBlogLists
+  };
+
+  window.SparkCMSBlogDetails = {
+    refresh: initBlogDetails
   };
 
   window.SparkCMSEvents = {

--- a/theme/templates/blocks/blog.post-detail.php
+++ b/theme/templates/blocks/blog.post-detail.php
@@ -1,0 +1,112 @@
+<!-- File: blog.post-detail.php -->
+<!-- Template: blog.post-detail -->
+<?php $blockId = uniqid('blog-detail-'); ?>
+<templateSetting caption="Blog Detail Settings" order="1">
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Back Link Label</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_back_label" value="← Back to all posts">
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Back Link URL</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_back_url" value="/blog">
+            <small class="form-text text-muted">Choose where the back link directs visitors.</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Auto-detect Slug from URL?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_auto_slug" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_auto_slug" value="no"> No</label>
+        </dd>
+        <small class="form-text text-muted">When enabled, the block attempts to load a post based on the current page URL.</small>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Manual Slug (optional)</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_slug" placeholder="e.g. getting-started-web-development">
+            <small class="form-text text-muted">Used when auto-detect is disabled or as a fallback value.</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Detail Base Path</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_base" value="/blog">
+            <small class="form-text text-muted">Matches the path segment that precedes the slug, e.g. <code>/blog</code>.</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Slug Query Parameter</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_query_param" placeholder="post">
+            <small class="form-text text-muted">Optional. Provide a query parameter name to detect the slug (e.g. <code>?post=slug</code>).</small>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Featured Image?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_image" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_image" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Author &amp; Date?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_meta" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_meta" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Category?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_category" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_category" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box mb-3">
+        <dt>Show Tags?</dt>
+        <dd class="align-options">
+            <label class="me-2"><input type="radio" name="custom_show_tags" value="yes" checked> Yes</label>
+            <label><input type="radio" name="custom_show_tags" value="no"> No</label>
+        </dd>
+    </dl>
+    <dl class="sparkDialog _tpl-box">
+        <dt>Not Found Message</dt>
+        <dd>
+            <input type="text" class="form-control" name="custom_empty" value="We couldn’t find that blog post. Please check back soon!">
+        </dd>
+    </dl>
+</templateSetting>
+<article id="<?= $blockId ?>" class="blog-post-detail" data-tpl-tooltip="Blog Post Detail" data-blog-detail data-base="{custom_base}" data-auto-slug="{custom_auto_slug}" data-slug="{custom_slug}" data-query-param="{custom_query_param}" data-show-image="{custom_show_image}" data-show-meta="{custom_show_meta}" data-show-category="{custom_show_category}" data-show-tags="{custom_show_tags}" data-empty="{custom_empty}">
+    <div class="container">
+        <div class="blog-detail-loading text-muted" data-blog-loading style="display: none;">Loading blog post…</div>
+        <div class="blog-detail-empty text-muted" data-blog-empty style="display: none;">{custom_empty}</div>
+        <div class="blog-detail-body" data-blog-body>
+            <div class="blog-detail-back mb-4">
+                <a class="blog-detail-back-link" href="{custom_back_url}" data-blog-back data-editable>{custom_back_label}</a>
+            </div>
+            <header class="blog-detail-header">
+                <span class="blog-detail-category" data-blog-category>Category</span>
+                <h1 class="blog-detail-title" data-blog-title>Blog Post Title</h1>
+                <div class="blog-detail-meta" data-blog-meta>
+                    <span class="blog-detail-author" data-blog-author>Author Name</span>
+                    <span class="blog-detail-date" data-blog-date>Jan 1, 2024</span>
+                </div>
+            </header>
+            <figure class="blog-detail-image-wrapper" data-blog-image-wrapper>
+                <img class="blog-detail-image" src="" alt="" data-blog-image>
+            </figure>
+            <div class="blog-detail-content" data-blog-content>
+                <p>Blog post content will appear here once published.</p>
+            </div>
+            <div class="blog-detail-tags" data-blog-tags>
+                <h2 class="blog-detail-tags-title">Tags</h2>
+                <ul class="blog-detail-tag-list" data-blog-tag-list>
+                    <li class="blog-detail-tag">Example Tag</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</article>


### PR DESCRIPTION
## Summary
- add a configurable blog post detail block template with placeholders for title, meta, image, content, and tags
- extend the front-end scripts to hydrate detail blocks by slug detection and show loading/empty states (including the combined bundle)
- style the blog detail presentation with new layout, typography, and tag treatments

## Testing
- php -l theme/templates/blocks/blog.post-detail.php

------
https://chatgpt.com/codex/tasks/task_e_68dfec9959688331a91a449578f3e877