### PR TITLE
Center align blog post cells

### DIFF
--- a/CMS/spark-cms.css
+++ b/CMS/spark-cms.css
@@ -7212,7 +7212,7 @@
 
 .blog-post-cell {
     display: flex;
-    align-items: flex-start;
+    align-items: center;
     gap: 16px;
 }
 


### PR DESCRIPTION
## Summary
- update the `.blog-post-cell` styling to vertically center its contents for better alignment

## Testing
- no tests were run (css-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dff411e2508331b10cfa033f6d4fe9