### PR TITLE
Validate form fields JSON input

### DIFF
--- a/CMS/modules/forms/save_form.php
+++ b/CMS/modules/forms/save_form.php
@@ -10,7 +10,19 @@ $forms = read_json_file($formsFile);
 
 $id = isset($_POST['id']) && $_POST['id'] !== '' ? (int)$_POST['id'] : null;
 $name = sanitize_text($_POST['name'] ?? '');
-$fieldsData = isset($_POST['fields']) ? json_decode($_POST['fields'], true) : [];
+$fieldsData = [];
+if (isset($_POST['fields'])) {
+    $decodedFields = json_decode($_POST['fields'], true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        http_response_code(400);
+        echo 'Invalid fields data';
+        exit;
+    }
+    if (is_array($decodedFields)) {
+        $fieldsData = $decodedFields;
+    }
+}
+
 $fields = [];
 foreach ($fieldsData as $field) {
     if (!is_array($field)) continue;


### PR DESCRIPTION
## Summary
- validate submitted form field JSON before processing
- return a 400 response when form field JSON is invalid and only loop over array data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e023d035a08331b349e95a5d98774f