### PR TITLE
Enforce authentication for blog listings

### DIFF
--- a/CMS/modules/blogs/list_categories.php
+++ b/CMS/modules/blogs/list_categories.php
@@ -1,6 +1,9 @@
 <?php
 // File: list_categories.php
+require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/BlogRepository.php';
+
+require_login();
 
 $repository = new BlogRepository();
 $categories = $repository->listCategories();

--- a/CMS/modules/blogs/list_posts.php
+++ b/CMS/modules/blogs/list_posts.php
@@ -1,6 +1,9 @@
 <?php
 // File: list_posts.php
+require_once __DIR__ . '/../../includes/auth.php';
 require_once __DIR__ . '/BlogRepository.php';
+
+require_login();
 
 $repository = new BlogRepository();
 $posts = $repository->readPosts();


### PR DESCRIPTION
## Summary
- load the central auth helper in the blog list endpoints
- call require_login so only authenticated users can access the JSON listings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e023ca0a9883318e38f712fcfbfc39