### PR TITLE
Fix blog media picker thumbnail paths

### DIFF
--- a/CMS/modules/blogs/blogs.js
+++ b/CMS/modules/blogs/blogs.js
@@ -144,10 +144,17 @@ $(document).ready(function(){
         if(!cleaned){
             return '';
         }
+        if(cleaned.startsWith('CMS/')){
+            return `${base}/${cleaned}`.replace(/\/+/g, '/');
+        }
+        if(cleaned.startsWith('uploads/')){
+            const cmsPrefix = `${base}/CMS`.replace(/\/+$/, '');
+            return `${cmsPrefix}/${cleaned}`.replace(/\/+/g, '/');
+        }
         if(!base){
             return `/${cleaned}`;
         }
-        return `${base}/${cleaned}`;
+        return `${base}/${cleaned}`.replace(/\/+/g, '/');
     }
 
     function normalizeImageValue(value){


### PR DESCRIPTION
## Summary
- ensure blog media picker resolves CMS upload paths correctly so thumbnails load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03f744c9083318f55eb7c37b77bf2