### PR TITLE
Display active template name in settings panel

### DIFF
--- a/liveed/builder.php
+++ b/liveed/builder.php
@@ -104,7 +104,7 @@ $previewModalHtml = '<div id="previewModal" class="modal">'
     . '<div class="modal-footer"><button type="button" class="btn btn-secondary" id="closePreview"><i class="fa-solid fa-xmark btn-icon" aria-hidden="true"></i><span class="btn-label">Close</span></button></div>'
     . '</div></div>';
 
-$builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><span class="title">Settings</span><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div>'
+$builderEnd = '</main><div id="settingsPanel" class="settings-panel"><div class="settings-header"><div class="title-group"><span class="title">Settings</span><span class="template-name"></span></div><button type="button" class="close-btn">&times;</button></div><div class="settings-content"></div></div>'
     . '<div id="historyPanel" class="history-panel"><div class="history-header"><span class="title">Page History</span><button type="button" class="close-btn">&times;</button></div><div class="history-content"></div></div>'
     . $mediaPickerHtml . $previewModalHtml . '</div>'
     . '<script>window.builderPageId = ' . json_encode($page['id']) . ';window.builderBase = ' . json_encode($scriptBase) . ';window.builderSlug = ' . json_encode($page['slug']) . ';window.builderLastModified = ' . json_encode($page['last_modified']) . ';</script>'

--- a/liveed/css/builder-core.css
+++ b/liveed/css/builder-core.css
@@ -313,12 +313,24 @@
   background: rgba(15, 23, 42, 0.8);
   border-bottom: 1px solid rgba(51, 65, 85, 0.2);
 }
+.settings-panel .settings-header .title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 .settings-panel .settings-header .title {
   font-weight: 600;
   font-size: 14px;
   color: #e2e8f0;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+}
+.settings-panel .settings-header .template-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: #cbd5f5;
+  text-transform: none;
+  letter-spacing: 0;
 }
 .settings-panel .settings-header .close-btn {
   background: none;


### PR DESCRIPTION
## Summary
- add a template name placeholder to the settings panel header markup and style it for readability
- show the friendly template name of the selected block when the settings panel opens and clear it when closing

## Testing
- php -l liveed/builder.php

------
https://chatgpt.com/codex/tasks/task_e_68e044b5263483319982664d9d9cc3fb