### PR TITLE
Remove hover highlight from LiveEd sections

### DIFF
--- a/liveed/css/builder-palette.css
+++ b/liveed/css/builder-palette.css
@@ -107,8 +107,8 @@
 }
 
 .block-wrapper:hover {
-  border-color: #e2e8f0;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  border-color: transparent;
+  box-shadow: none;
 }
 
 .block-wrapper.selected {


### PR DESCRIPTION
## Summary
- remove the hover border and shadow on LiveEd block wrappers to eliminate section hover highlighting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e046124d4c8331b81335abd5681566