### PR TITLE
Make calendar day height responsive

### DIFF
--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -1090,7 +1090,7 @@ section.container-fluid {
 }
 
 .calendar-block__calendar-day {
-    min-height: 120px;
+    min-height: clamp(6.25rem, 12vw, 7.5rem);
     padding: 0.75rem;
     border-radius: var(--border-radius-md, 8px);
     border: 1px solid var(--gray-3);


### PR DESCRIPTION
## Summary
- replace the fixed calendar day height with a responsive clamp value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e048a8312083318ecb560408bf0cd0