### PR TITLE
Improve calendar day focus state

### DIFF
--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -1103,9 +1103,14 @@ section.container-fluid {
 }
 
 .calendar-block__calendar-day:hover,
-.calendar-block__calendar-day:focus-within {
+.calendar-block__calendar-day:focus-within,
+.calendar-block__calendar-day:focus-visible {
     border-color: var(--primary-3);
     box-shadow: 0 12px 25px rgba(15, 23, 42, 0.12);
+}
+
+.calendar-block__calendar-day:focus-visible {
+    outline: none;
 }
 
 .calendar-block__calendar-day--outside {


### PR DESCRIPTION
## Summary
- extend the calendar day hover styling to cover focus-visible states so keyboard focus matches hover visuals
- remove the default outline from focus-visible states to avoid a double focus indicator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e048abc17483318bd5f39efa9acb08