### PR TITLE
Adjust mobile CTA layout for responsive header

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -519,12 +519,19 @@ button:focus-visible,
     }
 
     .cta-btn {
-        display: none;
+        display: flex;
+        width: 100%;
+        justify-content: center;
+        margin-top: 0.75rem;
+        padding: 0.95rem 1.5rem;
+        font-size: 1.05rem;
     }
 
     .header-actions {
         width: 100%;
-        justify-content: space-between;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.75rem;
     }
 
     .search-box {


### PR DESCRIPTION
## Summary
- update the mobile breakpoint styles so the CTA button remains visible and fills the available width
- stack header actions vertically on small screens to keep the search box and CTA from overlapping

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e048c139188331ba1f05822b49004f