### PR TITLE
Use hidden attribute for back-to-top button

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -458,6 +458,10 @@ button:focus-visible,
     box-shadow: 0 25px 45px -18px rgba(15, 23, 42, 0.45);
     transition: all 0.3s ease;
     z-index: 999;
+}
+
+#back-to-top-btn[hidden],
+#back-to-top-btn[aria-hidden="true"] {
     display: none;
 }
 

--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -233,7 +233,7 @@ function renderFooterMenu($items){
         </footer>
 
         <!-- Back to Top Button -->
-        <button id="back-to-top-btn" aria-label="Back to Top">
+        <button id="back-to-top-btn" aria-label="Back to Top" hidden aria-hidden="true">
             <span>
                 <span>
                     <i class="fas fa-chevron-up" aria-hidden="true"></i>
@@ -255,6 +255,7 @@ function renderFooterMenu($items){
     <script>
         const navToggle = document.querySelector('.nav-toggle');
         const mainNav = document.getElementById('main-nav');
+        const backToTopBtn = document.getElementById('back-to-top-btn');
 
         if (navToggle && mainNav) {
             navToggle.addEventListener('click', () => {
@@ -271,24 +272,25 @@ function renderFooterMenu($items){
             });
         }
 
-        // Show/hide back to top button
-        window.addEventListener('scroll', function() {
-            const backToTopBtn = document.getElementById('back-to-top-btn');
-            if (window.scrollY > 100) {
-                backToTopBtn.style.display = 'block';
-            } else {
-                backToTopBtn.style.display = 'none';
-            }
-        });
+        if (backToTopBtn) {
+            const updateBackToTopVisibility = () => {
+                const shouldShow = window.scrollY > 100;
+                backToTopBtn.toggleAttribute('hidden', !shouldShow);
+                backToTopBtn.setAttribute('aria-hidden', String(!shouldShow));
+            };
 
-        // Smooth scroll to top
-        document.getElementById('back-to-top-btn').addEventListener('click', function(e) {
-            e.preventDefault();
-            window.scrollTo({
-                top: 0,
-                behavior: 'smooth'
+            updateBackToTopVisibility();
+            window.addEventListener('scroll', updateBackToTopVisibility);
+
+            // Smooth scroll to top
+            backToTopBtn.addEventListener('click', function(e) {
+                e.preventDefault();
+                window.scrollTo({
+                    top: 0,
+                    behavior: 'smooth'
+                });
             });
-        });
+        }
     </script>
 
 </body>

--- a/theme/templates/partials/footer.php
+++ b/theme/templates/partials/footer.php
@@ -29,7 +29,7 @@
     </footer>
 
     <!-- Back to Top Button -->
-    <button id="back-to-top-btn" class="_js-scroll-top" aria-label="Back to Top">
+    <button id="back-to-top-btn" class="_js-scroll-top" aria-label="Back to Top" hidden aria-hidden="true">
         <span>
             <span>
                 <i class="fa-solid fa-chevron-up" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- default the back-to-top button to a hidden state using semantic attributes
- update the page script to toggle `hidden`/`aria-hidden` instead of inline styles
- ensure the CSS hides the control when the accessibility attributes are present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e048c677b483319570da5b857331b9