### PR TITLE
Use shared head partial in page template

### DIFF
--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -9,19 +9,14 @@ if (!empty($settings['logo'])) {
 } else {
     $logo = $themeBase . '/images/logo.png';
 }
-$faviconSetting = $settings['favicon'] ?? '';
-if (is_string($faviconSetting) && $faviconSetting !== '' && preg_match('#^https?://#i', $faviconSetting)) {
-    $favicon = $faviconSetting;
-} elseif (!empty($settings['favicon'])) {
-    $favicon = $scriptBase . '/CMS/' . ltrim($settings['favicon'], '/');
-} else {
-    $favicon = $themeBase . '/images/favicon.png';
-}
 $mainMenu = $menus[0]['items'] ?? [];
 $primaryMenuItems = array_slice($mainMenu, 0, 5);
 $overflowMenuItems = array_slice($mainMenu, 5);
 $footerMenu = $menus[1]['items'] ?? [];
 $social = $settings['social'] ?? [];
+
+$headExtra = $page['head'] ?? ($page['head_extra'] ?? '');
+$bodyAttributes = 'class="d-flex flex-column min-vh-100"';
 
 function renderMenu($items, $isDropdown = false){
     foreach ($items as $it) {
@@ -48,33 +43,7 @@ function renderFooterMenu($items){
     }
 }
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <!-- Metas & Morweb CMS Assets -->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
-    <!-- Favicon -->
-    <link rel="shortcut icon" href="<?php echo htmlspecialchars($favicon); ?>" type="image/x-icon"/>
-    
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,600;0,700;1,400&family=PT+Serif:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
-
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    
-    <!-- Custom Stylesheets -->
-    <link rel="stylesheet" href="<?php echo $themeBase; ?>/css/root.css?v=mw3.2"/>
-    <link rel="stylesheet" href="<?php echo $themeBase; ?>/css/skin.css?v=mw3.2"/>
-    <link rel="stylesheet" href="<?php echo $themeBase; ?>/css/override.css?v=mw3.2"/>
-</head>
-<body class="d-flex flex-column min-vh-100">
+<?php include __DIR__ . "/../partials/head.php"; ?>
 
     <!-- Default Page -->
     <div id="app" class="page-template default-page d-flex flex-column min-vh-100">

--- a/theme/templates/partials/head.php
+++ b/theme/templates/partials/head.php
@@ -7,6 +7,8 @@ if (is_string($faviconSetting) && $faviconSetting !== '' && preg_match('#^https?
 } else {
     $favicon = $themeBase . '/images/favicon.png';
 }
+$headExtra = $headExtra ?? '';
+$bodyAttributes = isset($bodyAttributes) ? trim($bodyAttributes) : '';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -34,6 +36,7 @@ if (is_string($faviconSetting) && $faviconSetting !== '' && preg_match('#^https?
         <link nocache="nocache" rel="stylesheet" href="<?php echo $themeBase; ?>/css/root.css?v=mw3.2"/>
         <link nocache="nocache" rel="stylesheet" href="<?php echo $themeBase; ?>/css/skin.css?v=mw3.2"/>
         <link nocache="nocache" rel="stylesheet" href="<?php echo $themeBase; ?>/css/override.css?v=mw3.2"/>
+        <?php if (!empty($headExtra)) { echo $headExtra; } ?>
     </head>
-    <body>
+    <body<?php echo $bodyAttributes !== '' ? ' ' . $bodyAttributes : ''; ?>>
 


### PR DESCRIPTION
## Summary
- replace the inline head markup in the page template with the shared head partial
- allow templates to pass additional head markup and body attributes into the head partial for customization

## Testing
- php -l theme/templates/pages/page.php
- php -l theme/templates/partials/head.php

------
https://chatgpt.com/codex/tasks/task_e_68e048cf4a7c8331bf1eaf9e826f31b3