### PR TITLE
Add extra large gap spacing class for layout templates

### DIFF
--- a/theme/css/skin.css
+++ b/theme/css/skin.css
@@ -1795,6 +1795,7 @@ section.container-fluid {
 .g-1 { --row-gap: 0.75rem; --row-gap-mobile: 0.75rem; }
 .g-3 { --row-gap: 1.5rem; --row-gap-mobile: 1.25rem; }
 .g-5 { --row-gap: 2.5rem; --row-gap-mobile: 2rem; }
+.g-6 { --row-gap: 3.5rem; --row-gap-mobile: 2.75rem; }
 
 ._tpl-box,
 .mwDialog,

--- a/theme/templates/blocks/layout.column-2.php
+++ b/theme/templates/blocks/layout.column-2.php
@@ -21,7 +21,7 @@
                 <option value=" g-1">Small</option>
                 <option value=" g-3" selected="selected">Medium (default)</option>
                 <option value=" g-5">Large</option>
-                <option value=" g-5">Extra Large</option>
+                <option value=" g-6">Extra Large</option>
             </select>
         </dd>
         <dt>Alignment:</dt>

--- a/theme/templates/blocks/layout.column-3.php
+++ b/theme/templates/blocks/layout.column-3.php
@@ -9,7 +9,7 @@
                 <option value=" g-1">Small</option>
                 <option value=" g-3" selected="selected">Medium (default)</option>
                 <option value=" g-5">Large</option>
-                <option value=" g-5">Extra Large</option>
+                <option value=" g-6">Extra Large</option>
             </select>
         </dd>
         <dt>Alignment:</dt>

--- a/theme/templates/blocks/layout.column-4.php
+++ b/theme/templates/blocks/layout.column-4.php
@@ -9,7 +9,7 @@
                 <option value=" g-1">Small</option>
                 <option value=" g-3" selected="selected">Medium (default)</option>
                 <option value=" g-5">Large</option>
-                <option value=" g-5">Extra Large</option>
+                <option value=" g-6">Extra Large</option>
             </select>
         </dd>
         <dt>Alignment:</dt>

--- a/theme/templates/blocks/layout.sidebar.php
+++ b/theme/templates/blocks/layout.sidebar.php
@@ -24,7 +24,7 @@
                 <option value=" g-1">Small</option>
                 <option value=" g-3" selected>Medium (default)</option>
                 <option value=" g-5">Large</option>
-                <option value=" g-5">Extra Large</option>
+                <option value=" g-6">Extra Large</option>
             </select>
         </dd>
     </dl>


### PR DESCRIPTION
## Summary
- map the Extra Large gap option in column and sidebar templates to a distinct `g-6` spacing class
- add the `g-6` spacing utility so the new option renders with a wider gap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e048e256588331acc4bd2a77d1d816