### PR TITLE
Simplify section layout wrapper toggle

### DIFF
--- a/theme/templates/blocks/layout.section.php
+++ b/theme/templates/blocks/layout.section.php
@@ -50,21 +50,8 @@
         </dd>
     </dl>
 </templateSetting>
-<toggle rel="custom_type" value="container">
-	<div style="background-color:{custom_bg_color};" data-tpl-tooltip="Section">
-    <section class="container" >
+<div style="background-color:{custom_bg_color};" data-tpl-tooltip="Section">
+    <section class="{custom_type}">
         <div class="drop-area"></div>
     </section>
-	</div>
-</toggle>
-<toggle rel="custom_type" value="container-fluid">
-	
-		<div style="background-color:{custom_bg_color};" data-tpl-tooltip="Section">
-
-    <section class="container-fluid" >
-        <div class="drop-area"></div>
-    </section>
-		</div>
-
-	
-</toggle>
+</div>


### PR DESCRIPTION
## Summary
- replace duplicate toggle wrappers in the section layout with a single markup block
- bind the section class directly to the `custom_type` selection while preserving the background color style

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e048ed28108331b2943ee2213f7dd4