### PR TITLE
Ensure blog read more arrow uses DOM creation

### DIFF
--- a/theme/js/combined.js
+++ b/theme/js/combined.js
@@ -331,7 +331,11 @@
           var readMore = document.createElement('a');
           readMore.className = 'blog-read-more';
           readMore.href = resolveDetailUrl(settings.base, post.slug);
-          readMore.innerHTML = 'Read more <span aria-hidden="true">&rarr;</span>';
+          readMore.textContent = 'Read more';
+          var arrow = document.createElement('span');
+          arrow.setAttribute('aria-hidden', 'true');
+          arrow.textContent = ' \u2192';
+          readMore.appendChild(arrow);
           article.appendChild(readMore);
 
           itemsHost.appendChild(article);

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -329,7 +329,11 @@
           var readMore = document.createElement('a');
           readMore.className = 'blog-read-more';
           readMore.href = resolveDetailUrl(settings.base, post.slug);
-          readMore.innerHTML = 'Read more <span aria-hidden="true">&rarr;</span>';
+          readMore.textContent = 'Read more';
+          var arrow = document.createElement('span');
+          arrow.setAttribute('aria-hidden', 'true');
+          arrow.textContent = ' \u2192';
+          readMore.appendChild(arrow);
           article.appendChild(readMore);
 
           itemsHost.appendChild(article);


### PR DESCRIPTION
## Summary
- create the decorative arrow span in hydrate via `document.createElement`
- append the arrow span to the read more link and mark it aria-hidden to preserve accessible text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0490915d88331a26b734bdca973b1