### PR TITLE
Refactor navigation and back-to-top behavior into shared script

### DIFF
--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -221,47 +221,5 @@ function renderFooterMenu($items){
     <script src="<?php echo $themeBase; ?>/js/global.js?v=mw3.2"></script>
     <script src="<?php echo $themeBase; ?>/js/script.js?v=mw3.2"></script>
 
-    <!-- Navigation & Back to Top Scripts -->
-    <script>
-        const navToggle = document.querySelector('.nav-toggle');
-        const mainNav = document.getElementById('main-nav');
-        const backToTopBtn = document.getElementById('back-to-top-btn');
-
-        if (navToggle && mainNav) {
-            navToggle.addEventListener('click', () => {
-                const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
-                navToggle.setAttribute('aria-expanded', String(!isExpanded));
-                mainNav.classList.toggle('active');
-            });
-
-            mainNav.querySelectorAll('a').forEach((link) => {
-                link.addEventListener('click', () => {
-                    navToggle.setAttribute('aria-expanded', 'false');
-                    mainNav.classList.remove('active');
-                });
-            });
-        }
-
-        if (backToTopBtn) {
-            const updateBackToTopVisibility = () => {
-                const shouldShow = window.scrollY > 100;
-                backToTopBtn.toggleAttribute('hidden', !shouldShow);
-                backToTopBtn.setAttribute('aria-hidden', String(!shouldShow));
-            };
-
-            updateBackToTopVisibility();
-            window.addEventListener('scroll', updateBackToTopVisibility);
-
-            // Smooth scroll to top
-            backToTopBtn.addEventListener('click', function(e) {
-                e.preventDefault();
-                window.scrollTo({
-                    top: 0,
-                    behavior: 'smooth'
-                });
-            });
-        }
-    </script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move the navigation toggle and back-to-top logic into the shared global JavaScript bundle
- expose a refresh helper so dynamically added markup and other templates share the same behavior
- remove the duplicate inline script from the page template now that the logic is centralized

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e04b2cf23083318e894fa18357039e