### PR TITLE
Support multi-category blog filtering

### DIFF
--- a/CMS/data/blog_posts.json
+++ b/CMS/data/blog_posts.json
@@ -51,6 +51,10 @@
     "excerpt": "Practical tips for building inclusive websites that everyone can use with ease.",
     "content": "<p>Accessibility should be considered at every stage of a project. Start by ensuring semantic HTML, providing sufficient color contrast, and testing with assistive technologies...</p>",
     "category": "Accessibility",
+    "categories": [
+      "Accessibility",
+      "Design"
+    ],
     "author": "Alice",
     "status": "published",
     "publishDate": "2024-02-05T11:15:00",
@@ -96,6 +100,10 @@
     "excerpt": "Step-by-step techniques for building responsive layouts with CSS Grid.",
     "content": "<p>CSS Grid empowers designers to craft responsive, two-dimensional layouts with ease. Learn how to define grid containers, place items precisely, and create adaptive designs that scale across devices...</p>",
     "category": "Design",
+    "categories": [
+      "Design",
+      "Frontend"
+    ],
     "author": "Alice",
     "status": "published",
     "publishDate": "2024-02-14T09:00:00",

--- a/tests/blog_multiple_categories_manual.md
+++ b/tests/blog_multiple_categories_manual.md
@@ -1,0 +1,34 @@
+# Blog Category Filtering Manual Test
+
+This manual test ensures the blog list hydrator supports posts that provide a primary
+`category` string as well as an optional `categories` array containing multiple values.
+
+## Setup
+1. Run a local copy of SparkCMS (for example with `php -S localhost:8000` from the
+   project root).
+2. Navigate to the blog listing page that uses the JavaScript hydrator.
+
+## Scenario
+The dataset includes posts that declare multiple categories, such as:
+
+```json
+{
+  "title": "Designing Accessible Web Experiences",
+  "category": "Accessibility",
+  "categories": ["Accessibility", "Design"],
+  "status": "published"
+}
+```
+
+## Steps
+1. Configure a blog list block with `data-category="design"`.
+2. Verify that posts that list `"Design"` inside their `categories` array appear in the
+   hydrated list even if their primary `category` is different.
+3. Configure a blog list block with `data-category="accessibility"` and confirm the same
+   post is still included.
+4. Confirm that filtering by an unrelated category (for example `data-category="security"`)
+   excludes the post.
+
+## Expected Result
+Posts are displayed when any normalized category value—whether from `category` or the
+`categories` array—matches the requested filter.

--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -62,7 +62,7 @@ import basePath from './utils/base-path.js';
     return String(value)
       .split(',')
       .map(function (entry) {
-        return entry.toLowerCase().trim();
+        return normalizeCategory(entry);
       })
       .filter(function (entry) {
         if (entry.length === 0 || seen[entry]) {
@@ -235,11 +235,28 @@ import basePath from './utils/base-path.js';
         var filtered = posts.slice();
         if (categories.length) {
           filtered = filtered.filter(function (post) {
-            var postCategory = normalizeCategory(post.category);
-            if (!postCategory) {
+            var seen = Object.create(null);
+            var normalized = [];
+            var primary = normalizeCategory(post.category);
+            if (primary && !seen[primary]) {
+              normalized.push(primary);
+              seen[primary] = true;
+            }
+            if (Array.isArray(post.categories)) {
+              post.categories.forEach(function (value) {
+                var entry = normalizeCategory(value);
+                if (entry && !seen[entry]) {
+                  normalized.push(entry);
+                  seen[entry] = true;
+                }
+              });
+            }
+            if (!normalized.length) {
               return false;
             }
-            return categories.indexOf(postCategory) !== -1;
+            return normalized.some(function (value) {
+              return categories.indexOf(value) !== -1;
+            });
           });
         }
         filtered.sort(function (a, b) {


### PR DESCRIPTION
## Summary
- update the blog hydrator to normalize category filters and match either the primary category or any value in a post's categories array
- add sample multi-category metadata to the blog posts fixture data
- document manual verification steps for posts with multiple categories

## Testing
- not run (manual steps documented)


------
https://chatgpt.com/codex/tasks/task_e_68e04b927824833192773f3af79f5401