### PR TITLE
Encode slug parameters when building detail URLs

### DIFF
--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -81,13 +81,14 @@ import basePath from './utils/base-path.js';
     if (!detail) {
       detail = '/blog';
     }
+    var safeSlug = encodeURIComponent(String(slug));
     if (/^https?:\/\//i.test(detail)) {
-      return detail.replace(/\/+$/, '') + '/' + slug;
+      return detail.replace(/\/+$/, '') + '/' + safeSlug;
     }
     var base = basePath();
     detail = detail.replace(/\/+$/, '');
     detail = detail.replace(/^\/+/, '');
-    var path = detail ? detail + '/' + slug : slug;
+    var path = detail ? detail + '/' + safeSlug : safeSlug;
     var start = base;
     if (start && start.charAt(0) !== '/') {
       start = '/' + start;
@@ -857,13 +858,14 @@ import basePath from './utils/base-path.js';
       return '';
     }
     var slug = createEventSlug(event);
+    var encodedSlug = slug ? encodeURIComponent(String(slug)) : '';
     if (/^https?:\/\//i.test(base)) {
-      return base.replace(/\/+$/, '') + (slug ? '/' + slug : '');
+      return base.replace(/\/+$/, '') + (encodedSlug ? '/' + encodedSlug : '');
     }
     var normalized = base.replace(/\/+$/, '').replace(/^\/+/, '');
     var path = normalized;
-    if (slug) {
-      path = normalized ? normalized + '/' + slug : slug;
+    if (encodedSlug) {
+      path = normalized ? normalized + '/' + encodedSlug : encodedSlug;
     }
     var start = basePath();
     if (start && start.charAt(0) !== '/') {


### PR DESCRIPTION
## Summary
- encode blog detail slugs with `encodeURIComponent` inside `resolveDetailUrl`
- apply the same encoding to event detail links built by `resolveEventDetailUrl`

## Testing
- `node - <<'NODE'` (blog slug encoding check)
- `node - <<'NODE'` (event slug encoding check)


------
https://chatgpt.com/codex/tasks/task_e_68e04babfe288331b29abb1e0aeac619