### PR TITLE
Improve select placeholders and required handling

### DIFF
--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -188,6 +188,15 @@ function applySelectValue(select, value) {
     });
   } else {
     const target = value ?? '';
+    if (target === '' || target == null) {
+      const placeholderOption = select.querySelector('option[value=""]');
+      if (placeholderOption) {
+        placeholderOption.selected = true;
+      } else {
+        select.value = '';
+      }
+      return;
+    }
     select.value = target;
     if (target && select.value !== target) {
       const manualOption = document.createElement('option');
@@ -247,6 +256,9 @@ function populateFormsSelects(container, block) {
       const placeholderOption = document.createElement('option');
       placeholderOption.value = '';
       placeholderOption.textContent = placeholder;
+      placeholderOption.disabled = true;
+      placeholderOption.hidden = true;
+      placeholderOption.selected = true;
       fragment.appendChild(placeholderOption);
 
       forms.forEach((form) => {

--- a/theme/js/script.js
+++ b/theme/js/script.js
@@ -200,6 +200,9 @@ import basePath from './utils/base-path.js';
       var placeholderOption = document.createElement('option');
       placeholderOption.value = '';
       placeholderOption.textContent = 'Please select';
+      placeholderOption.disabled = true;
+      placeholderOption.hidden = true;
+      placeholderOption.selected = true;
       select.appendChild(placeholderOption);
       options.forEach(function (option) {
         var opt = document.createElement('option');
@@ -207,6 +210,14 @@ import basePath from './utils/base-path.js';
         opt.textContent = option;
         select.appendChild(opt);
       });
+      if (required) {
+        select.addEventListener('change', function () {
+          if (select.value === '') {
+            select.selectedIndex = 0;
+          }
+        });
+      }
+
       wrapper.appendChild(select);
       appendFeedback(wrapper);
       return wrapper;
@@ -267,6 +278,14 @@ import basePath from './utils/base-path.js';
       var inputs = wrapper.querySelectorAll('input, textarea, select');
       inputs.forEach(function (input) {
         input.classList.add('is-invalid');
+        if (
+          input.tagName === 'SELECT' &&
+          input.required &&
+          !input.multiple &&
+          (input.value === '' || input.selectedIndex === -1)
+        ) {
+          input.selectedIndex = 0;
+        }
       });
       var feedback = wrapper.querySelector('.invalid-feedback');
       if (feedback) {


### PR DESCRIPTION
## Summary
- disable and hide placeholder options when building select fields in the editor and public form renderer
- ensure required selects revert to their placeholder when no value is chosen and keep placeholder selection when reading stored values

## Testing
- php tests/forms_repository_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e04c8fac5c83318fefa4283bfffce4