### PR TITLE
Add fallback text color for page hero title

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -314,7 +314,7 @@ button:focus-visible,
     font-family: var(--font-family-serif);
     font-weight: 700;
     font-size: clamp(2.5rem, 3.5vw, 3.75rem);
-    color: var(--text-color-on-primary);
+    color: var(--text-color-on-primary, #fff);
     line-height: 1.1;
     margin-bottom: 1.25rem;
 }


### PR DESCRIPTION
## Summary
- add a fallback value for the hero page title color variable to ensure readability on the primary background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04d5bbd1883319c623cb1a77c3572