### PR TITLE
Improve footer social focus state

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -431,9 +431,16 @@ button:focus-visible,
     backdrop-filter: blur(12px);
 }
 
-.footer-social a:hover {
+.footer-social a:hover,
+.footer-social a:focus-visible {
     background: rgba(79, 70, 229, 0.85);
     transform: translateY(-4px);
+}
+
+.footer-social a:focus-visible {
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.5);
+    outline: 2px solid rgba(79, 70, 229, 0.85);
+    outline-offset: 3px;
 }
 
 .footer-copy {


### PR DESCRIPTION
## Summary
- extend the footer social icon hover styling to also apply on :focus-visible
- add a visible outline and glow to ensure the focus state is discernible beyond a color shift

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04d678cd083318080c9d756a1c4bd