### PR TITLE
Respect reduced-motion preference for smooth scrolling

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -587,7 +587,19 @@ button:focus-visible,
 
 /* Smooth Scrolling */
 html {
-    scroll-behavior: smooth;
+    scroll-behavior: auto;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+    html {
+        scroll-behavior: smooth;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
 }
 
 /* Loading Animation */


### PR DESCRIPTION
## Summary
- wrap smooth scrolling behavior in a prefers-reduced-motion media query
- add explicit fallback to disable smooth scrolling when reduced-motion is requested

## Testing
- not run (not applicable in container environment)

------
https://chatgpt.com/codex/tasks/task_e_68e04d6d40308331bd3d0414ec4a9994