### PR TITLE
Add hero gradient tokens and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Each module usually exposes a `view.php` entry point with supporting services, J
 - **Builder UI (`/liveed`).** Provides block palette management, responsive preview toggles, media picker, undo/redo, manual save, and page history integration. Builder assets live under `liveed/css`, `liveed/modules`, and `liveed/builder.js`.
 - **Theme templates.** Located in `theme/templates` with folders for pages (`templates/pages`), blocks (`templates/blocks`), and partials. Templates expect arrays of pages, menus, blog posts, and site settings injected by `CMS/index.php`.
 - **Asset bundling.** Run `php bundle.php` to concatenate the primary theme stylesheets (`theme/css/root.css`, `skin.css`, `override.css`) into `combined.css`. JavaScript is served directly from `theme/js/global.js` and `theme/js/script.js` so the canonical sources stay in sync across environments.
-- **Customization.** Override CSS variables in `theme/css/override.css`, add scripts in `theme/js`, or introduce new block templates for the builder. The theme can be versioned independently of content by committing changes to the repository.
+- **Customization.** Override CSS variables in `theme/css/override.css`, add scripts in `theme/js`, or introduce new block templates for the builder. To adjust the homepage hero, update the `--hero-gradient-1` and `--hero-gradient-2` tokens (ideally via overrides in `theme/css/override.css`) to point at new gradient colors while reusing the shared layout. The theme can be versioned independently of content by committing changes to the repository.
 
 ## Public Forms & Integrations
 

--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -293,7 +293,7 @@ button:focus-visible,
     content: "";
     position: absolute;
     inset: 0;
-    background: radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.15), transparent 60%), radial-gradient(circle at 80% 0%, rgba(16, 185, 129, 0.12), transparent 55%);
+    background: radial-gradient(circle at 20% 20%, var(--hero-gradient-1), transparent 60%), radial-gradient(circle at 80% 0%, var(--hero-gradient-2), transparent 55%);
     z-index: -1;
 }
 

--- a/theme/css/root.css
+++ b/theme/css/root.css
@@ -149,6 +149,8 @@
   --text-color-on-fourth-dark: var(--white);
 
   --background-gradient: radial-gradient(circle at 0% 0%, rgba(99, 102, 241, 0.1), transparent 55%), radial-gradient(circle at 100% 0%, rgba(56, 189, 248, 0.12), transparent 50%), linear-gradient(180deg, #f9fafb 0%, #f3f4f6 100%);
+  --hero-gradient-1: rgba(79, 70, 229, 0.15);
+  --hero-gradient-2: rgba(16, 185, 129, 0.12);
   --card-background: var(--white);
   --card-shadow: 0 25px 50px -12px rgba(79, 70, 229, 0.15);
   --card-radius: 1.25rem;


### PR DESCRIPTION
## Summary
- introduce hero gradient color tokens in the root design token layer
- update the page hero overlay to reference the new gradient tokens
- document how to customize the hero gradient through token overrides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e04d61247c8331969e22be015a3cf0