### PR TITLE
Adjust dropdown menu classes for nested navigation

### DIFF
--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -21,16 +21,42 @@ $bodyAttributes = 'class="d-flex flex-column min-vh-100"';
 function renderMenu($items, $isDropdown = false){
     foreach ($items as $it) {
         $hasChildren = !empty($it['children']);
+
+        $liClasses = $isDropdown ? ['dropdown-item'] : ['nav-item'];
+        $linkClasses = $isDropdown ? ['dropdown-item'] : ['nav-link'];
+        $linkAttributes = [];
+
         if ($hasChildren) {
-            echo '<li class="nav-item dropdown">';
-            echo '<a class="nav-link dropdown-toggle" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').' role="button" data-bs-toggle="dropdown" aria-expanded="false">'.htmlspecialchars($it['label']).'</a>';
+            if ($isDropdown) {
+                $liClasses[] = 'dropdown-submenu';
+                $liClasses[] = 'dropend';
+                $linkClasses[] = 'dropdown-toggle';
+            } else {
+                $liClasses[] = 'dropdown';
+                $linkClasses[] = 'dropdown-toggle';
+            }
+            $linkAttributes[] = 'role="button"';
+            $linkAttributes[] = 'data-bs-toggle="dropdown"';
+            $linkAttributes[] = 'aria-expanded="false"';
+        }
+
+        if (!empty($it['new_tab'])) {
+            $linkAttributes[] = 'target="_blank"';
+        }
+
+        $liClassAttribute = ' class="'.implode(' ', $liClasses).'"';
+        $linkClassAttribute = ' class="'.implode(' ', $linkClasses).'"';
+        $linkAttributeString = empty($linkAttributes) ? '' : ' '.implode(' ', $linkAttributes);
+
+        echo '<li'.$liClassAttribute.'>';
+        echo '<a'.$linkClassAttribute.' href="'.htmlspecialchars($it['link']).'"'.$linkAttributeString.'>'.htmlspecialchars($it['label']).'</a>';
+
+        if ($hasChildren) {
             echo '<ul class="dropdown-menu">';
             renderMenu($it['children'], true);
             echo '</ul>';
-        } else {
-            echo '<li class="nav-item'.($isDropdown ? '' : '').'">';
-            echo '<a class="nav-link" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
         }
+
         echo '</li>';
     }
 }


### PR DESCRIPTION
## Summary
- update the renderMenu helper so dropdown items receive dropdown-specific classes and attributes
- ensure nested menus emit dropdown-menu wrappers for consistent styling and keyboard toggling

## Testing
- php -l theme/templates/pages/page.php

------
https://chatgpt.com/codex/tasks/task_e_68e04d6f543c83318c74fa804546ac8c