### PR TITLE
Enable focus-driven dropdown menus

### DIFF
--- a/theme/css/override.css
+++ b/theme/css/override.css
@@ -144,7 +144,8 @@ button:focus-visible,
     transition: all 0.3s ease;
 }
 
-.main-nav li:hover ul {
+.main-nav li:hover > ul,
+.main-nav li:focus-within > ul {
     opacity: 1;
     visibility: visible;
     transform: translateY(0);


### PR DESCRIPTION
## Summary
- allow desktop dropdown menus to open when their trigger receives focus
- rely on focus state to hide dropdown panels once keyboard focus leaves the menu

## Testing
- Manual keyboard navigation with Playwright (Tab/Shift+Tab)


------
https://chatgpt.com/codex/tasks/task_e_68e04d5717c08331bffb81e3e19b3a48