### PR TITLE
Refactor menu helpers into shared partial

### DIFF
--- a/theme/templates/pages/page.php
+++ b/theme/templates/pages/page.php
@@ -18,56 +18,7 @@ $social = $settings['social'] ?? [];
 $headExtra = $page['head'] ?? ($page['head_extra'] ?? '');
 $bodyAttributes = 'class="d-flex flex-column min-vh-100"';
 
-function renderMenu($items, $isDropdown = false){
-    foreach ($items as $it) {
-        $hasChildren = !empty($it['children']);
-
-        $liClasses = $isDropdown ? ['dropdown-item'] : ['nav-item'];
-        $linkClasses = $isDropdown ? ['dropdown-item'] : ['nav-link'];
-        $linkAttributes = [];
-
-        if ($hasChildren) {
-            if ($isDropdown) {
-                $liClasses[] = 'dropdown-submenu';
-                $liClasses[] = 'dropend';
-                $linkClasses[] = 'dropdown-toggle';
-            } else {
-                $liClasses[] = 'dropdown';
-                $linkClasses[] = 'dropdown-toggle';
-            }
-            $linkAttributes[] = 'role="button"';
-            $linkAttributes[] = 'data-bs-toggle="dropdown"';
-            $linkAttributes[] = 'aria-expanded="false"';
-        }
-
-        if (!empty($it['new_tab'])) {
-            $linkAttributes[] = 'target="_blank"';
-        }
-
-        $liClassAttribute = ' class="'.implode(' ', $liClasses).'"';
-        $linkClassAttribute = ' class="'.implode(' ', $linkClasses).'"';
-        $linkAttributeString = empty($linkAttributes) ? '' : ' '.implode(' ', $linkAttributes);
-
-        echo '<li'.$liClassAttribute.'>';
-        echo '<a'.$linkClassAttribute.' href="'.htmlspecialchars($it['link']).'"'.$linkAttributeString.'>'.htmlspecialchars($it['label']).'</a>';
-
-        if ($hasChildren) {
-            echo '<ul class="dropdown-menu">';
-            renderMenu($it['children'], true);
-            echo '</ul>';
-        }
-
-        echo '</li>';
-    }
-}
-
-function renderFooterMenu($items){
-    foreach ($items as $it) {
-        echo '<li class="nav-item">';
-        echo '<a class="nav-link text-light px-2" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
-        echo '</li>';
-    }
-}
+require_once __DIR__ . '/../partials/menu.php';
 ?>
 <?php include __DIR__ . "/../partials/head.php"; ?>
 

--- a/theme/templates/pages/search.php
+++ b/theme/templates/pages/search.php
@@ -12,30 +12,7 @@ $mainMenu = $menus[0]['items'] ?? [];
 $footerMenu = $menus[1]['items'] ?? [];
 $social = $settings['social'] ?? [];
 
-function renderMenu($items, $isDropdown = false){
-    foreach ($items as $it) {
-        $hasChildren = !empty($it['children']);
-        if ($hasChildren) {
-            echo '<li class="nav-item dropdown">';
-            echo '<a class="nav-link dropdown-toggle" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').' role="button" data-bs-toggle="dropdown" aria-expanded="false">'.htmlspecialchars($it['label']).'</a>';
-            echo '<ul class="dropdown-menu">';
-            renderMenu($it['children'], true);
-            echo '</ul>';
-        } else {
-            echo '<li class="nav-item'.($isDropdown ? '' : '').'">';
-            echo '<a class="nav-link" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
-        }
-        echo '</li>';
-    }
-}
-
-function renderFooterMenu($items){
-    foreach ($items as $it) {
-        echo '<li class="nav-item">';
-        echo '<a class="nav-link px-2" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
-        echo '</li>';
-    }
-}
+require_once __DIR__ . '/../partials/menu.php';
 ?>
 <?php include __DIR__ . "/../partials/head.php"; ?>
 

--- a/theme/templates/partials/menu.php
+++ b/theme/templates/partials/menu.php
@@ -1,0 +1,57 @@
+<?php
+if (!function_exists('renderMenu')) {
+    function renderMenu($items, $isDropdown = false)
+    {
+        foreach ($items as $it) {
+            $hasChildren = !empty($it['children']);
+
+            $liClasses = $isDropdown ? ['dropdown-item'] : ['nav-item'];
+            $linkClasses = $isDropdown ? ['dropdown-item'] : ['nav-link'];
+            $linkAttributes = [];
+
+            if ($hasChildren) {
+                if ($isDropdown) {
+                    $liClasses[] = 'dropdown-submenu';
+                    $liClasses[] = 'dropend';
+                    $linkClasses[] = 'dropdown-toggle';
+                } else {
+                    $liClasses[] = 'dropdown';
+                    $linkClasses[] = 'dropdown-toggle';
+                }
+                $linkAttributes[] = 'role="button"';
+                $linkAttributes[] = 'data-bs-toggle="dropdown"';
+                $linkAttributes[] = 'aria-expanded="false"';
+            }
+
+            if (!empty($it['new_tab'])) {
+                $linkAttributes[] = 'target="_blank"';
+            }
+
+            $liClassAttribute = ' class="' . implode(' ', $liClasses) . '"';
+            $linkClassAttribute = ' class="' . implode(' ', $linkClasses) . '"';
+            $linkAttributeString = empty($linkAttributes) ? '' : ' ' . implode(' ', $linkAttributes);
+
+            echo '<li' . $liClassAttribute . '>';
+            echo '<a' . $linkClassAttribute . ' href="' . htmlspecialchars($it['link']) . '"' . $linkAttributeString . '>' . htmlspecialchars($it['label']) . '</a>';
+
+            if ($hasChildren) {
+                echo '<ul class="dropdown-menu">';
+                renderMenu($it['children'], true);
+                echo '</ul>';
+            }
+
+            echo '</li>';
+        }
+    }
+}
+
+if (!function_exists('renderFooterMenu')) {
+    function renderFooterMenu($items)
+    {
+        foreach ($items as $it) {
+            echo '<li class="nav-item">';
+            echo '<a class="nav-link text-light px-2" href="' . htmlspecialchars($it['link']) . '"' . (!empty($it['new_tab']) ? ' target="_blank"' : '') . '>' . htmlspecialchars($it['label']) . '</a>';
+            echo '</li>';
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract the navigation and footer menu rendering helpers into a shared partial
- load the shared menu helpers in both the standard page and search templates to remove duplication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04e52e92c8331ad25549ba50d1773