### PR TITLE
Reset events cart storage after parse failures

### DIFF
--- a/theme/js/global.js
+++ b/theme/js/global.js
@@ -994,6 +994,19 @@ import basePath from './utils/base-path.js';
       return parsed;
     } catch (error) {
       console.warn('[SparkCMS] Unable to parse events cart from storage:', error);
+      try {
+        window.localStorage.removeItem(EVENTS_CART_STORAGE_KEY);
+        console.info('[SparkCMS] Events cart storage has been reset.');
+        if (typeof window.dispatchEvent === 'function' && typeof window.CustomEvent === 'function') {
+          window.dispatchEvent(
+            new CustomEvent('sparkcms:events-cart-reset', {
+              detail: { reason: 'parse-error' }
+            })
+          );
+        }
+      } catch (cleanupError) {
+        console.warn('[SparkCMS] Unable to clear events cart storage during recovery:', cleanupError);
+      }
       return fallback;
     }
   }


### PR DESCRIPTION
## Summary
- clear the events cart storage key when its saved state cannot be parsed
- log a reset message and broadcast a custom reset event so the UI can recover cleanly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e04f4724cc8331842a5348bfc45c11