### PR TITLE
Fix theme error templates redeclaration and add template smoke test

### DIFF
--- a/tests/theme_templates_test.php
+++ b/tests/theme_templates_test.php
@@ -1,0 +1,41 @@
+<?php
+$root = dirname(__DIR__);
+require $root . '/CMS/includes/template_renderer.php';
+
+$settings = json_decode(file_get_contents($root . '/CMS/data/settings.json'), true);
+$menus = json_decode(file_get_contents($root . '/CMS/data/menus.json'), true);
+
+if (!is_array($settings) || !is_array($menus)) {
+    throw new RuntimeException('Failed to load settings or menus data.');
+}
+
+$templatesDir = realpath($root . '/theme/templates/pages');
+if ($templatesDir === false) {
+    throw new RuntimeException('Theme templates directory not found.');
+}
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($templatesDir, FilesystemIterator::SKIP_DOTS)
+);
+
+foreach ($iterator as $file) {
+    if ($file->getExtension() !== 'php') {
+        continue;
+    }
+
+    $templateFile = $file->getPathname();
+    $relativePath = substr($templateFile, strlen($root) + 1);
+
+    $htmlFirst = cms_capture_template_html($templateFile, $settings, $menus, '');
+    $htmlSecond = cms_capture_template_html($templateFile, $settings, $menus, '');
+
+    if ($htmlFirst === '' || $htmlSecond === '') {
+        throw new RuntimeException("Template {$relativePath} rendered empty output.");
+    }
+
+    if (strpos($htmlFirst, '{{CONTENT}}') === false || strpos($htmlSecond, '{{CONTENT}}') === false) {
+        throw new RuntimeException("Template {$relativePath} is missing the content placeholder.");
+    }
+}
+
+echo "Theme template rendering tests passed\n";

--- a/theme/templates/pages/errors/403.php
+++ b/theme/templates/pages/errors/403.php
@@ -12,30 +12,7 @@ $mainMenu = $menus[0]['items'] ?? [];
 $footerMenu = $menus[1]['items'] ?? [];
 $social = $settings['social'] ?? [];
 
-function renderMenu($items, $isDropdown = false){
-    foreach ($items as $it) {
-        $hasChildren = !empty($it['children']);
-        if ($hasChildren) {
-            echo '<li class="nav-item dropdown">';
-            echo '<a class="nav-link dropdown-toggle" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').' role="button" data-bs-toggle="dropdown" aria-expanded="false">'.htmlspecialchars($it['label']).'</a>';
-            echo '<ul class="dropdown-menu">';
-            renderMenu($it['children'], true);
-            echo '</ul>';
-        } else {
-            echo '<li class="nav-item'.($isDropdown ? '' : '').'">';
-            echo '<a class="nav-link" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
-        }
-        echo '</li>';
-    }
-}
-
-function renderFooterMenu($items){
-    foreach ($items as $it) {
-        echo '<li class="nav-item">';
-        echo '<a class="nav-link px-2" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
-        echo '</li>';
-    }
-}
+require_once __DIR__ . '/../../partials/menu.php';
 ?>
 <?php include __DIR__ . "/../../partials/head.php"; ?>
 

--- a/theme/templates/pages/errors/404.php
+++ b/theme/templates/pages/errors/404.php
@@ -12,30 +12,7 @@ $mainMenu = $menus[0]['items'] ?? [];
 $footerMenu = $menus[1]['items'] ?? [];
 $social = $settings['social'] ?? [];
 
-function renderMenu($items, $isDropdown = false){
-    foreach ($items as $it) {
-        $hasChildren = !empty($it['children']);
-        if ($hasChildren) {
-            echo '<li class="nav-item dropdown">';
-            echo '<a class="nav-link dropdown-toggle" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').' role="button" data-bs-toggle="dropdown" aria-expanded="false">'.htmlspecialchars($it['label']).'</a>';
-            echo '<ul class="dropdown-menu">';
-            renderMenu($it['children'], true);
-            echo '</ul>';
-        } else {
-            echo '<li class="nav-item'.($isDropdown ? '' : '').'">';
-            echo '<a class="nav-link" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
-        }
-        echo '</li>';
-    }
-}
-
-function renderFooterMenu($items){
-    foreach ($items as $it) {
-        echo '<li class="nav-item">';
-        echo '<a class="nav-link px-2" href="'.htmlspecialchars($it['link']).'"'.(!empty($it['new_tab']) ? ' target="_blank"' : '').'>'.htmlspecialchars($it['label']).'</a>';
-        echo '</li>';
-    }
-}
+require_once __DIR__ . '/../../partials/menu.php';
 ?>
 <?php include __DIR__ . "/../../partials/head.php"; ?>
 


### PR DESCRIPTION
## Summary
- reuse the shared menu partial from the 403/404 theme templates to prevent function redeclaration fatals when templates are rendered multiple times
- add a theme template rendering smoke test that captures each page template twice to ensure the content placeholder is preserved

## Testing
- for f in tests/*.php; do echo "Running $f"; php $f; done

------
https://chatgpt.com/codex/tasks/task_e_68e054e2eebc833188fe46d12fc38a7c