### PR TITLE
Improve canonical link detection in SEO report

### DIFF
--- a/CMS/modules/seo/SeoReport.php
+++ b/CMS/modules/seo/SeoReport.php
@@ -275,8 +275,13 @@ class SeoReport
 
         $linkTags = $doc->getElementsByTagName('link');
         foreach ($linkTags as $link) {
-            $rel = strtolower(trim((string)$link->getAttribute('rel')));
-            if ($rel === 'canonical' && trim((string)$link->getAttribute('href')) !== '') {
+            $relRaw = strtolower(trim((string)$link->getAttribute('rel')));
+            if ($relRaw === '') {
+                continue;
+            }
+
+            $relTokens = preg_split('/\s+/', $relRaw) ?: [];
+            if (in_array('canonical', $relTokens, true) && trim((string)$link->getAttribute('href')) !== '') {
                 $metrics['hasCanonical'] = true;
             }
         }


### PR DESCRIPTION
## Summary
- ensure the SEO report recognises canonical links even when the rel attribute contains multiple tokens

## Testing
- php -l CMS/modules/seo/SeoReport.php

------
https://chatgpt.com/codex/tasks/task_e_68e08425ada08331b5236e1e51a84e22