### PR TITLE
Ensure canonical metadata renders in theme head

### DIFF
--- a/theme/templates/partials/head.php
+++ b/theme/templates/partials/head.php
@@ -16,6 +16,26 @@ $bodyAttributes = isset($bodyAttributes) ? trim($bodyAttributes) : '';
         <!-- Metas & Morweb CMS Assets -->
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <?php
+            $pageData = isset($page) && is_array($page) ? $page : [];
+            $pageTitle = trim((string)($pageData['meta_title'] ?? ''));
+            if ($pageTitle === '') {
+                $pageTitle = trim((string)($pageData['title'] ?? ''));
+            }
+            if ($pageTitle === '') {
+                $pageTitle = $settings['site_name'] ?? 'SparkCMS';
+            }
+
+            $metaDescription = trim((string)($pageData['meta_description'] ?? ''));
+            $canonicalUrl = trim((string)($pageData['canonical_url'] ?? ''));
+        ?>
+        <title><?php echo htmlspecialchars($pageTitle, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></title>
+        <?php if ($metaDescription !== ''): ?>
+        <meta name="description" content="<?php echo htmlspecialchars($metaDescription, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+        <?php endif; ?>
+        <?php if ($canonicalUrl !== ''): ?>
+        <link rel="canonical" href="<?php echo htmlspecialchars($canonicalUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?>">
+        <?php endif; ?>
 
         <!-- Favicon -->
         <link rel="shortcut icon" href="<?php echo htmlspecialchars($favicon); ?>" type="image/x-icon"/>


### PR DESCRIPTION
## Summary
- add dynamic title, description, and canonical link tags to the theme head partial so saved metadata appears in the rendered page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e086c8d1c88331bbc98693a5c02b5c