### PR TITLE
Fix SEO detail modal visibility toggle

### DIFF
--- a/CMS/modules/seo/seo.js
+++ b/CMS/modules/seo/seo.js
@@ -386,6 +386,7 @@
         }
         $issuesList.html(issuesMarkup.join(''));
 
+        $overlay.removeAttr('hidden');
         $overlay.addClass('is-visible');
         $overlay.attr('aria-hidden', 'false');
         $overlay.data('active-slug', page.slug || '');
@@ -408,6 +409,7 @@
         }
         $modal.removeClass('is-visible');
         $modal.attr('aria-hidden', 'true');
+        $modal.attr('hidden', 'hidden');
         $(document).off('keydown.seoModal');
         var returnFocus = $modal.data('return-focus');
         if (returnFocus && typeof returnFocus.focus === 'function') {


### PR DESCRIPTION
## Summary
- ensure the SEO detail modal removes the hidden attribute when opened
- restore the hidden attribute when closing so future openings work reliably

## Testing
- php tests/seo_report_test.php

------
https://chatgpt.com/codex/tasks/task_e_68e0af535388833189e0faed6fd1a3bc