### PR TITLE
Align full SEO audit action with accessibility behavior

### DIFF
--- a/CMS/modules/seo/seo.js
+++ b/CMS/modules/seo/seo.js
@@ -621,7 +621,15 @@
             });
             $modal.find('[data-seo-action="full-audit"]').on('click', function () {
                 var slug = $modal.data('active-slug');
-                window.alert('Launching full SEO audit for ' + (slug || 'selected page') + '.\n\nCrawl will refresh metadata, structured data, and internal linking diagnostics.');
+                if (!slug) {
+                    return;
+                }
+
+                if (!loadSeoModule('page=' + encodeURIComponent(slug))) {
+                    if (stats && stats.detailBaseUrl) {
+                        window.location.href = stats.detailBaseUrl + encodeURIComponent(slug);
+                    }
+                }
             });
         }
 


### PR DESCRIPTION
## Summary
- update the Full SEO Audit modal action to reuse the existing module loader
- ensure the button redirects to the detailed SEO report when ajax loading is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b2938b8083319f0d2c27fb059076