### PR TITLE
Add lifecycle hook registry for builder block scripts

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -11,7 +11,7 @@ import {
 import { initUndoRedo, getBlockPath, getPathLocation } from './modules/undoRedo.js';
 import { initWysiwyg } from './modules/wysiwyg.js';
 import { createMediaPicker } from './modules/mediaPicker.js';
-import { executeScripts } from "./modules/executeScripts.js";
+import { executeScripts } from './modules/executeScripts.js';
 
 let allBlockFiles = [];
 let favorites = [];
@@ -682,6 +682,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           if (!clone) return;
           clone.classList.remove('selected');
           block.after(clone);
+          executeScripts(clone);
           if (history && history.recordOperation) {
             const path = getBlockPath(clone, canvas);
             if (path && path.length) {

--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -1,6 +1,7 @@
 // File: dragDrop.js
 import { ensureBlockState, createBlockElementFromSchema, serializeBlock } from './state.js';
 import { getBlockPath, getPathLocation } from './undoRedo.js';
+import { executeScripts } from './executeScripts.js';
 
 // caching block control markup avoids rebuilding the DOM for each block
 const controlsTemplate = `
@@ -240,6 +241,8 @@ export function createDragDropController(options = {}) {
             if (!wrapper) return;
             if (after == null) area.appendChild(wrapper);
             else area.insertBefore(wrapper, after);
+
+            executeScripts(wrapper);
 
             if (typeof state.recordOperation === 'function') {
               const path = getBlockPath(wrapper, state.canvas);

--- a/liveed/modules/executeScripts.js
+++ b/liveed/modules/executeScripts.js
@@ -1,22 +1,142 @@
+const blockScriptHooks = new Map();
+let defaultsRegistered = false;
+
+function normalizeName(name) {
+  return typeof name === 'string' ? name.trim() : '';
+}
+
+function findMatches(root, selector) {
+  if (!selector || !root) return [];
+  const matches = [];
+  if (typeof root.matches === 'function' && root.matches(selector)) {
+    matches.push(root);
+  }
+  if (typeof root.querySelectorAll === 'function') {
+    matches.push(...root.querySelectorAll(selector));
+  }
+  return matches;
+}
+
+function callGlobalRefresh(path) {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const target = window[path];
+  if (!target) {
+    return false;
+  }
+  const method = typeof target === 'function' ? target : target.refresh;
+  if (typeof method !== 'function') {
+    return false;
+  }
+  try {
+    method.call(target);
+    return true;
+  } catch (error) {
+    console.error('[executeScripts] Error running hook for', path, error);
+    return false;
+  }
+}
+
+export function registerBlockScriptHook(name, options) {
+  const key = normalizeName(name);
+  if (!key || !options || typeof options !== 'object') {
+    return;
+  }
+  const { selector, callback } = options;
+  if (typeof selector !== 'string' || !selector.trim()) {
+    return;
+  }
+  if (typeof callback !== 'function') {
+    return;
+  }
+  blockScriptHooks.set(key, {
+    selector: selector.trim(),
+    callback,
+  });
+}
+
+export function clearBlockScriptHooks() {
+  blockScriptHooks.clear();
+  defaultsRegistered = false;
+}
+
+function ensureDefaultHooks() {
+  if (defaultsRegistered) return;
+  defaultsRegistered = true;
+
+  registerBlockScriptHook('SparkCMSBlogLists.refresh', {
+    selector: '[data-blog-list]',
+    callback(matches) {
+      if (!matches.length) return;
+      callGlobalRefresh('SparkCMSBlogLists');
+    },
+  });
+
+  registerBlockScriptHook('SparkCMSBlogDetails.refresh', {
+    selector: '[data-blog-detail]',
+    callback(matches) {
+      if (!matches.length) return;
+      callGlobalRefresh('SparkCMSBlogDetails');
+    },
+  });
+
+  registerBlockScriptHook('SparkCMSEvents.refresh', {
+    selector: '[data-events-block]',
+    callback(matches) {
+      if (!matches.length) return;
+      callGlobalRefresh('SparkCMSEvents');
+    },
+  });
+
+  registerBlockScriptHook('SparkCMSCalendars.refresh', {
+    selector: '[data-calendar-block]',
+    callback(matches) {
+      if (!matches.length) return;
+      callGlobalRefresh('SparkCMSCalendars');
+    },
+  });
+
+  registerBlockScriptHook('SparkCMSImageGalleries.refresh', {
+    selector: '.image-gallery',
+    callback(matches) {
+      if (!matches.length) return;
+      callGlobalRefresh('SparkCMSImageGalleries');
+    },
+  });
+
+  registerBlockScriptHook('SparkCMSNavigation.refresh', {
+    selector: '.nav-toggle, #main-nav, #back-to-top-btn, ._js-scroll-top',
+    callback(matches) {
+      if (!matches.length) return;
+      callGlobalRefresh('SparkCMSNavigation');
+    },
+  });
+}
+
 /**
- * Ensure any script tags within the provided element are executed.
- * Replaces each script with a new one so the browser runs it.
- * @param {Element} container
+ * Run lifecycle hooks for blocks that require scripted behaviour.
+ * Only registered hooks are executed, preventing arbitrary inline scripts.
+ * @param {Element|Document} container
  */
 export function executeScripts(container) {
   if (!container) return;
+  ensureDefaultHooks();
 
-  const scripts = container.querySelectorAll('script');
-  if (!scripts.length) return;
-
-  scripts.forEach((oldScript) => {
-    const newScript = document.createElement('script');
-
-    for (const attr of oldScript.attributes) {
-      newScript.setAttribute(attr.name, attr.value);
+  const triggered = new Set();
+  blockScriptHooks.forEach((hook, name) => {
+    if (triggered.has(name)) return;
+    const matches = findMatches(container, hook.selector);
+    if (!matches.length) return;
+    triggered.add(name);
+    try {
+      hook.callback(matches, container);
+    } catch (error) {
+      console.error('[executeScripts] Failed running hook', name, error);
     }
-
-    newScript.textContent = oldScript.textContent;
-    oldScript.replaceWith(newScript);
   });
+}
+
+export function getRegisteredBlockScriptHooks() {
+  return new Map(blockScriptHooks);
 }


### PR DESCRIPTION
## Summary
- replace executeScripts with a whitelist-driven lifecycle hook registry for block behaviors
- call the lifecycle hooks after inserting or duplicating blocks so interactive blocks initialize without inline scripts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e16c1081348331aa509aa3bacb7b5b