### PR TITLE
Add asynchronous link checking via web worker

### DIFF
--- a/liveed/css/builder-core.css
+++ b/liveed/css/builder-core.css
@@ -52,6 +52,35 @@
 .save-status.error {
   color: #e53e3e;
 }
+.link-warning-panel {
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(254, 226, 226, 0.85);
+  border: 1px solid rgba(229, 62, 62, 0.6);
+  color: #742a2a;
+  font-size: 13px;
+  line-height: 1.4;
+  box-shadow: 0 2px 6px rgba(229, 62, 62, 0.15);
+}
+.link-warning-panel.hidden {
+  display: none;
+}
+.link-warning-title {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.6px;
+  margin-bottom: 4px;
+}
+.link-warning-list {
+  margin: 0;
+  padding-left: 18px;
+}
+.link-warning-list li {
+  margin-bottom: 2px;
+}
 .block-palette {
   width: 280px;
   background: rgba(12, 14, 20, 0.95);

--- a/liveed/modules/link-check-worker.js
+++ b/liveed/modules/link-check-worker.js
@@ -1,0 +1,101 @@
+const CONCURRENCY_LIMIT = 5;
+
+function createCheckTask(value, type, baseUrl, seen) {
+  if (!value) return null;
+  let fullUrl;
+  try {
+    fullUrl = new URL(value, baseUrl).href;
+  } catch (error) {
+    return async () => `${type} ${value} invalid`;
+  }
+  const key = `${type}:${fullUrl}`;
+  if (seen.has(key)) return null;
+  seen.add(key);
+  return async () => {
+    try {
+      const response = await fetch(fullUrl, { method: 'HEAD' });
+      if (!response.ok) {
+        return `${type} ${value} returned ${response.status}`;
+      }
+    } catch (error) {
+      return `${type} ${value} unreachable`;
+    }
+    return null;
+  };
+}
+
+function extractTargets(html) {
+  if (typeof DOMParser === 'function') {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    return {
+      links: Array.from(doc.querySelectorAll('a[href]')).map((el) => el.getAttribute('href')), 
+      images: Array.from(doc.querySelectorAll('img[src]')).map((el) => el.getAttribute('src')),
+    };
+  }
+
+  const anchors = [];
+  const images = [];
+  const anchorRegex = /<a\b[^>]*href\s*=\s*("([^"]*)"|'([^']*)'|([^'">\s]+))/gi;
+  const imageRegex = /<img\b[^>]*src\s*=\s*("([^"]*)"|'([^']*)'|([^'">\s]+))/gi;
+  let match = anchorRegex.exec(html);
+  while (match) {
+    const value = match[2] || match[3] || match[4] || '';
+    if (value) anchors.push(value);
+    match = anchorRegex.exec(html);
+  }
+  match = imageRegex.exec(html);
+  while (match) {
+    const value = match[2] || match[3] || match[4] || '';
+    if (value) images.push(value);
+    match = imageRegex.exec(html);
+  }
+
+  return { links: anchors, images };
+}
+
+async function runChecks(html, baseUrl) {
+  const seen = new Set();
+  const tasks = [];
+  const targets = extractTargets(html);
+
+  targets.links.forEach((href) => {
+    const task = createCheckTask(href, 'Link', baseUrl, seen);
+    if (task) tasks.push(task);
+  });
+  targets.images.forEach((src) => {
+    const task = createCheckTask(src, 'Image', baseUrl, seen);
+    if (task) tasks.push(task);
+  });
+
+  const warnings = [];
+  const queue = tasks.slice();
+  const workers = new Array(Math.min(CONCURRENCY_LIMIT, queue.length)).fill(null).map(async () => {
+    while (queue.length) {
+      const task = queue.shift();
+      if (!task) continue;
+      const warning = await task();
+      if (warning) warnings.push(warning);
+    }
+  });
+
+  await Promise.all(workers);
+  return warnings;
+}
+
+self.addEventListener('message', async (event) => {
+  const { data } = event;
+  if (!data || data.type !== 'checkLinks') return;
+  const { html = '', baseUrl = self.location.href, jobId } = data;
+  try {
+    const warnings = await runChecks(html, baseUrl);
+    self.postMessage({ type: 'linkCheckResult', jobId, warnings });
+  } catch (error) {
+    self.postMessage({
+      type: 'linkCheckResult',
+      jobId,
+      warnings: [],
+      error: error ? String(error.message || error) : 'Unknown error',
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a web worker module that parses HTML and checks links without blocking the editor
- update the save flow to queue link checks in the background while saving immediately
- surface link-check warnings in a dedicated panel with new styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e16f2cdd6083318fa87028ba374d6a