### PR TITLE
Add reusable hover scale class for builder drag handles

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -993,20 +993,41 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
 
+  const hoverScaleClass = 'builder-hover-scale';
+  const getDraggableBlock = (target) => {
+    const handle = target.closest('.control.drag');
+    if (!handle) return null;
+    return handle.closest('.block-wrapper');
+  };
+
+  const applyHoverScale = (target) => {
+    const block = getDraggableBlock(target);
+    if (block) block.classList.add(hoverScaleClass);
+  };
+
+  const clearHoverScale = (target) => {
+    const block = getDraggableBlock(target);
+    if (block) block.classList.remove(hoverScaleClass);
+  };
+
   document.addEventListener('mouseover', (e) => {
-    const handle = e.target.closest('.control.drag');
-    if (handle) {
-      const block = handle.closest('.block-wrapper');
-      if (block) block.style.transform = 'scale(1.02)';
-    }
+    applyHoverScale(e.target);
   });
 
   document.addEventListener('mouseout', (e) => {
-    const handle = e.target.closest('.control.drag');
-    if (handle) {
-      const block = handle.closest('.block-wrapper');
-      if (block) block.style.transform = '';
-    }
+    clearHoverScale(e.target);
+  });
+
+  document.addEventListener('touchstart', (e) => {
+    applyHoverScale(e.target);
+  });
+
+  document.addEventListener('touchcancel', (e) => {
+    clearHoverScale(e.target);
+  });
+
+  document.addEventListener('touchend', (e) => {
+    clearHoverScale(e.target);
   });
 
   window.addEventListener('beforeunload', () => {

--- a/liveed/css/builder-core.css
+++ b/liveed/css/builder-core.css
@@ -215,6 +215,11 @@
 .block-wrapper {
   position: relative;
   margin-bottom: 1rem;
+  transition: transform 0.2s ease;
+}
+
+.block-wrapper.builder-hover-scale {
+  transform: scale(1.02);
 }
 .block-controls {
   position: absolute;


### PR DESCRIPTION
## Summary
- add a reusable builder hover scale class to the builder stylesheet
- switch drag handle hover behavior to toggle the new class instead of inline transforms
- ensure hover styling is cleared on mouseout and touch cancellation events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c73cf124833185febf0689fb8432