### PR TITLE
Clear builder autosave timer during teardown

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -34,6 +34,27 @@ let currentSearchTerm = '';
 // successive saves while the user is still actively editing.
 const SAVE_DEBOUNCE_DELAY = 1000;
 
+function registerBuilderCleanup(handler) {
+  if (typeof window === 'undefined' || typeof handler !== 'function') {
+    return;
+  }
+  const previous = typeof window.builderCleanup === 'function' ? window.builderCleanup : null;
+  window.builderCleanup = function builderCleanupWrapper() {
+    if (previous) {
+      try {
+        previous();
+      } catch (error) {
+        console.error('Error running existing builder cleanup handler', error);
+      }
+    }
+    try {
+      handler();
+    } catch (error) {
+      console.error('Error running builder cleanup handler', error);
+    }
+  };
+}
+
 function setPageRevision(value = '') {
   pageRevision = value || '';
   if (typeof window !== 'undefined') {
@@ -542,9 +563,17 @@ function toggleFavorite(blockId) {
   }
 }
 
-let saveTimer;
+let saveTimer = null;
+
+function cancelScheduledSave() {
+  if (saveTimer !== null) {
+    clearTimeout(saveTimer);
+    saveTimer = null;
+  }
+}
 
 function savePage() {
+  cancelScheduledSave();
   if (!canvas) return;
   if (conflictActive) {
     handleConflict('content');
@@ -619,7 +648,7 @@ function savePage() {
 }
 
 function scheduleSave() {
-  clearTimeout(saveTimer);
+  cancelScheduledSave();
   storeDraft();
   if (conflictActive) return;
   saveTimer = setTimeout(savePage, SAVE_DEBOUNCE_DELAY);
@@ -847,7 +876,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (redoBtn) redoBtn.addEventListener('click', () => history.redo());
   if (saveBtn)
     saveBtn.addEventListener('click', () => {
-      clearTimeout(saveTimer);
+      cancelScheduledSave();
       savePage();
     });
   if (historyBtn && historyPanel) {
@@ -1010,7 +1039,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   window.addEventListener('beforeunload', () => {
+    cancelScheduledSave();
     storeDraft();
+  });
+
+  registerBuilderCleanup(() => {
+    cancelScheduledSave();
   });
 
 });


### PR DESCRIPTION
## Summary
- add a helper to register builder cleanup handlers and expose the existing cleanup hook
- cancel pending autosave timers when saving, on beforeunload, and during builder teardown to prevent dangling references

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c72332e48331aee4030b1b378b94