### PR TITLE
Add server-backed blog post deletion

### DIFF
--- a/CMS/modules/blogs/blogs.js
+++ b/CMS/modules/blogs/blogs.js
@@ -832,14 +832,32 @@ $(document).ready(function(){
 
     function deletePost(id){
         confirmModal('Are you sure you want to delete this post?').then(ok => {
-            if(ok){
-                posts = posts.filter(p=>p.id!==id);
-                refreshCategoriesFromPosts();
-                populateFilters();
-                renderPosts();
-                updateStats();
-                renderCategories();
+            if(!ok){
+                return;
             }
+
+            $.ajax({
+                url: 'modules/blogs/delete_post.php',
+                method: 'POST',
+                data: { id },
+                dataType: 'json'
+            })
+            .done(function(response){
+                if(response && response.success){
+                    posts = posts.filter(p=>p.id!==id);
+                    refreshCategoriesFromPosts();
+                    populateFilters();
+                    renderPosts();
+                    updateStats();
+                    renderCategories();
+                }else{
+                    const message = response && response.message ? response.message : 'Unable to delete the post. Please try again later.';
+                    alertModal(message);
+                }
+            })
+            .fail(function(){
+                alertModal('Unable to delete the post. Please try again later.');
+            });
         });
     }
 

--- a/CMS/modules/blogs/delete_post.php
+++ b/CMS/modules/blogs/delete_post.php
@@ -1,0 +1,70 @@
+<?php
+// File: delete_post.php
+require_once __DIR__ . '/../../includes/auth.php';
+require_once __DIR__ . '/../../includes/data.php';
+
+require_login();
+
+header('Content-Type: application/json');
+
+if (strtoupper($_SERVER['REQUEST_METHOD'] ?? '') !== 'POST') {
+    http_response_code(405);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Invalid request method.'
+    ]);
+    exit;
+}
+
+$id = filter_input(INPUT_POST, 'id', FILTER_VALIDATE_INT);
+if (!$id) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'message' => 'A valid post ID is required.'
+    ]);
+    exit;
+}
+
+$postsFile = __DIR__ . '/../../data/blog_posts.json';
+$posts = read_json_file($postsFile);
+if (!is_array($posts)) {
+    $posts = [];
+}
+
+$removed = false;
+foreach ($posts as $index => $post) {
+    if (!is_array($post)) {
+        continue;
+    }
+    $postId = isset($post['id']) ? (int) $post['id'] : 0;
+    if ($postId === (int) $id) {
+        unset($posts[$index]);
+        $removed = true;
+    }
+}
+
+if (!$removed) {
+    http_response_code(404);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Post not found.'
+    ]);
+    exit;
+}
+
+$posts = array_values($posts);
+
+if (!write_json_file($postsFile, $posts)) {
+    http_response_code(500);
+    echo json_encode([
+        'success' => false,
+        'message' => 'Unable to delete the post. Please try again.'
+    ]);
+    exit;
+}
+
+echo json_encode([
+    'success' => true,
+    'message' => 'Post deleted.'
+]);


### PR DESCRIPTION
## Summary
- add a secured server endpoint to remove blog posts from the JSON datastore
- update the blog admin UI deletion flow to rely on the server response before mutating client state and surface errors

## Testing
- php -l CMS/modules/blogs/delete_post.php

------
https://chatgpt.com/codex/tasks/task_e_68e1dcb4642c8331999e34d66c35fcb4