### PR TITLE
Fix builder block settings encoding for Unicode templates

### DIFF
--- a/liveed/modules/base64.js
+++ b/liveed/modules/base64.js
@@ -1,0 +1,75 @@
+// File: base64.js
+function toBinaryString(value) {
+  if (typeof value !== 'string') {
+    value = value != null ? String(value) : '';
+  }
+  if (!value) return '';
+  if (typeof globalThis.TextEncoder === 'function') {
+    const encoder = new globalThis.TextEncoder();
+    const bytes = encoder.encode(value);
+    let binary = '';
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return binary;
+  }
+  if (typeof encodeURIComponent === 'function' && typeof unescape === 'function') {
+    return unescape(encodeURIComponent(value));
+  }
+  let binary = '';
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    binary += String.fromCharCode(code & 0xff);
+  }
+  return binary;
+}
+
+function fromBinaryString(binary) {
+  if (!binary) return '';
+  if (typeof globalThis.TextDecoder === 'function') {
+    const decoder = new globalThis.TextDecoder();
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return decoder.decode(bytes);
+  }
+  if (typeof decodeURIComponent === 'function' && typeof escape === 'function') {
+    return decodeURIComponent(escape(binary));
+  }
+  return binary;
+}
+
+function getBtoa() {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.btoa === 'function') {
+    return globalThis.btoa.bind(globalThis);
+  }
+  if (typeof Buffer !== 'undefined') {
+    return (str) => Buffer.from(str, 'binary').toString('base64');
+  }
+  throw new Error('Base64 encoding is not supported in this environment.');
+}
+
+function getAtob() {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.atob === 'function') {
+    return globalThis.atob.bind(globalThis);
+  }
+  if (typeof Buffer !== 'undefined') {
+    return (str) => Buffer.from(str, 'base64').toString('binary');
+  }
+  throw new Error('Base64 decoding is not supported in this environment.');
+}
+
+export function encodeUnicodeBase64(value = '') {
+  if (!value) return '';
+  const binary = toBinaryString(value);
+  const btoaFn = getBtoa();
+  return btoaFn(binary);
+}
+
+export function decodeUnicodeBase64(value = '') {
+  if (!value) return '';
+  const atobFn = getAtob();
+  const binary = atobFn(value);
+  return fromBinaryString(binary);
+}

--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -9,6 +9,7 @@ import {
 import { sanitizeTemplateMarkup, normalizeTemplateName } from './sanitizer.js';
 import { getBlockPath, getPathLocation } from './undoRedo.js';
 import { executeScripts } from './executeScripts.js';
+import { encodeUnicodeBase64 } from './base64.js';
 
 // caching block control markup avoids rebuilding the DOM for each block
 const controlsTemplate = `
@@ -132,7 +133,7 @@ function safeEncodeTemplateSetting(block, value, reason) {
     return { success: true, value: '' };
   }
   try {
-    return { success: true, value: btoa(value) };
+    return { success: true, value: encodeUnicodeBase64(value) };
   } catch (error) {
     reportTemplateSettingsIssue('encode', { block, reason }, error);
     return { success: false, value: '' };

--- a/liveed/modules/settings.js
+++ b/liveed/modules/settings.js
@@ -1,6 +1,7 @@
 // File: settings.js
 import { ensureBlockState, getSetting, setSetting, getSettings } from './state.js';
 import { executeScripts } from './executeScripts.js';
+import { decodeUnicodeBase64 } from './base64.js';
 
 let canvas;
 let settingsPanel;
@@ -72,7 +73,7 @@ function safeDecodeTemplateSetting(value, context = {}) {
     return { success: true, value: '' };
   }
   try {
-    return { success: true, value: atob(value) };
+    return { success: true, value: decodeUnicodeBase64(value) };
   } catch (error) {
     reportTemplateSettingsIssue('decode', context, error);
     return { success: false, value: '' };

--- a/liveed/modules/state.js
+++ b/liveed/modules/state.js
@@ -1,5 +1,6 @@
 // File: state.js
 import { sanitizeTemplateMarkup } from './sanitizer.js';
+import { encodeUnicodeBase64 } from './base64.js';
 const stateMap = new Map();
 let nextId = 1;
 const RESERVED_KEYS = new Set(['blockId', 'template', 'original', 'active', 'ts']);
@@ -362,7 +363,7 @@ export async function createBlockElementFromSchema(schema, options = {}) {
   block.dataset.original = cleaned || '';
   if (ts) {
     try {
-      block.dataset.ts = btoa(ts);
+      block.dataset.ts = encodeUnicodeBase64(ts);
     } catch (e) {
       block.dataset.ts = '';
     }


### PR DESCRIPTION
## Summary
- add a Unicode-safe base64 helper used by the builder
- update block encoding/decoding to keep template settings with smart quotes and other characters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e105180c833186488780410d12b1