### PR TITLE
Fix drag-and-drop block insertion in live editor

### DIFF
--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -740,7 +740,6 @@ export function createDragDropController(options = {}) {
   }
 
   const throttledDragOver = throttleRAF(handleDragOver);
-  const throttledDrop = throttleRAF(handleDrop);
 
   function delegateDragEvents(e) {
     switch (e.type) {
@@ -757,7 +756,9 @@ export function createDragDropController(options = {}) {
         throttledDragOver(e);
         break;
       case 'drop':
-        throttledDrop(e);
+        // Drop events cannot be throttled because the drag state may reset
+        // before the handler runs, which would prevent blocks from being added.
+        handleDrop(e);
         break;
       case 'dragend':
         handleDragEnd(e);


### PR DESCRIPTION
## Summary
- ensure drop events run synchronously in the live editor drag-and-drop controller
- add documentation comment explaining why drop handling cannot be throttled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e5b81acc8331a0f997ff7b1871cd