### PR TITLE
Ensure new blocks auto-open settings panel

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -1098,6 +1098,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.addEventListener('canvasUpdated', updateCanvasPlaceholder);
   document.addEventListener('canvasUpdated', scheduleSave);
 
+  document.addEventListener('blockAdded', (event) => {
+    const detail = event && event.detail ? event.detail : {};
+    if (detail.source !== 'palette') return;
+    const block = detail.block;
+    if (!block || !canvas.contains(block)) return;
+    if (settingsPanel && settingsPanel.classList.contains('open') && settingsPanel.block === block) {
+      return;
+    }
+    openSettings(block);
+  });
+
   document.addEventListener('blockSettingsApplied', (event) => {
     if (!history || !history.recordOperation) return;
     const detail = event && event.detail ? event.detail : {};

--- a/liveed/modules/dragDrop.js
+++ b/liveed/modules/dragDrop.js
@@ -651,6 +651,22 @@ export function createDragDropController(options = {}) {
 
             if (state.openSettings) state.openSettings(wrapper);
             document.dispatchEvent(new Event('canvasUpdated'));
+            if (typeof document !== 'undefined' && typeof CustomEvent === 'function') {
+              try {
+                document.dispatchEvent(
+                  new CustomEvent('blockAdded', {
+                    detail: {
+                      block: wrapper,
+                      template: file,
+                      source: 'palette',
+                      metadata: meta || null,
+                    },
+                  })
+                );
+              } catch (error) {
+                // Ignore event dispatch errors to avoid interrupting the drop flow.
+              }
+            }
             announce('Block added to canvas.');
           })
           .catch((error) => {


### PR DESCRIPTION
## Summary
- dispatch a `blockAdded` custom event after palette drops so downstream listeners can react to new blocks
- listen for `blockAdded` events in the builder UI to automatically open the settings panel for the newly added block

## Testing
- manual: loaded the builder and simulated a new block drop to confirm the settings panel opens automatically

------
https://chatgpt.com/codex/tasks/task_e_68e1e3a8c3c083319d425f54dda13690