### PR TITLE
Skip draft conflict popup

### DIFF
--- a/liveed/builder.js
+++ b/liveed/builder.js
@@ -423,6 +423,13 @@ function handleConflict(source = 'content', message = '') {
     statusEl.classList.remove('saving');
   }
   if (conflictPromptShown) return;
+  // Avoid interrupting the editor with a confirmation prompt when only the
+  // background draft save failed with an outdated revision. The status message
+  // still informs the user about the conflict, but the disruptive modal
+  // previously shown as "Draft is outdated" is skipped.
+  if (source === 'draft') {
+    return;
+  }
   conflictPromptShown = true;
   const promptMessage =
     (message ? message + '\n\n' : '') +


### PR DESCRIPTION
## Summary
- prevent the builder from showing a confirmation modal when a background draft save hits an outdated revision conflict
- keep the status message update so editors are informed without interrupting their workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ecbd29ec8331b01733bd930d828a