### PR TITLE
Remove link warning panel from builder

### DIFF
--- a/liveed/css/builder-core.css
+++ b/liveed/css/builder-core.css
@@ -52,35 +52,6 @@
 .save-status.error {
   color: #e53e3e;
 }
-.link-warning-panel {
-  width: 100%;
-  margin-top: 4px;
-  padding: 8px 10px;
-  border-radius: 6px;
-  background: rgba(254, 226, 226, 0.85);
-  border: 1px solid rgba(229, 62, 62, 0.6);
-  color: #742a2a;
-  font-size: 13px;
-  line-height: 1.4;
-  box-shadow: 0 2px 6px rgba(229, 62, 62, 0.15);
-}
-.link-warning-panel.hidden {
-  display: none;
-}
-.link-warning-title {
-  font-weight: 600;
-  text-transform: uppercase;
-  font-size: 12px;
-  letter-spacing: 0.6px;
-  margin-bottom: 4px;
-}
-.link-warning-list {
-  margin: 0;
-  padding-left: 18px;
-}
-.link-warning-list li {
-  margin-bottom: 2px;
-}
 .block-palette {
   width: 280px;
   background: rgba(12, 14, 20, 0.95);


### PR DESCRIPTION
## Summary
- remove the link warning panel from the LiveEd builder UI
- delete the link-check worker integration and related status messaging
- clean up CSS styles that only supported the warning panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ee6153348331a69dd883d5805c0c